### PR TITLE
GitHub Actions: Enable i686-pc-windows-msvc build

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         config:
-#          - {name: i686-pc-windows-msvc, os: windows-latest, cmakeArgs: -G "Visual Studio 16 2019" -A Win32}
+          - {name: i686-pc-windows-msvc, os: windows-latest, cmakeArgs: -DCMAKE_SYSTEM_VERSION="10.0.18362.0" -G "Visual Studio 16 2019" -A Win32}
           - {name: x86_64-apple-darwin, os: macos-latest, cmakeArgs: -G "Xcode"}
           - {name: x86_64-pc-linux-gnu, os: ubuntu-latest}
           - {name: x86_64-pc-windows-msvc, os: windows-latest, cmakeArgs: -DCMAKE_SYSTEM_VERSION="10.0.18362.0" -G "Visual Studio 16 2019" -A x64}


### PR DESCRIPTION
I guess it was disabled because of build issues with zlib