### PR TITLE
[BUGFIX] Add ALTDeviceID to iOS Info.plist

### DIFF
--- a/shell/apple/emulator-ios/plist.in
+++ b/shell/apple/emulator-ios/plist.in
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ALTDeviceID</key>
+	<string>dummy</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
This value needs to exist in the plist file so AltServer can replace it with the device's UDID on install. 

Reference from DolphiniOS - https://github.com/OatmealDome/dolphin/commit/7f0e826558ad22009083ced6590d1e8a41d39d1b