### PR TITLE
Enable 7zArchive for MSVC

### DIFF
--- a/core/archive/7zArchive.h
+++ b/core/archive/7zArchive.h
@@ -24,6 +24,8 @@
 #include "deps/lzma/7z.h"
 #include "deps/lzma/7zFile.h"
 
+#include <algorithm>
+
 class SzArchive : public Archive
 {
 public:

--- a/core/archive/archive.cpp
+++ b/core/archive/archive.cpp
@@ -20,8 +20,8 @@
  */
 
 #include "archive.h"
-#ifndef _MSC_VER
 #include "7zArchive.h"
+#ifndef _MSC_VER
 #include "ZipArchive.h"
 #endif
 
@@ -29,12 +29,12 @@ Archive *OpenArchive(const char *path)
 {
 	std::string base_path(path);
 
-#ifndef _MSC_VER
 	Archive *sz_archive = new SzArchive();
 	if (sz_archive->Open(base_path.c_str()) || sz_archive->Open((base_path + ".7z").c_str()) || sz_archive->Open((base_path + ".7Z").c_str()))
 		return sz_archive;
 	delete sz_archive;
 
+#ifndef _MSC_VER
 	Archive *zip_archive = new ZipArchive();
 	if (zip_archive->Open(base_path.c_str()) || zip_archive->Open((base_path + ".zip").c_str()) || zip_archive->Open((base_path + ".ZIP").c_str()))
 		return zip_archive;


### PR DESCRIPTION
Compilation fix for MSVC + enable 7zArchive, this file was previously out of the scope of my CMake build.