### PR TITLE
Allows override of flycast.lua file

### DIFF
--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -160,4 +160,9 @@ std::array<std::array<Option<MapleDeviceType>, 2>, 4> MapleExpansionDevices {
 Option<bool> UseRawInput("RawInput", false, "input");
 #endif
 
+// Lua
+
+OptionString LuaFileName("LuaFileName", "flycast.lua");
+Option<bool> OverrideLuaFile("OverrideLuaFile", false);
+
 } // namespace config

--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -160,9 +160,9 @@ std::array<std::array<Option<MapleDeviceType>, 2>, 4> MapleExpansionDevices {
 Option<bool> UseRawInput("RawInput", false, "input");
 #endif
 
-// Lua
-
+#ifdef USE_LUA
 OptionString LuaFileName("LuaFileName", "flycast.lua");
 Option<bool> OverrideLuaFile("OverrideLuaFile", false);
+#endif
 
 } // namespace config

--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -162,7 +162,6 @@ Option<bool> UseRawInput("RawInput", false, "input");
 
 #ifdef USE_LUA
 OptionString LuaFileName("LuaFileName", "flycast.lua");
-Option<bool> OverrideLuaFile("OverrideLuaFile", false);
 #endif
 
 } // namespace config

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -484,10 +484,10 @@ extern Option<bool> UseRawInput;
 constexpr bool UseRawInput = false;
 #endif
 
-// Lua
-
+#ifdef USE_LUA
 extern OptionString LuaFileName;
 extern Option<bool> OverrideLuaFile;
+#endif 
 
 } // namespace config
 

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -484,5 +484,10 @@ extern Option<bool> UseRawInput;
 constexpr bool UseRawInput = false;
 #endif
 
+// Lua
+
+extern OptionString LuaFileName;
+extern Option<bool> OverrideLuaFile;
+
 } // namespace config
 

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -486,7 +486,6 @@ constexpr bool UseRawInput = false;
 
 #ifdef USE_LUA
 extern OptionString LuaFileName;
-extern Option<bool> OverrideLuaFile;
 #endif 
 
 } // namespace config

--- a/core/lua/lua.cpp
+++ b/core/lua/lua.cpp
@@ -578,6 +578,20 @@ static void luaRegister(lua_State *L)
 		.endNamespace();
 }
 
+static std::string getLuaFile()
+{
+	std::string initFile;
+
+	if(config::OverrideLuaFile == true){
+		initFile = get_readonly_config_path(config::LuaFileName.get());
+	} else {
+		initFile = get_readonly_config_path("flycast.lua");
+	}
+
+	return initFile;
+
+} 
+
 static void doExec(const std::string& path)
 {
 	if (L == nullptr)
@@ -598,7 +612,7 @@ void exec(const std::string& path)
 
 void init()
 {
-	std::string initFile = get_readonly_config_path("flycast.lua");
+	std::string initFile = getLuaFile();
 	if (!file_exists(initFile))
 		return;
 	L = luaL_newstate();

--- a/core/lua/lua.cpp
+++ b/core/lua/lua.cpp
@@ -581,8 +581,7 @@ static void luaRegister(lua_State *L)
 static std::string getLuaFile()
 {
 	std::string initFile;
-
-	if(config::OverrideLuaFile == true){
+	if( !config::LuaFileName.get().empty()){
 		initFile = get_readonly_config_path(config::LuaFileName.get());
 	} else {
 		initFile = get_readonly_config_path("flycast.lua");

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1956,6 +1956,26 @@ static void gui_display_settings()
 		    }
 			ImGui::PopStyleVar();
 			ImGui::EndTabItem();
+
+			header("Lua Scripting");
+			// Begin Lua File Override
+			{
+				OptionCheckbox("Override Default Lua File", config::OverrideLuaFile);
+				ImGui::SameLine();
+				ShowHelpMarker("Override flycast's default lua file (flycast.lua). This file should be in Flycast's root directory");
+				if(config::OverrideLuaFile)
+				{
+					char LuaFileName[256];
+
+					strcpy(LuaFileName, config::LuaFileName.get().c_str());
+					ImGui::InputText("Lua Filename", LuaFileName, sizeof(LuaFileName), ImGuiInputTextFlags_CharsNoBlank, nullptr, nullptr);
+					ImGui::SameLine();
+					ShowHelpMarker("Specify lua filename to use. Should be located in Flycasts root directory.");
+					config::LuaFileName = LuaFileName;
+
+				}
+			}
+			// End Lua File Override
 		}
 		if (ImGui::BeginTabItem("About"))
 		{

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1957,8 +1957,8 @@ static void gui_display_settings()
 			ImGui::PopStyleVar();
 			ImGui::EndTabItem();
 
+			#ifdef USE_LUA
 			header("Lua Scripting");
-			// Begin Lua File Override
 			{
 				OptionCheckbox("Override Default Lua File", config::OverrideLuaFile);
 				ImGui::SameLine();
@@ -1975,7 +1975,7 @@ static void gui_display_settings()
 
 				}
 			}
-			// End Lua File Override
+			#endif
 		}
 		if (ImGui::BeginTabItem("About"))
 		{

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1960,20 +1960,14 @@ static void gui_display_settings()
 			#ifdef USE_LUA
 			header("Lua Scripting");
 			{
-				OptionCheckbox("Override Default Lua File", config::OverrideLuaFile);
+				char LuaFileName[256];
+
+				strcpy(LuaFileName, config::LuaFileName.get().c_str());
+				ImGui::InputText("Lua Filename", LuaFileName, sizeof(LuaFileName), ImGuiInputTextFlags_CharsNoBlank, nullptr, nullptr);
 				ImGui::SameLine();
-				ShowHelpMarker("Override flycast's default lua file (flycast.lua). This file should be in Flycast's root directory");
-				if(config::OverrideLuaFile)
-				{
-					char LuaFileName[256];
+				ShowHelpMarker("Specify lua filename to use. Should be located in Flycasts root directory. Defaults to flycast.lua when empty.");
+				config::LuaFileName = LuaFileName;
 
-					strcpy(LuaFileName, config::LuaFileName.get().c_str());
-					ImGui::InputText("Lua Filename", LuaFileName, sizeof(LuaFileName), ImGuiInputTextFlags_CharsNoBlank, nullptr, nullptr);
-					ImGui::SameLine();
-					ShowHelpMarker("Specify lua filename to use. Should be located in Flycasts root directory.");
-					config::LuaFileName = LuaFileName;
-
-				}
 			}
 			#endif
 		}


### PR DESCRIPTION
Allows users to select a lua file by name. 

I think that the override option is not necessary / tedious UX but 
a) did not want to let users hang themselves by accident 
b) did not want to step on toes if you intended flycast.lua to work in some particular way I had not anticipated.

Let me know if I should:
1) Remove override
2) Just set the config variables default to "flycast.lua"
3) change lua.cpp to just look for the config option instead. 