### PR TITLE
[iOS] GCMouse support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1134,6 +1134,7 @@ if(NOT LIBRETRO)
 					shell/apple/emulator-ios/emulator/ios_main.mm
 					shell/apple/emulator-ios/emulator/ios_gamepad.h
 					shell/apple/emulator-ios/emulator/ios_keyboard.h
+					shell/apple/emulator-ios/emulator/ios_mouse.h
 					shell/apple/emulator-ios/emulator/FlycastViewController.h
 					shell/apple/emulator-ios/emulator/FlycastViewController.mm
 					shell/apple/emulator-ios/emulator/PadViewController.h

--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -131,7 +131,9 @@ Option<bool> OmxAudioHdmi("audio_hdmi", true, "omx");
 // Maple
 
 Option<int> MouseSensitivity("MouseSensitivity", 100, "input");
+#ifdef __APPLE__
 Option<bool> MouseInvert("MouseInvert", false, "input");
+#endif
 Option<int> VirtualGamepadVibration("VirtualGamepadVibration", 20, "input");
 
 std::array<Option<MapleDeviceType>, 4> MapleMainDevices {

--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -131,6 +131,7 @@ Option<bool> OmxAudioHdmi("audio_hdmi", true, "omx");
 // Maple
 
 Option<int> MouseSensitivity("MouseSensitivity", 100, "input");
+Option<bool> MouseInvert("MouseInvert", false, "input");
 Option<int> VirtualGamepadVibration("VirtualGamepadVibration", 20, "input");
 
 std::array<Option<MapleDeviceType>, 4> MapleMainDevices {

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -506,7 +506,9 @@ extern Option<bool> OmxAudioHdmi;
 // Maple
 
 extern Option<int> MouseSensitivity;
+#ifdef __APPLE__
 extern Option<bool> MouseInvert;
+#endif
 extern Option<int> VirtualGamepadVibration;
 extern std::array<Option<MapleDeviceType>, 4> MapleMainDevices;
 extern std::array<std::array<Option<MapleDeviceType>, 2>, 4> MapleExpansionDevices;

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -506,6 +506,7 @@ extern Option<bool> OmxAudioHdmi;
 // Maple
 
 extern Option<int> MouseSensitivity;
+extern Option<bool> MouseInvert;
 extern Option<int> VirtualGamepadVibration;
 extern std::array<Option<MapleDeviceType>, 4> MapleMainDevices;
 extern std::array<std::array<Option<MapleDeviceType>, 2>, 4> MapleExpansionDevices;

--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -1428,10 +1428,6 @@ void SetMousePosition(int x, int y, int width, int height, u32 mouseId)
 		return;
 	mo_width = width;
 	mo_height = height;
-    
-    if (config::MouseInvert) {
-        y = y * -1;
-    }
 
 	if (config::Rotate90)
 	{
@@ -1466,7 +1462,7 @@ void SetRelativeMousePosition(float xrel, float yrel, u32 mouseId)
 		std::swap(width, height);
 	}
 	float dx = xrel * config::MouseSensitivity / 100.f;
-	float dy = (yrel * config::MouseSensitivity / 100.f) * (config::MouseInvert ? -1 : 1);
+	float dy = yrel * config::MouseSensitivity / 100.f;
 	mo_x_delta[mouseId] += dx;
 	mo_y_delta[mouseId] += dy;
 	int minX = -width / 32;

--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -1428,6 +1428,10 @@ void SetMousePosition(int x, int y, int width, int height, u32 mouseId)
 		return;
 	mo_width = width;
 	mo_height = height;
+    
+    if (config::MouseInvert) {
+        y = y * -1;
+    }
 
 	if (config::Rotate90)
 	{
@@ -1462,7 +1466,7 @@ void SetRelativeMousePosition(float xrel, float yrel, u32 mouseId)
 		std::swap(width, height);
 	}
 	float dx = xrel * config::MouseSensitivity / 100.f;
-	float dy = yrel * config::MouseSensitivity / 100.f;
+	float dy = (yrel * config::MouseSensitivity / 100.f) * (config::MouseInvert ? -1 : 1);
 	mo_x_delta[mouseId] += dx;
 	mo_y_delta[mouseId] += dy;
 	int minX = -width / 32;

--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -1449,7 +1449,7 @@ void SetMousePosition(int x, int y, int width, int height, u32 mouseId)
 	mo_y_prev[mouseId] = y;
 }
 
-void SetRelativeMousePosition(int xrel, int yrel, u32 mouseId)
+void SetRelativeMousePosition(float xrel, float yrel, u32 mouseId)
 {
 	if (mouseId >= MAPLE_PORTS)
 		return;
@@ -1461,8 +1461,8 @@ void SetRelativeMousePosition(int xrel, int yrel, u32 mouseId)
 		xrel = -xrel;
 		std::swap(width, height);
 	}
-	float dx = (float)xrel * config::MouseSensitivity / 100.f;
-	float dy = (float)yrel * config::MouseSensitivity / 100.f;
+	float dx = xrel * config::MouseSensitivity / 100.f;
+	float dy = yrel * config::MouseSensitivity / 100.f;
 	mo_x_delta[mouseId] += dx;
 	mo_y_delta[mouseId] += dy;
 	int minX = -width / 32;

--- a/core/hw/maple/maple_devs.h
+++ b/core/hw/maple/maple_devs.h
@@ -177,7 +177,7 @@ extern s32 mo_x_prev[4];
 extern s32 mo_y_prev[4];
 
 void SetMousePosition(int x, int y, int width, int height, u32 mouseId = 0);
-void SetRelativeMousePosition(int xrel, int yrel, u32 mouseId = 0);
+void SetRelativeMousePosition(float xrel, float yrel, u32 mouseId = 0);
 
 #define SWAP32(a) ((((a) & 0xff) << 24)  | (((a) & 0xff00) << 8) | (((a) >> 8) & 0xff00) | (((a) >> 24) & 0xff))
 

--- a/core/input/gamepad_device.cpp
+++ b/core/input/gamepad_device.cpp
@@ -524,7 +524,7 @@ void Mouse::setAbsPos(int x, int y, int width, int height) {
 	SetMousePosition(x, y, width, height, maple_port());
 }
 
-void Mouse::setRelPos(int deltax, int deltay) {
+void Mouse::setRelPos(float deltax, float deltay) {
 	SetRelativeMousePosition(deltax, deltay, maple_port());
 }
 

--- a/core/input/gamepad_device.h
+++ b/core/input/gamepad_device.h
@@ -180,7 +180,7 @@ public:
 	}
 
 	void setAbsPos(int x, int y, int width, int height);
-	void setRelPos(int deltax, int deltay);
+	void setRelPos(float deltax, float deltay);
 	void setButton(Button button, bool pressed);
 	void setWheel(int delta);
 };

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1252,6 +1252,7 @@ static void gui_display_settings()
 
 	    	ImGui::Spacing();
 	    	OptionSlider("Mouse sensitivity", config::MouseSensitivity, 1, 500);
+            OptionCheckbox("Invert mouse", config::MouseInvert, "If your vertical mouse input feels wrong try enabling");
 #ifdef _WIN32
 	    	OptionCheckbox("Use Raw Input", config::UseRawInput, "Supports multiple pointing devices (mice, light guns) and keyboards");
 #endif

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1252,7 +1252,9 @@ static void gui_display_settings()
 
 	    	ImGui::Spacing();
 	    	OptionSlider("Mouse sensitivity", config::MouseSensitivity, 1, 500);
-            OptionCheckbox("Invert mouse", config::MouseInvert, "If your vertical mouse input feels wrong try enabling");
+#ifdef __APPLE__
+            OptionCheckbox("Invert mouse", config::MouseInvert, "If your vertical mouse input feels wrong try enabling. Only applies to external iOS mice.");
+#endif
 #ifdef _WIN32
 	    	OptionCheckbox("Use Raw Input", config::UseRawInput, "Supports multiple pointing devices (mice, light guns) and keyboards");
 #endif

--- a/shell/apple/emulator-ios/emulator/EmulatorView.mm
+++ b/shell/apple/emulator-ios/emulator/EmulatorView.mm
@@ -24,13 +24,13 @@
 #include "ios_gamepad.h"
 
 @implementation EmulatorView {
-	std::shared_ptr<IOSMouse> mouse;
+	std::shared_ptr<IOSTouchMouse> mouse;
 }
 
 - (void)didMoveToSuperview
 {
 	[super didMoveToSuperview];
-	mouse = std::make_shared<IOSMouse>();
+	mouse = std::make_shared<IOSTouchMouse>();
 	GamepadDevice::Register(mouse);
 }
 

--- a/shell/apple/emulator-ios/emulator/FlycastViewController.mm
+++ b/shell/apple/emulator-ios/emulator/FlycastViewController.mm
@@ -153,7 +153,7 @@ extern int screen_dpi;
             addObserverForName:GCMouseDidConnectNotification object:nil queue:[NSOperationQueue mainQueue]
             usingBlock:^(NSNotification *note) {
             GCMouse *mouse = note.object;
-            IOSMouse::addMouse(moue);
+            IOSMouse::addMouse(mouse);
         }];
         
         self.mouseDisconnectObserver = [[NSNotificationCenter defaultCenter]

--- a/shell/apple/emulator-ios/emulator/FlycastViewController.mm
+++ b/shell/apple/emulator-ios/emulator/FlycastViewController.mm
@@ -37,6 +37,7 @@
 #include "cfg/option.h"
 #include "ios_gamepad.h"
 #include "ios_keyboard.h"
+#include "ios_mouse.h"
 
 //@import AltKit;
 #import "AltKit/AltKit-Swift.h"
@@ -47,6 +48,7 @@ static __unsafe_unretained FlycastViewController *flycastViewController;
 
 std::map<GCController *, std::shared_ptr<IOSGamepad>> IOSGamepad::controllers;
 std::map<GCKeyboard *, std::shared_ptr<IOSKeyboard>> IOSKeyboard::keyboards;
+std::map<GCMouse *, std::shared_ptr<IOSMouse>> IOSMouse::mice;
 
 void common_linux_setup();
 
@@ -60,6 +62,9 @@ void common_linux_setup();
 @property (nonatomic, strong) id gamePadDisconnectObserver;
 @property (nonatomic, strong) id keyboardConnectObserver;
 @property (nonatomic, strong) id keyboardDisconnectObserver;
+@property (nonatomic, strong) id mouseConnectObserver;
+@property (nonatomic, strong) id mouseDisconnectObserver;
+
 
 @property (nonatomic, strong) nw_path_monitor_t monitor;
 @property (nonatomic, strong) dispatch_queue_t monitorQueue;
@@ -142,6 +147,20 @@ extern int screen_dpi;
             usingBlock:^(NSNotification *note) {
             GCKeyboard *keyboard = note.object;
             IOSKeyboard::removeKeyboard(keyboard);
+        }];
+        
+        self.mouseConnectObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:GCMouseDidConnectNotification object:nil queue:[NSOperationQueue mainQueue]
+            usingBlock:^(NSNotification *note) {
+            GCMouse *mouse = note.object;
+            IOSMouse::addMouse(moue);
+        }];
+        
+        self.mouseDisconnectObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:GCMouseDidDisconnectNotification object:nil queue:[NSOperationQueue mainQueue]
+            usingBlock:^(NSNotification *note) {
+            GCMouse *mouse = note.object;
+            IOSMouse::removeMouse(mouse);
         }];
     }
 

--- a/shell/apple/emulator-ios/emulator/ios_gamepad.h
+++ b/shell/apple/emulator-ios/emulator/ios_gamepad.h
@@ -533,6 +533,7 @@ public:
     IOSTouchMouse() : SystemMouse("iOS")
     {
         _unique_id = "ios_mouse";
+        _name = "Touchscreen (Mouse)";
         loadMapping();
     }
 };

--- a/shell/apple/emulator-ios/emulator/ios_gamepad.h
+++ b/shell/apple/emulator-ios/emulator/ios_gamepad.h
@@ -526,3 +526,13 @@ protected:
 private:
 	u32 buttonState = 0;
 };
+
+class IOSTouchMouse : public SystemMouse
+{
+public:
+    IOSTouchMouse() : SystemMouse("iOS")
+    {
+        _unique_id = "ios_mouse";
+        loadMapping();
+    }
+};

--- a/shell/apple/emulator-ios/emulator/ios_gamepad.h
+++ b/shell/apple/emulator-ios/emulator/ios_gamepad.h
@@ -526,13 +526,3 @@ protected:
 private:
 	u32 buttonState = 0;
 };
-
-class IOSMouse : public SystemMouse
-{
-public:
-	IOSMouse() : SystemMouse("iOS")
-	{
-		_unique_id = "ios_mouse";
-		loadMapping();
-	}
-};

--- a/shell/apple/emulator-ios/emulator/ios_keyboard.h
+++ b/shell/apple/emulator-ios/emulator/ios_keyboard.h
@@ -1,5 +1,5 @@
 //
-//  ios.h
+//  ios_keyboard.h
 //  flycast
 //
 //  Created by Cameron Bates on 9/6/21.

--- a/shell/apple/emulator-ios/emulator/ios_mouse.h
+++ b/shell/apple/emulator-ios/emulator/ios_mouse.h
@@ -19,7 +19,7 @@ public:
         loadMapping();
 
         [gcMouse.mouseInput setMouseMovedHandler:^(GCMouseInput * _Nonnull mouse, float deltaX, float deltaY) {
-            setRelPos(roundf(deltaX), roundf(deltaY));
+            setRelPos(deltaX, deltaY);
         }];
 
         [gcMouse.mouseInput.leftButton setValueChangedHandler:

--- a/shell/apple/emulator-ios/emulator/ios_mouse.h
+++ b/shell/apple/emulator-ios/emulator/ios_mouse.h
@@ -8,16 +8,38 @@
 #import <GameController/GameController.h>
 
 #include "input/gamepad_device.h"
+#include "rend/gui.h"
 
-class IOSMouse : public SystemMouse
+class API_AVAILABLE(ios(14.0)) IOSMouse : public SystemMouse
 {
 public:
     IOSMouse(int port, GCMouse *mouse) : SystemMouse("iOS", port), gcMouse(mouse)
     {
         set_maple_port(port);
         loadMapping();
+
+        [gcMouse.mouseInput setMouseMovedHandler:^(GCMouseInput * _Nonnull mouse, float deltaX, float deltaY) {
+            setRelPos(roundf(deltaX), roundf(deltaY));
+        }];
+
+        [gcMouse.mouseInput.leftButton setValueChangedHandler:
+         ^(GCControllerButtonInput * _Nonnull button, float value, BOOL pressed) {
+            setButton(Mouse::LEFT_BUTTON, pressed);
+        }];
         
-//        [gcMouse.mouseInput set]
+        [gcMouse.mouseInput.rightButton setValueChangedHandler:
+         ^(GCControllerButtonInput * _Nonnull button, float value, BOOL pressed) {
+            setButton(Mouse::RIGHT_BUTTON, pressed);
+        }];
+        
+        [gcMouse.mouseInput.middleButton setValueChangedHandler:
+         ^(GCControllerButtonInput * _Nonnull button, float value, BOOL pressed) {
+            setButton(Mouse::MIDDLE_BUTTON, pressed);
+        }];
+        
+        [gcMouse.mouseInput.scroll setValueChangedHandler:^(GCControllerDirectionPad * _Nonnull dpad, float xValue, float yValue) {
+            setWheel(yValue);
+        }];
     }
     
     void set_maple_port(int port) override
@@ -27,11 +49,11 @@ public:
     
     static void addMouse(GCMouse *mouse)
     {
-        if (mice.count(mouce) > 0)
+        if (mice.count(mouse) > 0)
             return;
         
-        int port = std::mind((int)mice.size(), 3);
-        mice[mouse] = std::make_shared<IOSMouse>(port, keyboard);
+        int port = std::min((int)mice.size(), 3);
+        mice[mouse] = std::make_shared<IOSMouse>(port, mouse);
         GamepadDevice::Register(mice[mouse]);
     }
     

--- a/shell/apple/emulator-ios/emulator/ios_mouse.h
+++ b/shell/apple/emulator-ios/emulator/ios_mouse.h
@@ -36,8 +36,8 @@ public:
             setButton(Mouse::MIDDLE_BUTTON, pressed);
         }];
         
-        [gcMouse.mouseInput.scroll setValueChangedHandler:^(GCControllerDirectionPad * _Nonnull dpad, float xValue, float yValue) {
-            setWheel(yValue);
+        [gcMouse.mouseInput.scroll.yAxis setValueChangedHandler:^(GCControllerAxisInput * _Nonnull axis, float value) {
+            setWheel(value);
         }];
     }
 

--- a/shell/apple/emulator-ios/emulator/ios_mouse.h
+++ b/shell/apple/emulator-ios/emulator/ios_mouse.h
@@ -8,7 +8,6 @@
 #import <GameController/GameController.h>
 
 #include "input/gamepad_device.h"
-#include "rend/gui.h"
 
 class API_AVAILABLE(ios(14.0)) IOSMouse : public SystemMouse
 {
@@ -41,12 +40,12 @@ public:
             setWheel(yValue);
         }];
     }
-    
+
     void set_maple_port(int port) override
     {
-        GamepadDevice::set_maple_port(port);
+        SystemMouse::set_maple_port(port);
     }
-    
+
     static void addMouse(GCMouse *mouse)
     {
         if (mice.count(mouse) > 0)
@@ -54,15 +53,15 @@ public:
         
         int port = std::min((int)mice.size(), 3);
         mice[mouse] = std::make_shared<IOSMouse>(port, mouse);
-        GamepadDevice::Register(mice[mouse]);
+        SystemMouse::Register(mice[mouse]);
     }
-    
+
     static void removeMouse(GCMouse *mouse)
     {
         auto it = mice.find(mouse);
         if (it == mice.end())
             return;
-        GamepadDevice::Unregister(it->second);
+        SystemMouse::Unregister(it->second);
         mice.erase(it);
     }
 

--- a/shell/apple/emulator-ios/emulator/ios_mouse.h
+++ b/shell/apple/emulator-ios/emulator/ios_mouse.h
@@ -1,0 +1,50 @@
+//
+//  ios.h
+//  flycast
+//
+//  Created by Cameron Bates on 9/6/21.
+//
+#pragma once
+#import <GameController/GameController.h>
+
+#include "input/gamepad_device.h"
+
+class IOSMouse : public SystemMouse
+{
+public:
+    IOSMouse(int port, GCMouse *mouse) : SystemMouse("iOS", port), gcMouse(mouse)
+    {
+        set_maple_port(port);
+        loadMapping();
+        
+//        [gcMouse.mouseInput set]
+    }
+    
+    void set_maple_port(int port) override
+    {
+        GamepadDevice::set_maple_port(port);
+    }
+    
+    static void addMouse(GCMouse *mouse)
+    {
+        if (mice.count(mouce) > 0)
+            return;
+        
+        int port = std::mind((int)mice.size(), 3);
+        mice[mouse] = std::make_shared<IOSMouse>(port, keyboard);
+        GamepadDevice::Register(mice[mouse]);
+    }
+    
+    static void removeMouse(GCMouse *mouse)
+    {
+        auto it = mice.find(mouse);
+        if (it == mice.end())
+            return;
+        GamepadDevice::Unregister(it->second);
+        mice.erase(it);
+    }
+
+private:
+    GCMouse * __weak gcMouse = nullptr;
+    static std::map<GCMouse *, std::shared_ptr<IOSMouse>> mice;
+};

--- a/shell/apple/emulator-ios/emulator/ios_mouse.h
+++ b/shell/apple/emulator-ios/emulator/ios_mouse.h
@@ -1,5 +1,5 @@
 //
-//  ios.h
+//  ios_mouse.h
 //  flycast
 //
 //  Created by Cameron Bates on 9/6/21.
@@ -17,8 +17,8 @@ public:
         set_maple_port(port);
         loadMapping();
 
-        [gcMouse.mouseInput setMouseMovedHandler:^(GCMouseInput * _Nonnull mouse, float deltaX, float deltaY) {
-            setRelPos(deltaX, deltaY);
+        [gcMouse.mouseInput setMouseMovedHandler:^(GCMouseInput * _Nonnull mouse, float deltaX, float deltaY) { 
+            setRelPos(deltaX, deltaY * (config::MouseInvert ? -1 : 1));
         }];
 
         [gcMouse.mouseInput.leftButton setValueChangedHandler:


### PR DESCRIPTION
This PR adds in GCMouse support on iOS versions 14+

- Updated setRelPos/SetRelativeMousePosition to accept floats instead of ints
- Old IOSMouse is now IOSTouchMouse
  - To differentiate better in settings I set the name to `Touchscreen (Mouse)`
- On iOS 14+ the app will now lock and hide the mouse cursor
  - On pause/terminate this is set back to false so the user can navigate using mouse
- Added an option to invert external mice
  - This is only available on iOS
  - The trackpad on the iPad Smart Keyboard sends values inverted by default it seems. I didn't test with any other mice, but figured this option would be nice if the user feels like their mouse is wrong

https://user-images.githubusercontent.com/4458812/133198573-b939896f-ead3-46c7-89f8-2acf1e56659e.mp4
