### PR TITLE
Fixes Github macOS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,7 @@ else()
 endif()
 
 find_package(PkgConfig QUIET)
-if(PKG_CONFIG_FOUND AND NOT ANDROID)
+if(PKG_CONFIG_FOUND AND NOT ANDROID AND NOT APPLE)
     pkg_search_module(AO ao)
     if(AO_FOUND)
         target_compile_definitions(${PROJECT_NAME} PRIVATE USE_LIBAO)


### PR DESCRIPTION
Disable `pkg-config` in macOS as suggested in https://github.com/flyinghead/flycast/issues/111

root cause: `macos-10.15/20200829.1` has `pkg-config` now, but `macos-10.15/20200825.1` doesn't, so even the exact same commit failed in my fork (Github built it with 20200829.1)