### PR TITLE
ci: fix ccache cache key

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -51,16 +51,16 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: /tmp/ccache
-          key: ccache-${{ matrix.config.os }}-${{ github.sha }}
-          restore-keys: ccache-${{ matrix.config.os }}-
+          key: ccache-${{ matrix.config.name }}-${{ github.sha }}
+          restore-keys: ccache-${{ matrix.config.name }}-
         if: matrix.config.os != 'windows-latest'
 
       - uses: actions/cache@v2
         id: cache
         with:
           path: $HOME/ccache
-          key: ccache-${{ matrix.config.os }}-${{ github.sha }}
-          restore-keys: ccache-${{ matrix.config.os }}-
+          key: ccache-${{ matrix.config.name }}-${{ github.sha }}
+          restore-keys: ccache-${{ matrix.config.name }}-
         if: matrix.config.os == 'windows-latest'
 
       - name: Download DX2010


### PR DESCRIPTION
Each ci build will now have its own cache. Should fix the following issue when two jobs share the same cache key

![image](https://user-images.githubusercontent.com/25406440/146670160-531d84e9-eeb4-4bbb-8e3a-e712598f5c75.png)
