### PR TITLE
Fix missing `libSDL2.a` static library on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,7 @@ if(NOT LIBRETRO)
 			set(SDL2_FOUND 1)
 		endif()
 
-		if(TARGET SDL2::SDL2-static)
+		if((APPLE OR WIN32) AND TARGET SDL2::SDL2-static)
 			target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2-static)
 		elseif(TARGET SDL2::SDL2)
 			target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2)


### PR DESCRIPTION
Change introduced in https://github.com/flyinghead/flycast/commit/73fa0e3efcb27220db976f4becf1679ec8639352

This makes [recent Flatpak builds to fail](https://github.com/flathub/org.flycast.Flycast/commits/master):
`ninja: error: '/usr/lib/x86_64-linux-gnu/libSDL2.a', needed by 'build/flycast', missing and no known rule to make it`

This change won't impact macOS nor Win32.

---

I have tested locally to build the Flatpak, it works. However, I don't know the state of static Flycast binaries for Linux, and this recent commits were not about that anyway.