### PR TITLE
deps/picotcp: pico_ipv6_source_dev_find requires PICO_SUPPORT_IPV6

### DIFF
--- a/core/deps/picotcp/stack/pico_socket.c
+++ b/core/deps/picotcp/stack/pico_socket.c
@@ -1090,11 +1090,11 @@ static int pico_socket_xmit_one(struct pico_socket *s, const void *buf, const in
 #ifdef PICO_SUPPORT_IPV6
     else if (IS_SOCK_IPV6(s) && ep && pico_ipv6_is_multicast(&ep->remote_addr.ip6.addr[0])) {
         dev = pico_ipv6_link_find(src);
+    } else if (IS_SOCK_IPV6(s) && ep) {
+        dev = pico_ipv6_source_dev_find(s->stack, &ep->remote_addr.ip6);
     }
 #endif
-    else if (IS_SOCK_IPV6(s) && ep) {
-        dev = pico_ipv6_source_dev_find(&ep->remote_addr.ip6);
-    } else if (IS_SOCK_IPV4(s) && ep) {
+    else if (IS_SOCK_IPV4(s) && ep) {
         dev = pico_ipv4_source_dev_find(&ep->remote_addr.ip4);
     } else {
         dev = get_sock_dev(s);


### PR DESCRIPTION
Backport https://github.com/virtualsquare/picotcp/commit/529074aab4f53a87426673548d6793ced666b6ed

Fix the following MSVC debug build issue:
```
pico_socket.c.obj : error LNK2019: unresolved external symbol pico_ipv6_source_dev_find referenced in function pico_socket_xmit_one
```