### PR TITLE
HiDPI mode for Windows and proper scaling on macOS

### DIFF
--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -150,7 +150,9 @@ void gui_init()
     //io.Fonts->AddFontFromFileTTF("../../misc/fonts/ProggyTiny.ttf", 10.0f);
     //ImFont* font = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf", 18.0f, NULL, io.Fonts->GetGlyphRangesJapanese());
     //IM_ASSERT(font != NULL);
-
+#if !(defined(_WIN32) || defined(__APPLE__))
+    scaling = std::max(1.f, screen_dpi / 100.f * 0.75f);
+#endif
     if (scaling > 1)
 		ImGui::GetStyle().ScaleAllSizes(scaling);
 

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -52,7 +52,7 @@ extern u8 kb_key[6];		// normal keys pressed
 int screen_dpi = 96;
 
 static bool inited = false;
-static float scaling = 1;
+float scaling = 1;
 GuiState gui_state = Main;
 static bool settings_opening;
 #ifdef __ANDROID__
@@ -151,7 +151,6 @@ void gui_init()
     //ImFont* font = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf", 18.0f, NULL, io.Fonts->GetGlyphRangesJapanese());
     //IM_ASSERT(font != NULL);
 
-    scaling = std::max(1.f, screen_dpi / 100.f * 0.75f);
     if (scaling > 1)
 		ImGui::GetStyle().ScaleAllSizes(scaling);
 

--- a/core/rend/gui.h
+++ b/core/rend/gui.h
@@ -29,6 +29,7 @@ void gui_term();
 void gui_refresh_files();
 
 extern int screen_dpi;
+extern float scaling;
 extern u32 vmu_lcd_data[8][48 * 32];
 extern bool vmu_lcd_status[8];
 extern bool vmu_lcd_changed[8];

--- a/shell/apple/emulator-osx/emulator-osx/osx-main.mm
+++ b/shell/apple/emulator-osx/emulator-osx/osx-main.mm
@@ -193,6 +193,11 @@ extern "C" void emu_gles_init(int width, int height)
     CFRelease(allDisplayModes);
     
 	screen_dpi = (int)(displayNativeSize.width / displayPhysicalSize.width * 25.4f);
+    NSSize displayResolution;
+    displayResolution.width = CGDisplayPixelsWide(displayID);
+    displayResolution.height = CGDisplayPixelsHigh(displayID);
+    scaling = displayNativeSize.width / displayResolution.width;
+    
 	screen_width = width;
 	screen_height = height;
 


### PR DESCRIPTION
Windows:
Since SDL2 does not support `SDL_WINDOW_ALLOW_HIGHDPI` yet (https://github.com/libsdl-org/SDL/issues/2119), use `SetProcessDpiAwareness` to make Flycast "DPI aware" + use correct DPI Scaling for rendering now.

Mac:
Calculate the correct scaling factor by using the `scaled resolution / native resolution`.

p.s. `SDL_GetDisplayDPI()` is incorrect on macOS since it is relying on the `backingScaleFactor`
https://github.com/libsdl-org/SDL/issues/3446: [actual commit](https://hg.libsdl.org/SDL/rev/3b03741c0095)
