### PR TITLE
msvc build fixes

### DIFF
--- a/core/hw/sh4/modules/serial.cpp
+++ b/core/hw/sh4/modules/serial.cpp
@@ -9,7 +9,7 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 #else
-#include <windows.h>
+#include <io.h>
 #endif
 #include "types.h"
 #include "hw/sh4/sh4_mmr.h"

--- a/core/rend/vulkan/vmallocator.cpp
+++ b/core/rend/vulkan/vmallocator.cpp
@@ -23,10 +23,7 @@
 #include "vmallocator.h"
 #include "vulkan_context.h"
 
-#if HOST_CPU == CPU_ARM
-__attribute__((pcs("aapcs-vfp")))
-#endif
-static void vmaAllocateDeviceMemoryCallback(
+VKAPI_ATTR static void VKAPI_CALL vmaAllocateDeviceMemoryCallback(
     VmaAllocator      allocator,
     uint32_t          memoryType,
     VkDeviceMemory    memory,
@@ -35,10 +32,7 @@ static void vmaAllocateDeviceMemoryCallback(
 	DEBUG_LOG(RENDERER, "VMAAllocator: %llu bytes allocated (type %d)", (unsigned long long)size, memoryType);
 }
 
-#if HOST_CPU == CPU_ARM
-__attribute__((pcs("aapcs-vfp")))
-#endif
-static void vmaFreeDeviceMemoryCallback(
+VKAPI_ATTR static void VKAPI_CALL vmaFreeDeviceMemoryCallback(
     VmaAllocator      allocator,
     uint32_t          memoryType,
     VkDeviceMemory    memory,

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -35,11 +35,8 @@ VulkanContext *VulkanContext::contextInstance;
 
 static const char *PipelineCacheFileName = DATA_PATH "vulkan_pipeline.cache";
 
-#if HOST_CPU == CPU_ARM
-__attribute__((pcs("aapcs-vfp")))
-#endif
 #ifndef __ANDROID__
-static VkBool32 debugUtilsMessengerCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes,
+VKAPI_ATTR static VkBool32 VKAPI_CALL debugUtilsMessengerCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes,
 									 VkDebugUtilsMessengerCallbackDataEXT const * pCallbackData, void * /*pUserData*/)
 {
 	std::string msg = vk::to_string(static_cast<vk::DebugUtilsMessageSeverityFlagBitsEXT>(messageSeverity)) + ": "


### PR DESCRIPTION
io.h is required by MSVC in order to use the `read`/`write` functions.
References:
- https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/posix-read?view=vs-2019
- https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/read?view=vs-2019

Use platform-specific calling convention macros from https://github.com/flyinghead/flycast/blob/aac665e6177d91d4289b79e2f10a3b867daa46e6/core/khronos/vulkan/vk_platform.h#L49-L69
in `core/rend/vulkan/vmallocator.cpp` and `core/rend/vulkan/vulkan_context.cpp`. Fix build issues in MSVC.