### PR TITLE
(libretro) Move audio batch callback onto main thread + improve audio sample pacing

### DIFF
--- a/shell/libretro/audiostream.cpp
+++ b/shell/libretro/audiostream.cpp
@@ -21,24 +21,124 @@
 
 #include <libretro.h>
 
-#define SAMPLE_COUNT 512
-struct SoundFrame { s16 l; s16 r; };
+#include <vector>
+#include <mutex>
+
+#define AUDIO_BUFFER_SIZE_DEFAULT (1 << 11)
+#define AUDIO_BUFFER_SIZE_MAX (1 << 20) /* 1 MiB */
 
 extern retro_audio_sample_batch_t audio_batch_cb;
 
+static std::mutex audio_buffer_mutex;
+static std::vector<int16_t> audio_buffer;
+static size_t audio_buffer_idx;
+static size_t audio_batch_frames_max;
+
+static int16_t *audio_out_buffer = nullptr;
+static size_t audio_out_buffer_size;
+
+void retro_audio_init(void)
+{
+	const std::lock_guard<std::mutex> lock(audio_buffer_mutex);
+
+	audio_buffer.resize(AUDIO_BUFFER_SIZE_DEFAULT);
+	audio_buffer_idx = 0;
+	audio_batch_frames_max = std::numeric_limits<size_t>::max();
+
+	audio_out_buffer_size = AUDIO_BUFFER_SIZE_DEFAULT;
+	audio_out_buffer = (int16_t*)malloc(audio_out_buffer_size * sizeof(int16_t));
+}
+
+void retro_audio_deinit(void)
+{
+	const std::lock_guard<std::mutex> lock(audio_buffer_mutex);
+
+	audio_buffer.clear();
+	audio_buffer_idx = 0;
+
+	if (audio_out_buffer != nullptr)
+		free(audio_out_buffer);
+
+	audio_out_buffer = nullptr;
+	audio_out_buffer_size = 0;
+}
+
+void retro_audio_flush_buffer(void)
+{
+	const std::lock_guard<std::mutex> lock(audio_buffer_mutex);
+	audio_buffer_idx = 0;
+}
+
+void retro_audio_upload(void)
+{
+	audio_buffer_mutex.lock();
+
+	if (audio_out_buffer_size < audio_buffer_idx)
+	{
+		int16_t *tmp = (int16_t *)realloc(audio_out_buffer,
+				audio_buffer_idx * sizeof(int16_t));
+
+		if (!tmp)
+		{
+			audio_buffer_idx = 0;
+			audio_buffer_mutex.unlock();
+			return;
+		}
+
+		audio_out_buffer_size = audio_buffer_idx;
+		audio_out_buffer = tmp;
+	}
+
+	for (size_t i = 0; i < audio_buffer_idx; i++)
+		audio_out_buffer[i] = audio_buffer[i];
+
+	size_t num_frames = audio_buffer_idx >> 1;
+	audio_buffer_idx = 0;
+
+	audio_buffer_mutex.unlock();
+
+	int16_t *audio_out_buffer_ptr = audio_out_buffer;
+	while (num_frames > 0)
+	{
+		size_t frames_to_write = (num_frames > audio_batch_frames_max) ?
+				audio_batch_frames_max : num_frames;
+		size_t frames_written = audio_batch_cb(audio_out_buffer_ptr,
+				frames_to_write);
+
+		if ((frames_written < frames_to_write) &&
+			 (frames_written > 0))
+			audio_batch_frames_max = frames_written;
+
+		num_frames -= frames_to_write;
+		audio_out_buffer_ptr += frames_to_write << 1;
+	}
+}
+
 void WriteSample(s16 r, s16 l)
 {
-   static SoundFrame Buffer[SAMPLE_COUNT];
-   static u32 writePtr; // next sample index
-   Buffer[writePtr].r = r;
-   Buffer[writePtr].l = l;
+	const std::lock_guard<std::mutex> lock(audio_buffer_mutex);
 
-   if (++writePtr == SAMPLE_COUNT)
-   {
-      if (dc_is_running() && (!config::ThreadedRendering || config::LimitFPS))
-         audio_batch_cb((const int16_t*)Buffer, SAMPLE_COUNT);
-      writePtr = 0;
-   }
+	if (audio_buffer.size() < audio_buffer_idx + 2)
+	{
+		if (audio_buffer_idx + 2 > AUDIO_BUFFER_SIZE_MAX)
+		{
+			audio_buffer_idx = 0;
+			return;
+		}
+
+		try
+		{
+			audio_buffer.resize(audio_buffer_idx + 2 + AUDIO_BUFFER_SIZE_DEFAULT);
+		}
+		catch (std::bad_alloc &)
+		{
+			audio_buffer_idx = 0;
+			return;
+		}
+	}
+
+	audio_buffer[audio_buffer_idx++] = l;
+	audio_buffer[audio_buffer_idx++] = r;
 }
 
 void InitAudio()


### PR DESCRIPTION
At present, the libretro core has two issues related to the usage of the audio batch callback:

- When threaded rendering is enabled, the audio batch callback is used on a background thread. The libretro API does not guarantee the safety of this callback unless it is used on the main thread
- Audio samples are sent in batches of 256 frames, whereas the frontend expects exactly `(sample_rate/fps)` sample frames per call of `retro_run()`. This means that in each `retro_run()` interval, a smaller or greater number of samples are sent than are expected. The way that RetroArch syncs on audio means that uneven audio sample pacing affects video frame pacing - and in general, irregular audio pacing 'stresses' the frontend audio buffer

This PR moves the audio batch callback onto the main thread via an intermediary buffer. It also ensures that all the audio sample frames generated since the last iteration of `retro_run()` are uploaded to the frontend on the current iteration - improving synchronisation. I do not see any observable performance impact from these changes on my (very) low spec dev PC.

Finally, with the audio batch callback on the main thread, the `RETRO_ENVIRONMENT_GET_CLEAR_ALL_THREAD_WAITS_CB` hack is no longer required - and so it has been removed.