### PR TITLE
GitHub Actions update

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,7 +16,7 @@ jobs:
 
       - run: git fetch origin +refs/tags/*:refs/tags/*
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,8 +14,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: git fetch origin +refs/tags/*:refs/tags/*
-
       - uses: actions/cache@v2
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -31,7 +31,7 @@ jobs:
           echo "CCACHE_DIR=/tmp/ccache" >> $GITHUB_ENV
         if: matrix.config.os == 'ubuntu-latest'
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: /tmp/ccache
           key: ccache-${{ matrix.config.os }}-${{ github.sha }}

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -43,8 +43,6 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - run: git fetch origin +refs/tags/*:refs/tags/*
-
       - name: Create artifact directory
         run: mkdir -p build/artifact
 


### PR DESCRIPTION
- Bump actions/cache to v2
- Remove git fetch since it is not necessary anymore, see https://github.com/actions/checkout/pull/258 for details