### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,12 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
 **Please Note: This form is the minimum required information for submitting bugs.**  
 **Removing this form may lead to your issue being closed until it is completed.**
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
* Add an intermediate screen to choose between "Bug report" or "Feature request" when creating an issue on GitHub
![image](https://user-images.githubusercontent.com/25406440/134773478-5038ab6c-038c-428b-902d-bcf5f59fe2e4.png)

* "Bug report" template is the same as currently
* "Feature request" uses GitHub's default template
* A label is automatically assigned : "bug" for ""Bug report" and "enhancement" for "Feature request"
