### PR TITLE
deps: use official SDL url for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "core/deps/SDL"]
 	path = core/deps/SDL
-	url = https://github.com/spurious/SDL-mirror.git
+	url = https://github.com/libsdl-org/SDL.git


### PR DESCRIPTION
See https://github.com/spurious/SDL-mirror/issues/15

After this update, run
```
git submodule sync
git submodule update --init --recursive
```
to use the new url.