### PR TITLE
Add default coin mapping

### DIFF
--- a/core/sdl/sdl_gamepad.h
+++ b/core/sdl/sdl_gamepad.h
@@ -67,7 +67,8 @@ public:
 			map_button(SDL_CONTROLLER_BUTTON_DPAD_LEFT, DC_DPAD_LEFT);
 			map_button(SDL_CONTROLLER_BUTTON_DPAD_RIGHT, DC_DPAD_RIGHT);
 			map_button(SDL_CONTROLLER_BUTTON_BACK, EMU_BTN_MENU);
-			map_button(SDL_CONTROLLER_BUTTON_LEFTSHOULDER, DC_BTN_C); // service
+			map_button(SDL_CONTROLLER_BUTTON_LEFTSHOULDER, DC_BTN_C);  // service
+			map_button(SDL_CONTROLLER_BUTTON_START, DC_BTN_D);         // coin
 			map_button(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER, DC_BTN_Z); // test
 
 			auto map_axis = [&](SDL_GameControllerAxis sdl_axis, DreamcastKey dc_axis) {


### PR DESCRIPTION
Resolves https://github.com/flyinghead/flycast/issues/309.
The default COIN mapping is now the Start button. I've tested on a DualShock 3 and Xbox 360 controller.