### PR TITLE
Add 6×, 7×, 8× and 9× options for internal resolution

### DIFF
--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1710,8 +1710,8 @@ static void gui_display_settings()
 					ImGui::Columns(1, nullptr, false);
 		    	}
 
-	            const std::array<float, 9> scalings{ 0.5f, 1.f, 1.5f, 2.f, 2.5f, 3.f, 4.f, 4.5f, 5.f };
-	            const std::array<std::string, 9> scalingsText{ "Half", "Native", "x1.5", "x2", "x2.5", "x3", "x4", "x4.5", "x5" };
+	            const std::array<float, 13> scalings{ 0.5f, 1.f, 1.5f, 2.f, 2.5f, 3.f, 4.f, 4.5f, 5.f, 6.f, 7.f, 8.f, 9.f };
+	            const std::array<std::string, 13> scalingsText{ "Half", "Native", "x1.5", "x2", "x2.5", "x3", "x4", "x4.5", "x5", "x6", "x7", "x8", "x9" };
 	            std::array<int, scalings.size()> vres;
 	            std::array<std::string, scalings.size()> resLabels;
 	            u32 selected = 0;
@@ -1760,7 +1760,7 @@ static void gui_display_settings()
                 
                 ImGui::Text("Internal Resolution");
                 ImGui::SameLine();
-                ShowHelpMarker("Internal render resolution. Higher is better but more demanding");
+                ShowHelpMarker("Internal render resolution. Higher is better, but more demanding on the GPU. Values higher than your display resolution (but no more than double your display resolution) can be used for supersampling, which provides high-quality antialiasing without reducing sharpness.");
 
 		    	OptionSlider("Horizontal Stretching", config::ScreenStretching, 100, 150,
 		    			"Stretch the screen horizontally");


### PR DESCRIPTION
This can be used to get a smoother image (supersampling) on 1440p and 4K displays. The 9× setting is also suited for native resolution rendering on 8K displays, or 4× supersampling on 4K.

The setting description was also made more extensive:

![2022-03-31_22 55 23](https://user-images.githubusercontent.com/180032/161148201-9a2e613a-5993-4acc-b1a0-39c6ab26ce19.png)

*Supersampling above 4× is not effective because the viewport does not have mipmaps to work with. Generating mipmaps for high-quality real-time downsampling is too slow to be worth considering, since 4× supersampling is very expensive already. If further antialiasing is desired, MSAA or FXAA could be implemented and could be used on top of supersampling.*

I tested this change locally and it works as expected on a 2560×1440 monitor:

### 4× (native resolution for 2560×1440)

*Click to view at full size (and click again to show at pixel-perfect scale in the browser). Look at the controller buttons in the top-left corner.*

![2022-03-31_22 51 18](https://user-images.githubusercontent.com/180032/161148187-f7ef62fa-e1f4-4316-9f4c-99367f66a902.png)

### 5× (previous maximum)

![2022-03-31_22 51 36](https://user-images.githubusercontent.com/180032/161148195-32eb2543-9824-423c-b56c-3dbe4ff25037.png)

### 6× (ideal value for supersampling on 2560×1440, as it's internally 5120×2880)

![2022-03-31_22 51 47](https://user-images.githubusercontent.com/180032/161148197-57f20439-a03d-4ba5-9625-44ccd26bf667.png)