### PR TITLE
Display warning to user when it takes too long to find a game

### DIFF
--- a/core/rend/game_scanner.h
+++ b/core/rend/game_scanner.h
@@ -57,6 +57,19 @@ class GameScanner
 	void add_game_directory(const std::string& path)
 	{
 		//printf("Exploring %s\n", path.c_str());
+        if (game_list.size() == 0)
+        {
+            ++still_no_rom_counter;
+            if (still_no_rom_counter > 1000)
+            {
+                path_is_too_dirty = true;
+            }
+        }
+        else
+        {
+            path_is_too_dirty = false;
+        }
+        
 		DIR *dir = opendir(path.c_str());
 		if (dir == NULL)
 			return;
@@ -130,6 +143,8 @@ public:
 	void stop()
 	{
 		running = false;
+        still_no_rom_counter = 0;
+        path_is_too_dirty = false;
 		if (scan_thread && scan_thread->joinable())
 			scan_thread->join();
 	}
@@ -168,4 +183,6 @@ public:
 
 	std::mutex& get_mutex() { return mutex; }
 	const std::vector<GameMedia>& get_game_list() { return game_list; }
+    uint still_no_rom_counter = 0;
+    bool path_is_too_dirty = false;
 };

--- a/core/rend/game_scanner.h
+++ b/core/rend/game_scanner.h
@@ -183,6 +183,6 @@ public:
 
 	std::mutex& get_mutex() { return mutex; }
 	const std::vector<GameMedia>& get_game_list() { return game_list; }
-    uint still_no_rom_counter = 0;
+    unsigned int still_no_rom_counter = 0;
     bool path_is_too_dirty = false;
 };

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -684,8 +684,6 @@ static void contentpath_warning_popup()
             ImGui::SetCursorPosX((currentwidth - 100.f * scaling) / 2.f + ImGui::GetStyle().WindowPadding.x - 55.f * scaling);
             if (ImGui::Button("Reselect", ImVec2(100.f * scaling, 0.f)))
             {
-                settings.dreamcast.ContentPath.clear();
-                scanner.stop();
                 show_contentpath_warning_popup = false;
                 ImGui::CloseCurrentPopup();
                 show_contentpath_selection = true;
@@ -705,6 +703,9 @@ static void contentpath_warning_popup()
     }
     if (show_contentpath_selection)
     {
+        static auto original = settings.dreamcast.ContentPath;
+        settings.dreamcast.ContentPath.clear();
+        scanner.stop();
         ImGui::OpenPopup("Select Directory");
         select_directory_popup("Select Directory", scaling, [](bool cancelled, std::string selection)
         {
@@ -713,6 +714,11 @@ static void contentpath_warning_popup()
             if (!cancelled)
             {
                 settings.dreamcast.ContentPath.push_back(selection);
+                scanner.refresh();
+            }
+            else
+            {
+                settings.dreamcast.ContentPath = original;
                 scanner.refresh();
             }
         });

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -668,6 +668,57 @@ static void error_popup()
 	}
 }
 
+static void contentpath_warning_popup()
+{
+    static bool show_contentpath_warning_popup = true;
+    static bool show_contentpath_selection = false;
+    if (show_contentpath_warning_popup && scanner.path_is_too_dirty)
+    {
+        ImGui::OpenPopup("Incorrect Content Location?");
+        if (ImGui::BeginPopupModal("Incorrect Content Location?", NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove))
+        {
+            ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 400.f * scaling);
+            ImGui::TextWrapped("  Still searching in %d folders, no game can be found!  ", scanner.still_no_rom_counter);
+            ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(16 * scaling, 3 * scaling));
+            float currentwidth = ImGui::GetContentRegionAvailWidth();
+            ImGui::SetCursorPosX((currentwidth - 100.f * scaling) / 2.f + ImGui::GetStyle().WindowPadding.x - 55.f * scaling);
+            if (ImGui::Button("Reselect", ImVec2(100.f * scaling, 0.f)))
+            {
+                settings.dreamcast.ContentPath.clear();
+                scanner.stop();
+                show_contentpath_warning_popup = false;
+                ImGui::CloseCurrentPopup();
+                show_contentpath_selection = true;
+            }
+            
+            ImGui::SameLine();
+            ImGui::SetCursorPosX((currentwidth - 100.f * scaling) / 2.f + ImGui::GetStyle().WindowPadding.x + 55.f * scaling);
+            if (ImGui::Button("Cancel", ImVec2(100.f * scaling, 0.f)))
+            {
+                show_contentpath_warning_popup = false;
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::SetItemDefaultFocus();
+            ImGui::PopStyleVar();
+            ImGui::EndPopup();
+        }
+    }
+    if (show_contentpath_selection)
+    {
+        ImGui::OpenPopup("Select Directory");
+        select_directory_popup("Select Directory", scaling, [](bool cancelled, std::string selection)
+        {
+            show_contentpath_selection = false;
+            show_contentpath_warning_popup = true;
+            if (!cancelled)
+            {
+                settings.dreamcast.ContentPath.push_back(selection);
+                scanner.refresh();
+            }
+        });
+    }
+}
+
 void directory_selected_callback(bool cancelled, std::string selection)
 {
 	if (!cancelled)
@@ -1572,6 +1623,7 @@ static void gui_display_content()
     ImGui::PopStyleVar();
 
 	error_popup();
+    contentpath_warning_popup();
 
 	ImGui::Render();
 	ImGui_impl_RenderDrawData(ImGui::GetDrawData(), false);

--- a/core/rend/gui_util.cpp
+++ b/core/rend/gui_util.cpp
@@ -39,6 +39,7 @@ extern int screen_width, screen_height;
 
 static std::string select_current_directory;
 static std::vector<std::string> select_subfolders;
+static std::vector<std::string> display_files;
 bool subfolders_read;
 #ifdef _WIN32
 static const std::string separators = "/\\";
@@ -103,6 +104,7 @@ void select_directory_popup(const char *prompt, float scaling, StringCallback ca
 		if (!subfolders_read)
 		{
 			select_subfolders.clear();
+            display_files.clear();
 			error_message.clear();
 #ifdef _WIN32
 			if (select_current_directory == PSEUDO_ROOT)
@@ -175,6 +177,14 @@ void select_directory_popup(const char *prompt, float scaling, StringCallback ca
 								dotdot_seen = true;
 							select_subfolders.push_back(name);
 						}
+                        else
+                        {
+                            std::string extension = get_file_extension(name);
+                            if ( extension == "zip" || extension == "7z" || extension == "chd" || extension == "gdi" || ((settings.dreamcast.HideLegacyNaomiRoms
+                                    || (extension != "bin" && extension != "lst" && extension != "dat"))
+                            && extension != "cdi" && extension != "cue") == false )
+                                display_files.push_back(name);
+                        }
 					}
 					closedir(dir);
 #if defined(_WIN32) || defined(__ANDROID__)
@@ -249,6 +259,13 @@ void select_directory_popup(const char *prompt, float scaling, StringCallback ca
 				select_current_directory = child_path;
 			}
 		}
+        ImGui::PushStyleColor(ImGuiCol_Text, { 1, 1, 1, 0.3});
+        for (auto& name : display_files)
+        {
+            ImGui::Text(name.c_str());
+        }
+        ImGui::PopStyleColor();
+        
 		ImGui::PopStyleVar();
 		ImGui::EndChild();
 		if (ImGui::Button("Select Current Directory", ImVec2(0, 30 * scaling)))


### PR DESCRIPTION
Since there are different players reported similar issue to me, I decided to improve it thru UI.

When the Content Location is set to root or any big folder, it will take forever to discover the games.
Currently Flycast will just show a blank static page, although it is actively recursively searching for games. 

I've added a counter to track and will show the below warning. After clicking "Reselect", user can select a new Content Location directly.
![Untitled](https://user-images.githubusercontent.com/602245/98045212-1520d180-1e63-11eb-8540-55abfc8292dc.jpg)




And for better folder navigation + discovery, relevant files will be shown in unselectable grey text inside the directory selector:
![asd](https://user-images.githubusercontent.com/602245/98045293-3c779e80-1e63-11eb-9c42-2d5494ea71f4.jpg)
