### PR TITLE
Force cmake to add rpath to support macOS without Swift 5 Runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -927,6 +927,8 @@ elseif(APPLE)
         XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "shell/apple/emulator-osx/emulator-osx/emulator-osx-Bridging-Header.h"
 		RESOURCE "${XIB}"
 		XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon"
+        BUILD_WITH_INSTALL_RPATH TRUE
+        INSTALL_RPATH "@loader_path/../Frameworks"
     )
 
     find_library(AUDIO_UNIT_LIBRARY AudioUnit)


### PR DESCRIPTION
Swift 5 is introduced in macOS 10.14.4