### PR TITLE
Add Ninja Assault to lightgun as analog

### DIFF
--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -359,7 +359,8 @@ static void LoadSpecialSettings()
 				|| !strcmp(naomi_game_id, " CONFIDENTIAL MISSION ---------")
 				|| !strcmp(naomi_game_id, "DEATH CRIMSON OX")
 				|| !strncmp(naomi_game_id, "hotd2", 5)	// House of the Dead 2
-				|| !strcmp(naomi_game_id, "LUPIN THE THIRD  -THE SHOOTING-"))
+				|| !strcmp(naomi_game_id, "LUPIN THE THIRD  -THE SHOOTING-")
+				|| !strcmp(naomi_game_id, "NINJA ASSAULT"))
 		{
 			INFO_LOG(BOOT, "Enabling lightgun as analog setup for game %s", naomi_game_id);
 			settings.input.JammaSetup = JVS::LightGunAsAnalog;


### PR DESCRIPTION
Ninja Assault by Namco is another Naomi light gun game that can be added to this list. I have a feeling this will fix the mouse button input not working in this game.