### PR TITLE
ci: remove flac package

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ freebsd_instance:
   image_family: freebsd-12-2
 
 task:
-  install_script: pkg install -y alsa-lib cmake evdev-proto flac git libao libevdev libudev-devd libzip mesa-libs miniupnpc ninja pkgconf png pulseaudio sdl2
+  install_script: pkg install -y alsa-lib cmake evdev-proto git libao libevdev libudev-devd libzip mesa-libs miniupnpc ninja pkgconf png pulseaudio sdl2
   script:
     - git submodule update --init --recursive
     - cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up build environment (ubuntu-latest)
         run: |
           sudo apt-get update
-          sudo apt-get -y install ccache libao-dev libasound2-dev libevdev-dev libflac-dev libgl1-mesa-dev libpulse-dev libsdl2-dev libudev-dev libzip-dev libminiupnpc-dev
+          sudo apt-get -y install ccache libao-dev libasound2-dev libevdev-dev libgl1-mesa-dev libpulse-dev libsdl2-dev libudev-dev libzip-dev libminiupnpc-dev
           echo "CCACHE_DIR=/tmp/ccache" >> $GITHUB_ENV
         if: matrix.config.os == 'ubuntu-latest'
 


### PR DESCRIPTION
With the libchdr's update (https://github.com/flyinghead/flycast/commit/54c492cac6e06ced7a27544ace86ea275c84010d) using dr_flac, this package is no longer required to build Flycast