### PR TITLE
Sdl controller fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,14 @@ endif()
 
 project(flycast)
 
+# emuelec
+option(ENABLE_EMUELEC "Set to 1 to enable EmuELEC changes" ${ENABLE_EMUELEC})
+
+# emuelec
+if("${ENABLE_EMUELEC}" STREQUAL "1")
+  add_definitions(-D_ENABLEEMUELEC)
+endif()
+
 if(ENABLE_CTEST)
     include(CTest)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,6 @@ if(NOT LIBRETRO)
 	elseif(NOT ANDROID AND NOT IOS)
 	    find_package(SDL2)
 	endif()
-
 	if(SDL2_FOUND)
 	    target_compile_definitions(${PROJECT_NAME} PRIVATE USE_SDL USE_SDL_AUDIO)
 	    target_sources(${PROJECT_NAME} PRIVATE core/sdl/sdl.cpp core/sdl/sdl.h core/sdl/sdl_gamepad.h core/sdl/sdl_keyboard.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ option(USE_HOST_LIBZIP "Use host libzip" ON)
 option(USE_OPENMP "Use OpenMP if available" ON)
 option(USE_VULKAN "Build with Vulkan support" ON)
 option(LIBRETRO "Build libretro core" OFF)
-option(ENABLE_EMUELEC "Set to 1 to enable EmuELEC changes" ${ENABLE_EMUELEC})
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/shell/cmake")
 
@@ -239,12 +238,7 @@ if(NOT LIBRETRO)
 	elseif(NOT ANDROID AND NOT IOS)
 	    find_package(SDL2)
 	endif()
-  
-  # emuelec
-  if("${ENABLE_EMUELEC}" STREQUAL "1")
-    target_compile_definitions(${PROJECT_NAME} PRIVATE _ENABLEEMUELEC)
-  endif()
-  
+
 	if(SDL2_FOUND)
 	    target_compile_definitions(${PROJECT_NAME} PRIVATE USE_SDL USE_SDL_AUDIO)
 	    target_sources(${PROJECT_NAME} PRIVATE core/sdl/sdl.cpp core/sdl/sdl.h core/sdl/sdl_gamepad.h core/sdl/sdl_keyboard.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(USE_HOST_LIBZIP "Use host libzip" ON)
 option(USE_OPENMP "Use OpenMP if available" ON)
 option(USE_VULKAN "Build with Vulkan support" ON)
 option(LIBRETRO "Build libretro core" OFF)
+option(ENABLE_EMUELEC "Set to 1 to enable EmuELEC changes" ${ENABLE_EMUELEC})
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/shell/cmake")
 
@@ -31,14 +32,6 @@ if(APPLE)
 endif()
 
 project(flycast)
-
-# emuelec
-option(ENABLE_EMUELEC "Set to 1 to enable EmuELEC changes" ${ENABLE_EMUELEC})
-
-# emuelec
-if("${ENABLE_EMUELEC}" STREQUAL "1")
-  add_definitions(-D_ENABLEEMUELEC)
-endif()
 
 if(ENABLE_CTEST)
     include(CTest)
@@ -246,6 +239,12 @@ if(NOT LIBRETRO)
 	elseif(NOT ANDROID AND NOT IOS)
 	    find_package(SDL2)
 	endif()
+  
+  # emuelec
+  if("${ENABLE_EMUELEC}" STREQUAL "1")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE _ENABLEEMUELEC)
+  endif()
+  
 	if(SDL2_FOUND)
 	    target_compile_definitions(${PROJECT_NAME} PRIVATE USE_SDL USE_SDL_AUDIO)
 	    target_sources(${PROJECT_NAME} PRIVATE core/sdl/sdl.cpp core/sdl/sdl.h core/sdl/sdl_gamepad.h core/sdl/sdl_keyboard.h)

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -160,13 +160,13 @@ void input_sdl_init()
 #endif
 		std::string db = get_readonly_data_path("gamecontrollerdb.txt");
 		int rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
-#ifdef _ENABLE_EMUELEC
+//#ifdef _ENABLE_EMUELEC
 		if (rv < 0)
 		{
 			db = (std::string) nowide::getenv("SDL_GAMECONTROLLERCONFIG_FILE");
 			rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
 		}
-#endif
+//#endif
 		if (rv < 0)
 		{
 			db = get_readonly_config_path("gamecontrollerdb.txt");

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -160,7 +160,6 @@ void input_sdl_init()
 #endif
 		std::string db = get_readonly_data_path("gamecontrollerdb.txt");
 		int rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
-
 		if (rv < 0)
 		{
 			db = get_readonly_config_path("gamecontrollerdb.txt");

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -161,8 +161,11 @@ void input_sdl_init()
 		std::string db = get_readonly_data_path("gamecontrollerdb.txt");
 		int rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
 #ifdef _ENABLE_EMUELEC
-		db = (std::string) nowide::getenv("SDL_GAMECONTROLLERCONFIG_FILE");
-		rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
+		if (rv < 0)
+		{
+			db = (std::string) nowide::getenv("SDL_GAMECONTROLLERCONFIG_FILE");
+			rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
+		}
 #endif
 		if (rv < 0)
 		{

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -160,7 +160,7 @@ void input_sdl_init()
 #endif
 		std::string db = get_readonly_data_path("gamecontrollerdb.txt");
 		int rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
-#ifdef ENABLE_EMUELEC
+#ifdef _ENABLE_EMUELEC
 		db = (std::string) nowide::getenv("SDL_GAMECONTROLLERCONFIG_FILE");
 		rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
 #endif

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -158,18 +158,20 @@ void input_sdl_init()
 			SDL_SetHint(SDL_HINT_XINPUT_ENABLED, "0");
 		}
 #endif
-		std::string db = (std::string) nowide::getenv("SDL_GAMECONTROLLERCONFIG_FILE");
+		std::string db = get_readonly_data_path("gamecontrollerdb.txt");
 		int rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
-		if (rv < 0)
-		{
-			db = get_readonly_data_path("gamecontrollerdb.txt");
-			rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
-		}		
 		if (rv < 0)
 		{
 			db = get_readonly_config_path("gamecontrollerdb.txt");
 			rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
 		}
+#ifdef ENABLE_EMUELEC
+		if (rv < 0)
+		{
+			db = (std::string) nowide::getenv("SDL_GAMECONTROLLERCONFIG_FILE");
+			rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
+		}		
+#endif
 		if (rv > 0)
 			DEBUG_LOG(INPUT ,"%d mappings loaded from %s", rv, db.c_str());
 

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -160,13 +160,7 @@ void input_sdl_init()
 #endif
 		std::string db = get_readonly_data_path("gamecontrollerdb.txt");
 		int rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
-//#ifdef _ENABLE_EMUELEC
-		if (rv < 0)
-		{
-			db = (std::string) nowide::getenv("SDL_GAMECONTROLLERCONFIG_FILE");
-			rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
-		}
-//#endif
+
 		if (rv < 0)
 		{
 			db = get_readonly_config_path("gamecontrollerdb.txt");

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -158,11 +158,13 @@ void input_sdl_init()
 			SDL_SetHint(SDL_HINT_XINPUT_ENABLED, "0");
 		}
 #endif
-		if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) < 0)
-			die("SDL: error initializing Joystick subsystem");
-
-		std::string db = get_readonly_data_path("gamecontrollerdb.txt");
+		std::string db = (std::string) nowide::getenv("SDL_GAMECONTROLLERCONFIG_FILE");
 		int rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
+		if (rv < 0)
+		{
+			db = get_readonly_data_path("gamecontrollerdb.txt");
+			rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
+		}		
 		if (rv < 0)
 		{
 			db = get_readonly_config_path("gamecontrollerdb.txt");
@@ -170,6 +172,10 @@ void input_sdl_init()
 		}
 		if (rv > 0)
 			DEBUG_LOG(INPUT ,"%d mappings loaded from %s", rv, db.c_str());
+
+		if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) < 0)
+			die("SDL: error initializing Joystick subsystem");
+			
 	}
 	if (SDL_WasInit(SDL_INIT_HAPTIC) == 0)
 		SDL_InitSubSystem(SDL_INIT_HAPTIC);

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -160,18 +160,15 @@ void input_sdl_init()
 #endif
 		std::string db = get_readonly_data_path("gamecontrollerdb.txt");
 		int rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
+#ifdef ENABLE_EMUELEC
+		db = (std::string) nowide::getenv("SDL_GAMECONTROLLERCONFIG_FILE");
+		rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
+#endif
 		if (rv < 0)
 		{
 			db = get_readonly_config_path("gamecontrollerdb.txt");
 			rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
 		}
-#ifdef ENABLE_EMUELEC
-		if (rv < 0)
-		{
-			db = (std::string) nowide::getenv("SDL_GAMECONTROLLERCONFIG_FILE");
-			rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
-		}		
-#endif
 		if (rv > 0)
 			DEBUG_LOG(INPUT ,"%d mappings loaded from %s", rv, db.c_str());
 


### PR DESCRIPTION
Hey,
For gamecontrollerdb.txt to be used searched correctly the file has to be loaded before the SDL init of input contollers.

Also,
Emuelec doesn't have the correct search path and the change enables Emuelec to retrieve the correct file.
