### PR TITLE
[macOS] Enable "New Instance" in File and Dock menu

### DIFF
--- a/shell/apple/emulator-osx/emulator-osx/AppDelegate.swift
+++ b/shell/apple/emulator-osx/emulator-osx/AppDelegate.swift
@@ -18,6 +18,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 		if let name = Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String {
 			window.title = name
 		}
+        NSApplication.shared.mainMenu?.item(at: 1)?.submenu?.insertItem(
+            NSMenuItem(title: "New Instance", action: #selector(newInstance(_:)), keyEquivalent: "n"), at: 0
+        )
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {
@@ -26,6 +29,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         return true
+    }
+    
+    func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
+        let dockMenu = NSMenu()
+        dockMenu.addItem(withTitle: "New Instance", action: #selector(newInstance(_:)), keyEquivalent: "n")
+        return dockMenu
+    }
+    
+    @objc func newInstance(_ sender: NSMenuItem) {
+        Process.launchedProcess(launchPath: "/usr/bin/open", arguments: ["-n", Bundle.main.bundlePath])
     }
 }
 

--- a/shell/apple/emulator-osx/emulator-osx/osx-main.mm
+++ b/shell/apple/emulator-osx/emulator-osx/osx-main.mm
@@ -133,6 +133,11 @@ extern "C" void emu_gles_init(int width, int height) {
     if (home != NULL)
     {
         std::string config_dir = std::string(home) + "/.reicast";
+        int instanceNumber = (int)[[NSRunningApplication runningApplicationsWithBundleIdentifier:@"com.reicast.Flycast"] count];
+        if (instanceNumber > 1){
+            config_dir += "/" + std::to_string(instanceNumber);
+            [[NSApp dockTile] setBadgeLabel:@(instanceNumber).stringValue];
+        }
         mkdir(config_dir.c_str(), 0755); // create the directory if missing
         set_user_config_dir(config_dir);
         set_user_data_dir(config_dir);


### PR DESCRIPTION
Adds the ability to launch multiple Flycast from menu or `Cmd+N`
New instances will show the running "instance number" on the dock icon's badge

<img width="513" alt="Screenshot 2020-04-26 at 12 38 33 PM" src="https://user-images.githubusercontent.com/602245/80297963-e098d280-87ba-11ea-9353-207b4f4862bc.png">

Since Flycast on macOS uses the non configurable `~/.reicast`as config + data folder path, now it will create subfolder named with the instance number for additional instances.

Known issue: 
Instances must be created in sequential order. If user opens `Instance 2` and then quit `Instance 1`, the next created instance will also be `Instance 2`, resulting two `Instance 2` are running.
(The icon badge can reflect this clash)