### PR TITLE
Update bitrise.yml

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,30 +1,27 @@
 ---
-format_version: '7'
+format_version: '11'
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: macos
 trigger_map:
-- pull_request_source_branch: "*"
-  workflow: buildonly
 - push_branch: "*"
-  workflow: deploy
+  workflow: primary
+- pull_request_source_branch: "*"
+  workflow: primary
 workflows:
-  deploy:
-    envs:
-    - opts:
-        is_expand: false
-      BITRISE_SCHEME: reicast-osx
+  primary:
     steps:
-    - activate-ssh-key@4.0.3:	
+    - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - cache-pull@2.0.1: {}
-    - script@1.1.5:
+    - git-clone@6: {}
+    - cache-pull@2: {}
+    - script@1:
         inputs:
         - content: |
             #!/bin/bash
             export GIT_HASH=`git log --pretty=format:'%h' -n 1`
             envman add --key GIT_HASH --value $GIT_HASH
             envman add --key GIT_BUILD --value `git describe --all --always | sed 's/remotes\/origin/heads/'`-$GIT_HASH
-    - script@1.1.5:
+    - script@1:
         inputs:
         - content: |
             #!/bin/bash
@@ -32,57 +29,32 @@ workflows:
             cd shell/apple
             mkdir artifacts
             brew install --build-from-source ./sdl2.rb
-    - certificate-and-profile-installer@1.10.1: {}
-    - recreate-user-schemes@1.0.2:
+    - certificate-and-profile-installer@1: {}
+    - recreate-user-schemes@1:
         inputs:
         - project_path: "$BITRISE_PROJECT_PATH"
-    - xcode-archive-mac@1.6.2:
-        deps:
-          brew:
-          - name: sdl2
+    - xcode-archive-mac@1:
         inputs:
         - project_path: "$BITRISE_PROJECT_PATH"
         - scheme: "$BITRISE_SCHEME"
         - export_method: "$BITRISE_EXPORT_METHOD"
-    - amazon-s3-uploader@1.0.1:
+    - amazon-s3-uploader@1:
+        run_if: '{{getenv "BITRISE_GIT_BRANCH" | eq "master"}}'
         inputs:
         - aws_access_key: AKIAJOZQS4H2PHQWYFCA
         - aws_secret_key: "$S3_SECRET_KEY"
         - bucket_name: flycast-builds
         - path_in_bucket: osx/$GIT_BUILD
         - file_path: "$BITRISE_EXPORTED_FILE_PATH"
-    - cache-push@2.1.1: {}
-  buildonly:
-    envs:
-    - opts:
-        is_expand: false
-      BITRISE_SCHEME: reicast-osx
-    steps:
-    - activate-ssh-key@4.0.3:	
-        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - cache-pull@2.0.1: {}
-    - script@1.1.5:
-        inputs:
-        - content: |
-            #!/bin/bash
-            export GIT_HASH=`git log --pretty=format:'%h' -n 1`
-            envman add --key GIT_HASH --value $GIT_HASH
-            envman add --key GIT_BUILD --value `git describe --all --always | sed 's/remotes\/origin/heads/'`-$GIT_HASH
-    - certificate-and-profile-installer@1.10.1: {}
-    - recreate-user-schemes@1.0.2:
-        inputs:
-        - project_path: "$BITRISE_PROJECT_PATH"
-    - xcode-archive-mac@1.6.2:
-        inputs:
-        - project_path: "$BITRISE_PROJECT_PATH"
-        - scheme: "$BITRISE_SCHEME"
-        - export_method: "$BITRISE_EXPORT_METHOD"
-    - cache-push@2.1.1: {}
+    - cache-push@2: {}
 app:
   envs:
   - opts:
       is_expand: false
     BITRISE_PROJECT_PATH: shell/apple/reicast.xcworkspace
+  - opts:
+      is_expand: false
+    BITRISE_SCHEME: reicast-osx
   - opts:
       is_expand: false
     BITRISE_EXPORT_METHOD: none


### PR DESCRIPTION
- Merge "deploy" and "buildonly" workflows into one with a condition to run amazon-s3-uploader script only on master
- Update steps version and use major version only to minor and patch updates automatically
- Add the git-clone step which was missing (?), does that mean the workflow defined in the bitrise.yml file is not used/updated?