### PR TITLE
Fix linux breakpad issues when glibc-2.34 is installed

### DIFF
--- a/core/deps/breakpad/src/client/linux/handler/exception_handler.cc
+++ b/core/deps/breakpad/src/client/linux/handler/exception_handler.cc
@@ -138,7 +138,7 @@ void InstallAlternateStackLocked() {
   // SIGSTKSZ may be too small to prevent the signal handlers from overrunning
   // the alternative stack. Ensure that the size of the alternative stack is
   // large enough.
-  static const unsigned kSigStackSize = std::max(16384, SIGSTKSZ);
+  static const unsigned kSigStackSize = std::max<size_t>(16384, SIGSTKSZ);
 
   // Only set an alternative stack if there isn't already one, or if the current
   // one is too small.


### PR DESCRIPTION
As outlined by Samuli Piippo in the qtwebengine chromium patch (https://codereview.qt-project.org/c/yocto/meta-qt6/+/378728/2/recipes-qt/qt6/qtwebengine/chromium/0004-breakpad-fix-build-with-glibc-2.34.patch), SIGSTCKZ is no longer being compile time constant in glibc-2.34. The proposed fix compiles on my end and I have not tested on a linux distro with an earlier version of glibc.