### PR TITLE
Custom Textures / Dump Textures supports NAOMI also

### DIFF
--- a/core/rend/gles/CustomTexture.cpp
+++ b/core/rend/gles/CustomTexture.cpp
@@ -26,6 +26,7 @@
 
 #include <png.h>
 #include "reios/reios.h"
+#include "cfg/cfg.h"
 
 void CustomTexture::LoaderThread()
 {
@@ -78,7 +79,7 @@ void CustomTexture::LoaderThread()
 
 std::string CustomTexture::GetGameId()
 {
-   std::string game_id(ip_meta.product_number, sizeof(ip_meta.product_number));
+   std::string game_id(cfgGetGameId());
    const size_t str_end = game_id.find_last_not_of(' ');
    if (str_end == std::string::npos)
 	  return "";


### PR DESCRIPTION
Since `reios_disk_id()` won't be called when platform is not dreamcast, so NAOMI games will have an empty `ip_meta`

Use the `reios_id` in config instead (value is `ip_meta.product_number` for DC, and `naomi_game_id` for NAOMI)