### PR TITLE
postprocess: fix GLES2-only build

### DIFF
--- a/core/rend/gles/postprocess.cpp
+++ b/core/rend/gles/postprocess.cpp
@@ -332,5 +332,7 @@ void PostProcessor::render(GLuint output_fbo)
 	glcache.ClearColor(0.f, 0.f, 0.f, 0.f);
 	glClear(GL_COLOR_BUFFER_BIT);
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+#ifndef GLES2
 	glBindVertexArray(0);
+#endif
 }


### PR DESCRIPTION
Added a missing `ifndef` guard for `glBindVertexArray`, useful for GLES2-only builds.

Similar guards exists in the same source file (`postprocess.cpp`), this one probably slipped. 