### PR TITLE
ggpo: static rtc when ggpo is enabled

### DIFF
--- a/core/hw/aica/aica_if.cpp
+++ b/core/hw/aica/aica_if.cpp
@@ -37,7 +37,12 @@ u32 GetRTC_now()
 	gmtm.tm_isdst = -1;
 	time_t time_offset = mktime(&localtm) - mktime(&gmtm);
 	// 1/1/50 to 1/1/70 is 20 years and 5 leap days
-	return (20 * 365 + 5) * 24 * 60 * 60 + rawtime + time_offset;
+
+	// rtc kept static for netplay when savestate is not loaded
+	if (config::GGPOEnable)
+		return (20 * 365 + 5) * 24 * 60 * 60;
+	else
+		return (20 * 365 + 5) * 24 * 60 * 60 + rawtime + time_offset;
 }
 
 u32 ReadMem_aica_rtc(u32 addr, u32 sz)


### PR DESCRIPTION
* Real Time Clock set to static value when GGPO is enabled. Useful for games when savestates are not loaded on boot.