### PR TITLE
Make Flycast debug friendly with Xcode

### DIFF
--- a/shell/apple/emulator-ios/LLDBInitFile
+++ b/shell/apple/emulator-ios/LLDBInitFile
@@ -1,0 +1,1 @@
+br set -r "UIApplication _run" -C "process handle -s false SIGBUS" -G true

--- a/shell/apple/emulator-ios/emulator/ios_main.mm
+++ b/shell/apple/emulator-ios/emulator/ios_main.mm
@@ -20,6 +20,8 @@
 #import <Foundation/Foundation.h>
 
 #include <string>
+#include <mach/task.h>
+#include <mach/mach_init.h>
 
 int darw_printf(const char* text,...)
 {
@@ -42,6 +44,10 @@ void os_SetWindowText(const char* t) {
 }
 
 void os_CreateWindow() {
+    if (getppid() != 1) {
+        /* Make LLDB ignore EXC_BAD_ACCESS for debugging */
+        task_set_exception_ports(mach_task_self(), EXC_MASK_BAD_ACCESS, MACH_PORT_NULL, EXCEPTION_DEFAULT, 0);
+    }
 }
 
 void UpdateInputState() {

--- a/shell/apple/emulator-osx/LLDBInitFile
+++ b/shell/apple/emulator-osx/LLDBInitFile
@@ -1,0 +1,1 @@
+br set -r "NSApplication run" -C "process handle -s false SIGBUS" -G true

--- a/shell/apple/emulator-osx/emulator-osx/SDLMain.mm
+++ b/shell/apple/emulator-osx/emulator-osx/SDLMain.mm
@@ -449,6 +449,11 @@ int main (int argc, char **argv)
         gFinderLaunch = NO;
     }
     
+    if (getppid() != 1) {
+        /* Make LLDB ignore EXC_BAD_ACCESS for debugging */
+        task_set_exception_ports(mach_task_self(), EXC_MASK_BAD_ACCESS, MACH_PORT_NULL, EXCEPTION_DEFAULT, 0);
+    }
+    
 #if SDL_USE_NIB_FILE
     NSApplicationMain (argc, argv);
 #else

--- a/shell/apple/generate_xcode_project.command
+++ b/shell/apple/generate_xcode_project.command
@@ -1,0 +1,27 @@
+script_dir=$(dirname "$0")
+cd $script_dir/../../
+
+echo "1) macOS ($(uname -m))"
+echo "2) iOS"
+read -p "Choose your target platform: " x
+
+if [ $x -eq 2 ]; then
+    option="-DCMAKE_SYSTEM_NAME=iOS"
+    lldbinitfolder="emulator-ios"
+    echo 'Building iOS xcodeproj for debugging'
+    echo 'Remove CODE_SIGNING_ALLOWED=NO in Build Settings if you are using your Apple Developer Certificate for signing'
+else
+    option="-DCMAKE_OSX_ARCHITECTURES=$(uname -m)"
+    lldbinitfolder="emulator-osx"
+    echo 'Building macOS xcodeproj for debugging'
+fi
+
+if [[ -z "${VULKAN_SDK}" ]]; then
+    echo 'Warning: VULKAN_SDK is not set in environment variable'
+fi
+
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=artifact -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=artifact $option -DCMAKE_XCODE_GENERATE_SCHEME=YES -G "Xcode"
+
+nl=$'\n'
+sed -i '' -E "s/launchStyle/customLLDBInitFile = \"\$(SRCROOT)\/shell\/apple\/\\${lldbinitfolder}\/LLDBInitFile\"\\${nl}launchStyle/g" build/flycast.xcodeproj/xcshareddata/xcschemes/flycast.xcscheme
+open build/flycast.xcodeproj


### PR DESCRIPTION
add `task_set_exception_ports()` to ignore `EXC_BAD_ACCESS`
add `process handle -s false SIGBUS` into lldbinit to ignore `SIGBUS`

add `generate_xcode_project.command` to create debug friendly macOS/iOS xcodeproj with the new lldbinit file

Tested on Intel macOS 10.15, Apple Silicon macOS 11, iOS 14.2

![image](https://user-images.githubusercontent.com/602245/144496484-8c1afe56-be8e-496e-b0c4-4b2d86baf724.png)
