### PR TITLE
cmake: fix sdl compilation with Ninja + MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,16 +125,16 @@ if(WIN32)
 	execute_process(COMMAND git apply -p1 ${CMAKE_CURRENT_SOURCE_DIR}/core/deps/patches/SDL.patch
 		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/core/deps/SDL) 
 	file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/core/deps/SDL")
-	if(MSVC)
+	if(CMAKE_GENERATOR MATCHES "Visual Studio")
 		set(SDL_CMAKE_ARCH_ARG -A ${CMAKE_GENERATOR_PLATFORM})
 	endif()
-	execute_process(COMMAND ${CMAKE_COMMAND} 
-		"-DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/core/deps/SDL" 
+	execute_process(COMMAND ${CMAKE_COMMAND}
+		"-DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/core/deps/SDL"
 		-DLIBC=ON
 		-DBUILD_SHARED_LIBS=OFF
 		-G "${CMAKE_GENERATOR}"
 		${SDL_CMAKE_ARCH_ARG}
-		"${CMAKE_CURRENT_SOURCE_DIR}/core/deps/SDL" 
+		"${CMAKE_CURRENT_SOURCE_DIR}/core/deps/SDL"
     	WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/core/deps/SDL")
 	execute_process(COMMAND ${CMAKE_COMMAND} --build "${CMAKE_CURRENT_BINARY_DIR}/core/deps/SDL" --config Release --target install)
 endif()

--- a/core/deps/patches/SDL.patch
+++ b/core/deps/patches/SDL.patch
@@ -49,7 +49,7 @@ index 2557d8628..f3d214b1d 100644
  
              /* Mouse data (ignoring synthetic mouse events generated for touchscreens) */
              if (inp.header.dwType == RIM_TYPEMOUSE) {
-+            	SDL_MouseID mouseID;
++                SDL_MouseID mouseID;
                  if (GetMouseMessageSource() == SDL_MOUSE_EVENT_SOURCE_TOUCH ||
                      (GetMessageExtraInfo() & 0x82) == 0x82) {
                      break;


### PR DESCRIPTION
Also fix a minor warning during `git apply`
```
D:/a/flycast/flycast/core/deps/patches/SDL.patch:52: space before tab in indent.
            	SDL_MouseID mouseID;
warning: 1 line adds whitespace errors.
```
https://github.com/flyinghead/flycast/runs/2640224149#step:8:47