### PR TITLE
ci: use windows-latest

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -10,14 +10,14 @@ jobs:
     strategy:
       matrix:
         config:
-          - {name: i686-pc-windows-msvc, os: windows-2019, cmakeArgs: -DCMAKE_SYSTEM_VERSION="10.0.18362.0" -G "Visual Studio 16 2019" -A Win32 -DVCPKG_TARGET_TRIPLET=x86-windows-static, buildType: Release}
+          - {name: i686-pc-windows-msvc, os: windows-latest, cmakeArgs: -G "Visual Studio 17 2022" -A Win32 -DVCPKG_TARGET_TRIPLET=x86-windows-static, buildType: Release}
           - {name: apple-darwin, os: macos-latest, cmakeArgs: -G "Xcode", destDir: osx, buildType: Release}
           - {name: apple-ios, os: macos-latest, cmakeArgs: -DCMAKE_SYSTEM_NAME=iOS -G "Xcode", destDir: ios, buildType: Release}
           - {name: x86_64-pc-linux-gnu, os: ubuntu-latest, buildType: Release}
-          - {name: x86_64-pc-windows-msvc, os: windows-2019, cmakeArgs: -DCMAKE_SYSTEM_VERSION="10.0.18362.0" -G "Visual Studio 16 2019" -A x64 -DVCPKG_TARGET_TRIPLET=x64-windows-static, buildType: Release}
-          - {name: x86_64-w64-mingw32, os: windows-2019, cmakeArgs: -G "MinGW Makefiles", destDir: win, buildType: RelWithDebInfo}
+          - {name: x86_64-pc-windows-msvc, os: windows-latest, cmakeArgs: -G "Visual Studio 17 2022" -A x64 -DVCPKG_TARGET_TRIPLET=x64-windows-static, buildType: Release}
+          - {name: x86_64-w64-mingw32, os: windows-latest, cmakeArgs: -G "MinGW Makefiles", destDir: win, buildType: RelWithDebInfo}
           - {name: libretro-x86_64-pc-linux-gnu, os: ubuntu-latest, cmakeArgs: -DLIBRETRO=ON -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE, buildType: Release}
-          - {name: libretro-x86_64-w64-mingw32, os: windows-2019, cmakeArgs: -DLIBRETRO=ON -G "MinGW Makefiles", buildType: Release}
+          - {name: libretro-x86_64-w64-mingw32, os: windows-latest, cmakeArgs: -DLIBRETRO=ON -G "MinGW Makefiles", buildType: Release}
 
     env:
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
@@ -44,16 +44,16 @@ jobs:
           echo "CCACHE_DIR=/tmp/ccache" >> $GITHUB_ENV
         if: matrix.config.os == 'ubuntu-latest'
 
-      - name: Set up build environment (windows-2019)
+      - name: Set up build environment (windows-latest)
         run: echo "DXSDK_DIR=${Env:HOMEDRIVE}${Env:HOMEPATH}\ccache\" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-        if: matrix.config.os == 'windows-2019' && matrix.config.name != 'libretro-x86_64-w64-mingw32'
+        if: matrix.config.os == 'windows-latest' && matrix.config.name != 'libretro-x86_64-w64-mingw32'
 
       - uses: actions/cache@v2
         with:
           path: /tmp/ccache
           key: ccache-${{ matrix.config.name }}-${{ github.sha }}
           restore-keys: ccache-${{ matrix.config.name }}-
-        if: matrix.config.os != 'windows-2019'
+        if: matrix.config.os != 'windows-latest'
 
       - uses: actions/cache@v2
         id: cache
@@ -61,10 +61,10 @@ jobs:
           path: $HOME/ccache
           key: ccache-${{ matrix.config.name }}-${{ github.sha }}
           restore-keys: ccache-${{ matrix.config.name }}-
-        if: matrix.config.os == 'windows-2019'
+        if: matrix.config.os == 'windows-latest'
 
       - name: Download DX2010
-        if: matrix.config.os == 'windows-2019' && matrix.config.name != 'libretro-x86_64-w64-mingw32'
+        if: matrix.config.os == 'windows-latest' && matrix.config.name != 'libretro-x86_64-w64-mingw32'
         run:   |
                curl -L https://download.microsoft.com/download/a/e/7/ae743f1f-632b-4809-87a9-aa1bb3458e31/DXSDK_Jun10.exe -o _DX2010_.exe
                7z x _DX2010_.exe DXSDK/Include -o_DX2010_

--- a/.github/workflows/uwp.yml
+++ b/.github/workflows/uwp.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     env:
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
@@ -30,7 +30,7 @@ jobs:
 
       - name: CMake
         run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=Release  -G "Visual Studio 16 2019" -A x64 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0" -DCMAKE_SYSTEM_PROCESSOR=AMD64 -DCMAKE_CROSSCOMPILING=OFF -DUSE_VULKAN=OFF -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake
+          cmake -B build -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 17 2022" -A x64 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_SYSTEM_PROCESSOR=AMD64 -DCMAKE_CROSSCOMPILING=OFF -DUSE_VULKAN=OFF -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake
           cmake --build build --config Release --parallel 2
         shell: cmd
 


### PR DESCRIPTION
windows-latest workflows now use Windows Server 2022, migration is done according to https://github.com/actions/virtual-environments/issues/4856