### PR TITLE
Android build update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,53 +1,36 @@
 language: android
-dist: trusty
+
 android:
   components:
-  - platform-tools
-  - tools
-  - build-tools-27.0.3
-  - android-25
-  - extra-google-m2repository
-  - extra-android-m2repository
-  licenses:
-  - android-sdk-preview-license-.+
-  - android-sdk-license-.+
-sudo: false
+    - android-28
+    - build-tools-28.0.3
+    - extra-android-m2repository
+
 before_cache:
-- rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-- rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
-  - "$HOME/.gradle/caches/"
-  - "$HOME/.gradle/wrapper/"
-  - "$HOME/.android/build-cache"
-before_install:
-- GIT_HASH=`git log --pretty=format:'%h' -n 1`
-- GIT_BUILD=`git describe --all --always`-$GIT_HASH
-- mkdir "$ANDROID_HOME/licenses" || true
-- echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
-- echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
-- chmod +x shell/android-studio/gradlew
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+    - $HOME/.android/build-cache
+
 install:
-- sudo apt-get -qq update
-- touch ~/.android/repositories.cfg
-- echo y | sdkmanager 'ndk-bundle'
-- echo y | sdkmanager 'ndk;21.0.6113669'
-- export NDK=ANDROID_NDK=ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle
-- export PATH=${PATH}:$ANDROID_HOME/tools
-- export PATH=${PATH}:$ANDROID_HOME/platform-tools
-- export PATH=${PATH}:$NDK
-- mkdir -p ~/.android
-before_script: 
+  - echo y | sdkmanager 'ndk-bundle'
+  - echo y | sdkmanager 'ndk;21.0.6113669'
+
 script:
-- git fetch --depth 250
-- cd shell/android-studio
-- export NUMBER_OF_PROCESSORS=2
-- sudo chmod 755 travis-build.sh
-- "./travis-build.sh"
+  - cd shell/android-studio
+  - chmod +x gradlew
+  - ./gradlew assembleDreamcastDebug --configure-on-demand --console=plain
+
 before_deploy:
-- cd ../../
-- mkdir -p artifacts/$GIT_BUILD/
-- cp shell/android-studio/reicast/build/outputs/apk/dreamcast/debug/reicast-dreamcast-debug.apk artifacts/$GIT_BUILD/flycast-debug-$GIT_HASH.apk
+  - cd ../../
+  - GIT_HASH=`git log --pretty=format:'%h' -n 1`
+  - GIT_BUILD=`git describe --all --always`-$GIT_HASH
+  - mkdir -p artifacts/$GIT_BUILD/
+  - cp shell/android-studio/reicast/build/outputs/apk/dreamcast/debug/reicast-dreamcast-debug.apk artifacts/$GIT_BUILD/flycast-debug-$GIT_HASH.apk
+
 deploy:
   provider: s3
   access_key_id: AKIAJOZQS4H2PHQWYFCA

--- a/shell/android-studio/build.gradle
+++ b/shell/android-studio/build.gradle
@@ -5,8 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath 'com.github.triplet.gradle:play-publisher:1.2.2'
+        classpath 'com.android.tools.build:gradle:3.6.2'
     }
 }
 

--- a/shell/android-studio/gradle/wrapper/gradle-wrapper.properties
+++ b/shell/android-studio/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip

--- a/shell/android-studio/reicast/build.gradle
+++ b/shell/android-studio/reicast/build.gradle
@@ -1,9 +1,8 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.github.triplet.play'
 
 def getBuildId = { ->
     def build_id = System.getenv("TRAVIS_JOB_ID") ?: "8"
-    return Integer.parseInt( build_id )
+    return Integer.parseInt(build_id)
 }
 
 def getVersionHash = { ->
@@ -25,20 +24,21 @@ def getVersionName = { ->
 }
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "27.0.3"
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
+    ndkVersion '21.0.6113669'
 
     defaultConfig {
         applicationId "com.flycast.emulator"
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode getBuildId()
         versionName getVersionName()
         vectorDrawables.useSupportLibrary = true
 
         ndk {
             moduleName "dc"
-                abiFilters 'armeabi-v7a', 'arm64-v8a'//, 'x86'
+            abiFilters 'armeabi-v7a', 'arm64-v8a'
         }
     }
 
@@ -86,16 +86,10 @@ android {
     lintOptions {
         abortOnError false
     }
-    
-	//packagingOptions{
-	//    doNotStrip "*/armeabi/*.so"
-	//    doNotStrip "*/armeabi-v7a/*.so"
-	//    doNotStrip "*/arm64-v8a/*.so"
-	//}
 }
 
 afterEvaluate {
-    android.applicationVariants.all {  v ->
+    android.applicationVariants.all { v ->
         if (v.buildType.name == "release") {
             def hashtag = getVersionHash()
             v.outputs[0].outputFileName = "flycast-android-" + hashtag + ".apk"
@@ -103,21 +97,15 @@ afterEvaluate {
     }
 }
 
-play {
-    track = 'beta'
-    serviceAccountEmail = 'reicast-beta-cd@api-7801059239587459896-777757.iam.gserviceaccount.com'
-    pk12File = file('../reicast-beta-cd.p12')
-}
-
 dependencies {
-    implementation 'com.android.support:support-v4:25.4.0'
-    implementation 'com.android.support:appcompat-v7:25.4.0'
-    implementation 'com.android.support:design:25.4.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'org.bouncycastle:bcprov-jdk16:1.46'
     implementation 'commons-io:commons-io:2.6'
-    implementation 'org.apache.commons:commons-lang3:3.7'
-    implementation ('com.googlecode.json-simple:json-simple:1.1.1') {
+    implementation 'org.apache.commons:commons-lang3:3.10'
+    implementation('com.googlecode.json-simple:json-simple:1.1.1') {
         exclude module: 'junit'
     }
     implementation fileTree(include: ['*.jar'], dir: 'libs')

--- a/shell/android-studio/reicast/src/main/jni/Application.mk
+++ b/shell/android-studio/reicast/src/main/jni/Application.mk
@@ -1,4 +1,2 @@
-APP_STL		:= c++_static
-APP_ABI 	:= armeabi-v7a arm64-v8a #x86 mips
-#NDK_TOOLCHAIN_VERSION := 4.8
-APP_SHORT_COMMANDS := true
+APP_ABI := armeabi-v7a arm64-v8a
+APP_STL := c++_static

--- a/shell/android-studio/travis-build.sh
+++ b/shell/android-studio/travis-build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -ev
-#if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
-#	./gradlew build --configure-on-demand --console=plain
-#else
-	./gradlew assembleDreamcastDebug  --configure-on-demand --console=plain
-#fi

--- a/shell/android-studio/travis-release.sh
+++ b/shell/android-studio/travis-release.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -ev
-echo travis release: pr = "${TRAVIS_PULL_REQUEST}" - branch = "${TRAVIS_BRANCH}"
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
-  if [ "${TRAVIS_BRANCH}" = "master" ]; then
-    ./gradlew publishApkDreamcastRelease --console=plain
-  fi
-fi


### PR DESCRIPTION
- Set NDK version to 21.0.6113669 as it is currently the only one which supports the "-static-openmp" flag set in Android.mk
- Remove instructions related to Google Play since Flycast is not published there.
- Update Gradle and Android Grade plugin (better support for CMake)
- Update build tools and sdk to version 28. The lastest version (29) is not supported because the access to /dev/ashmem has been restricted (source: https://developer.android.com/about/versions/10/behavior-changes-10#shared-memory)
- Simplify .travis.yml to handle these changes (build example: https://travis-ci.org/github/scribam/reicast-emulator/builds/671048323)