### PR TITLE
Add volume slider in audio settings

### DIFF
--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -56,6 +56,7 @@ Option<bool> AutoLatency("aica.AutoLatency",
 		);
 
 OptionString AudioBackend("backend", "auto", "audio");
+Option<int> AudioVolume("aica.Volume", 100);
 
 // Rendering
 

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -304,6 +304,7 @@ extern Option<int> AudioBufferSize;	//In samples ,*4 for bytes
 extern Option<bool> AutoLatency;
 
 extern OptionString AudioBackend;
+extern Option<int> AudioVolume;
 
 // Rendering
 

--- a/core/oslib/audiostream.cpp
+++ b/core/oslib/audiostream.cpp
@@ -79,8 +79,8 @@ audiobackend_t* GetAudioBackend(const std::string& slug)
 
 void WriteSample(s16 r, s16 l)
 {
-	Buffer[writePtr].r = r;
-	Buffer[writePtr].l = l;
+	Buffer[writePtr].r = r * config::AudioVolume / 100;
+	Buffer[writePtr].l = l * config::AudioVolume / 100;
 
 	if (++writePtr == SAMPLE_COUNT)
 	{

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1558,6 +1558,7 @@ static void gui_display_settings()
 			OptionCheckbox("Disable Sound", config::DisableSound, "Disable the emulator sound output");
 			OptionCheckbox("Enable DSP", config::DSPEnabled,
 					"Enable the Dreamcast Digital Sound Processor. Only recommended on fast platforms");
+			OptionSlider("Volume Level", config::AudioVolume, 0, 100, "Adjust the emulator's audio level");
 #ifdef __ANDROID__
 			if (config::AudioBackend.get() == "auto" || config::AudioBackend.get() == "android")
 				OptionCheckbox("Automatic Latency", config::AutoLatency,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/602245/130831315-1b09dd85-f708-4de1-b32e-8f2ae51f3059.png)

- Since the emulator is really loud
- Windows do not remember per app volume settings
- There isn't per app volume settings in macOS

Should the new default of volume set to 50%?