### PR TITLE
Compilation fix for ao audio backend

### DIFF
--- a/core/oslib/audiobackend_libao.cpp
+++ b/core/oslib/audiobackend_libao.cpp
@@ -24,7 +24,7 @@ static void libao_init()
 static u32 libao_push(const void* frame, u32 samples, bool wait)
 {
 	if (aodevice)
-		ao_play(aodevice, (const char*)frame, samples * 4);
+		ao_play(aodevice, (char*)frame, samples * 4);
 
 	return 1;
 }


### PR DESCRIPTION
```
/home/runner/work/reicast-emulator/reicast-emulator/core/oslib/audiobackend_libao.cpp: In function ‘u32 libao_push(const void*, u32, bool)’:
/home/runner/work/reicast-emulator/reicast-emulator/core/oslib/audiobackend_libao.cpp:27:21: error: invalid conversion from ‘const char*’ to ‘char*’ [-fpermissive]
   ao_play(aodevice, (const char*)frame, samples * 4);
                     ^~~~~~~~~~~~~~~~~~
In file included from /home/runner/work/reicast-emulator/reicast-emulator/core/oslib/audiobackend_libao.cpp:4:0:
/usr/include/ao/ao.h:119:23: note:   initializing argument 2 of ‘int ao_play(ao_device*, char*, uint_32)’
 int                   ao_play(ao_device *device,
                       ^~~~~~~
```