### PR TITLE
let windows terminals use Nix ConsoleListener, fix windows timestamp

### DIFF
--- a/core/log/ConsoleListenerDroid.cpp
+++ b/core/log/ConsoleListenerDroid.cpp
@@ -1,7 +1,8 @@
 // Copyright 2015 Dolphin Emulator Project
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
-#ifdef __ANDROID__
+#if defined(__ANDROID__) && !defined(LOG_TO_PTY)
+
 
 #include <android/log.h>
 

--- a/core/log/ConsoleListenerNix.cpp
+++ b/core/log/ConsoleListenerNix.cpp
@@ -1,7 +1,7 @@
 // Copyright 2015 Dolphin Emulator Project
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
-#if !defined(_WIN32) && !defined(__ANDROID__)
+#if (!defined(_WIN32) && !defined(__ANDROID__)) || defined(LOG_TO_PTY)
 #include <cstdio>
 #include <cstring>
 
@@ -14,7 +14,11 @@
 
 ConsoleListener::ConsoleListener()
 {
+#ifdef LOG_TO_PTY
+  m_use_color = 1;
+#else
   m_use_color = !!isatty(fileno(stderr));
+#endif
 }
 
 ConsoleListener::~ConsoleListener()

--- a/core/log/ConsoleListenerWin.cpp
+++ b/core/log/ConsoleListenerWin.cpp
@@ -1,7 +1,7 @@
 // Copyright 2015 Dolphin Emulator Project
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(LOG_TO_PTY)
 
 #include <windows.h>
 

--- a/core/windows/winmain.cpp
+++ b/core/windows/winmain.cpp
@@ -730,6 +730,10 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	char** argv = CommandLineToArgvA(cmd_line, &argc);
 
 #endif
+
+#if defined(_WIN32) && defined(LOG_TO_PTY)
+    setbuf(stderr,NULL);
+#endif
 	LogManager::Init();
 
 	ReserveBottomMemory();
@@ -791,7 +795,8 @@ double os_GetSeconds()
 	LARGE_INTEGER time_now;
 
 	QueryPerformanceCounter(&time_now);
-	return time_now.QuadPart*qpfd;
+	static LARGE_INTEGER time_now_base = time_now;
+	return (time_now.QuadPart - time_now_base.QuadPart)*qpfd;
 }
 
 void os_DebugBreak()

--- a/shell/linux/Makefile
+++ b/shell/linux/Makefile
@@ -422,6 +422,11 @@ ifdef ASAN
 	LDFLAGS += -fsanitize=address -static-libasan
 endif 
 
+ifdef LOG_TO_PTY
+    CFLAGS += -D LOG_TO_PTY
+endif
+
+
 EXECUTABLE_STRIPPED=nosym-reicast.$(PLATFORM_EXT)
 DC_PLATFORM=dreamcast
 EXECUTABLE=reicast.$(PLATFORM_EXT)


### PR DESCRIPTION
Allow windows pty like terminals to use Nix ConsoleListener, e.g. mintty used by msys2 and cygwin.

Fix windows logging timestamps, so they start from 00:00:000 like the linux version.

If using Nix ConsoleListener on windows, turn off buffering of stderr.
