### PR TITLE
Compilation fixes for MSVC

### DIFF
--- a/core/hw/naomi/naomi_m3comm.cpp
+++ b/core/hw/naomi/naomi_m3comm.cpp
@@ -59,14 +59,14 @@ void NaomiM3Comm::receiveNetwork()
 	const u32 slot_size = swap16(*(u16*)&m68k_ram[0x204]);
 	const u32 packet_size = slot_size * slot_count;
 
-	u8 buf[packet_size];
+	std::unique_ptr<u8[]> buf(new u8[packet_size]);
 
-	if (network.receive(buf, packet_size))
+	if (network.receive(buf.get(), packet_size))
 	{
 		packet_number += slot_count - 1;
 		*(u16*)&comm_ram[6] = swap16(packet_number);
 		std::unique_lock<std::mutex> lock(mem_mutex);
-		memcpy(&comm_ram[0x100 + slot_size], buf, packet_size);
+		memcpy(&comm_ram[0x100 + slot_size], buf.get(), packet_size);
 	}
 }
 

--- a/core/network/naomi_network.cpp
+++ b/core/network/naomi_network.cpp
@@ -27,6 +27,10 @@
 #include "hw/naomi/naomi_cart.h"
 #include "hw/naomi/naomi_flashrom.h"
 
+#ifdef _MSC_VER
+typedef int ssize_t;
+#endif
+
 sock_t NaomiNetwork::createAndBind(int protocol)
 {
 	sock_t sock = socket(AF_INET, protocol == IPPROTO_TCP ? SOCK_STREAM : SOCK_DGRAM, protocol);


### PR DESCRIPTION
- MSVC doesn't have `ssize_t`
- `u8 buf[packet_size];` generates https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2131?view=vs-2019