### PR TITLE
Add texture filter override setting, expose anisotropic filtering

### DIFF
--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -95,6 +95,7 @@ Option<int> RenderResolution("rend.Resolution", 480);
 Option<bool> VSync("rend.vsync", true);
 Option<u64> PixelBufferSize("rend.PixelBufferSize", 512 * 1024 * 1024);
 Option<int> AnisotropicFiltering("rend.AnisotropicFiltering", 1);
+Option<int> TextureFiltering("rend.TextureFiltering", 0); // Default
 Option<bool> ThreadedRendering("rend.ThreadedRendering", true);
 Option<bool> DupeFrames("rend.DupeFrames", false);
 

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -440,6 +440,7 @@ extern Option<int> RenderResolution;
 extern Option<bool> VSync;
 extern Option<u64> PixelBufferSize;
 extern Option<int> AnisotropicFiltering;
+extern Option<int> TextureFiltering; // 0: default, 1: force nearest, 2: force linear
 extern Option<bool> ThreadedRendering;
 extern Option<bool> DupeFrames;
 
@@ -491,7 +492,6 @@ constexpr bool UseRawInput = false;
 
 #ifdef USE_LUA
 extern OptionString LuaFileName;
-#endif 
+#endif
 
 } // namespace config
-

--- a/core/lua/lua.cpp
+++ b/core/lua/lua.cpp
@@ -166,6 +166,7 @@ CONFIG_ACCESSORS(RenderResolution)
 CONFIG_ACCESSORS(VSync)
 CONFIG_ACCESSORS(PixelBufferSize)
 CONFIG_ACCESSORS(AnisotropicFiltering)
+CONFIG_ACCESSORS(TextureFiltering)
 CONFIG_ACCESSORS(ThreadedRendering)
 
 // Audio
@@ -487,6 +488,7 @@ static void luaRegister(lua_State *L)
 					CONFIG_PROPERTY(VSync, bool)
 					CONFIG_PROPERTY(PixelBufferSize, u64)
 					CONFIG_PROPERTY(AnisotropicFiltering, int)
+					CONFIG_PROPERTY(TextureFiltering, int)
 					CONFIG_PROPERTY(ThreadedRendering, bool)
 				.endNamespace()
 
@@ -589,7 +591,7 @@ static std::string getLuaFile()
 
 	return initFile;
 
-} 
+}
 
 static void doExec(const std::string& path)
 {

--- a/core/rend/gles/gldraw.cpp
+++ b/core/rend/gles/gldraw.cpp
@@ -134,7 +134,7 @@ __forceinline
 								  color_clamp,
 								  ShaderUniforms.trilinear_alpha != 1.f,
 								  gpuPalette);
-	
+
 	glcache.UseProgram(CurrentShader->program);
 	if (CurrentShader->trilinear_alpha != -1)
 		glUniform1f(CurrentShader->trilinear_alpha, ShaderUniforms.trilinear_alpha);
@@ -173,37 +173,49 @@ __forceinline
 		SetTextureRepeatMode(GL_TEXTURE_WRAP_S, gp->tsp.ClampU, gp->tsp.FlipU);
 		SetTextureRepeatMode(GL_TEXTURE_WRAP_T, gp->tsp.ClampV, gp->tsp.FlipV);
 
+		bool nearest_filter;
+		if (config::TextureFiltering == 0) {
+			nearest_filter = gp->tsp.FilterMode == 0 || gpuPalette;
+		} else if (config::TextureFiltering == 1) {
+			nearest_filter = true;
+		} else {
+			nearest_filter = false;
+		}
+
+		bool mipmapped = texture->IsMipmapped();
+
 		//set texture filter mode
-		if (gp->tsp.FilterMode == 0 || gpuPalette)
+		if (nearest_filter)
 		{
-			//disable filtering, mipmaps
-			glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+			//nearest-neighbor filtering
+			glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipmapped ? GL_NEAREST_MIPMAP_LINEAR : GL_NEAREST);
 			glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 		}
 		else
 		{
 			//bilinear filtering
 			//PowerVR supports also trilinear via two passes, but we ignore that for now
-			bool mipmapped = texture->IsMipmapped();
 			glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipmapped ? GL_LINEAR_MIPMAP_NEAREST : GL_LINEAR);
 			glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		}
+
 #ifdef GL_TEXTURE_LOD_BIAS
-			if (!gl.is_gles && gl.gl_major >= 3 && mipmapped)
-				glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, D_Adjust_LoD_Bias[gp->tsp.MipMapD]);
+		if (!gl.is_gles && gl.gl_major >= 3 && mipmapped)
+			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, D_Adjust_LoD_Bias[gp->tsp.MipMapD]);
 #endif
-			if (gl.max_anisotropy > 1.f)
+
+		if (gl.max_anisotropy > 1.f)
+		{
+			if (config::AnisotropicFiltering > 1)
 			{
-				if (config::AnisotropicFiltering > 1)
-				{
-					glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY,
-							std::min<float>(config::AnisotropicFiltering, gl.max_anisotropy));
-					// Set the recommended minification filter for best results
-					if (mipmapped)
-						glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-				}
-				else
-					glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY, 1.f);
+				glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY,
+						std::min<float>(config::AnisotropicFiltering, gl.max_anisotropy));
+				// Set the recommended minification filter for best results
+				if (mipmapped)
+					glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
 			}
+			else
+				glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY, 1.f);
 		}
 	}
 
@@ -302,7 +314,7 @@ void DrawSorted(bool multipass)
 	if (!pidx_sort.empty())
 	{
 		u32 count=pidx_sort.size();
-		
+
 		{
 			//set some 'global' modes for all primitives
 
@@ -318,7 +330,7 @@ void DrawSorted(bool multipass)
 					SetGPState<ListType_Translucent,true>(params);
 					glDrawElements(GL_TRIANGLES, pidx_sort[p].count, gl.index_type,
 							(GLvoid*)(gl.get_index_size() * pidx_sort[p].first)); glCheck();
-				
+
 #if 0
 					//Verify restriping -- only valid if no sort
 					int fs=pidx_sort[p].first;
@@ -439,12 +451,12 @@ void SetMVS_Mode(ModifierVolumeMode mv_mode, ISP_Modvol ispc)
 		if (mv_mode == Inclusion)
 		{
 			// Inclusion volume
-			//res : old : final 
+			//res : old : final
 			//0   : 0      : 00
 			//0   : 1      : 01
 			//1   : 0      : 01
 			//1   : 1      : 01
-			
+
 			// if (1<=st) st=1; else st=0;
 			glcache.StencilFunc(GL_LEQUAL,1,3);
 			glcache.StencilOp(GL_ZERO, GL_ZERO, GL_REPLACE);
@@ -457,7 +469,7 @@ void SetMVS_Mode(ModifierVolumeMode mv_mode, ISP_Modvol ispc)
 				(actually, i think there was also another, racing game)
 			*/
 			// The initial value for exclusion volumes is 1 so we need to invert the result before and'ing.
-			//res : old : final 
+			//res : old : final
 			//0   : 0   : 00
 			//0   : 1   : 01
 			//1   : 0   : 00

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -212,10 +212,10 @@ void gui_init()
     }
 #elif defined(__APPLE__) && !defined(TARGET_IPHONE)
     std::string fontDir = std::string("/System/Library/Fonts/");
-    
+
     extern std::string os_Locale();
     std::string locale = os_Locale();
-    
+
     if (locale.find("ja") == 0)             // Japanese
     {
         io.Fonts->AddFontFromFileTTF((fontDir + "ヒラギノ角ゴシック W4.ttc").c_str(), 17.f * scaling, &font_cfg, io.Fonts->GetGlyphRangesJapanese());
@@ -1170,7 +1170,7 @@ static void contentpath_warning_popup()
                 ImGui::CloseCurrentPopup();
                 show_contentpath_selection = true;
             }
-            
+
             ImGui::SameLine();
             ImGui::SetCursorPosX((currentwidth - 100.f * scaling) / 2.f + ImGui::GetStyle().WindowPadding.x + 55.f * scaling);
             if (ImGui::Button("Cancel", ImVec2(100.f * scaling, 0.f)))
@@ -1651,6 +1651,60 @@ static void gui_display_settings()
 		    	}
 		    	OptionCheckbox("Widescreen Game Cheats", config::WidescreenGameHacks,
 		    			"Modify the game so that it displays in 16:9 anamorphic format and use horizontal screen stretching. Only some games are supported.");
+
+				const std::array<float, 5> aniso{ 1, 2, 4, 8, 16 };
+	            const std::array<std::string, 5> anisoText{ "Disabled", "2x", "4x", "8x", "16x" };
+	            u32 afSelected = 0;
+	            for (u32 i = 0; i < aniso.size(); i++)
+	            {
+	            	if (aniso[i] == config::AnisotropicFiltering)
+	            		afSelected = i;
+	            }
+
+                ImGuiStyle& style = ImGui::GetStyle();
+                float innerSpacing = style.ItemInnerSpacing.x;
+                ImGui::PushItemWidth(ImGui::CalcItemWidth() - innerSpacing * 2.0f - ImGui::GetFrameHeight() * 2.0f);
+                if (ImGui::BeginCombo("##Anisotropic Filtering", anisoText[afSelected].c_str(), ImGuiComboFlags_NoArrowButton))
+                {
+                	for (u32 i = 0; i < aniso.size(); i++)
+                    {
+                        bool is_selected = aniso[i] == config::AnisotropicFiltering;
+                        if (ImGui::Selectable(anisoText[i].c_str(), is_selected))
+                        	config::AnisotropicFiltering = aniso[i];
+                        if (is_selected)
+                            ImGui::SetItemDefaultFocus();
+                    }
+                    ImGui::EndCombo();
+                }
+                ImGui::PopItemWidth();
+                ImGui::SameLine(0, innerSpacing);
+
+                if (ImGui::ArrowButton("##Decrease Anisotropic Filtering", ImGuiDir_Left))
+                {
+                    if (afSelected > 0)
+                    	config::AnisotropicFiltering = aniso[afSelected - 1];
+                }
+                ImGui::SameLine(0, innerSpacing);
+                if (ImGui::ArrowButton("##Increase Anisotropic Filtering", ImGuiDir_Right))
+                {
+                    if (afSelected < aniso.size() - 1)
+                    	config::AnisotropicFiltering = aniso[afSelected + 1];
+                }
+                ImGui::SameLine(0, style.ItemInnerSpacing.x);
+
+                ImGui::Text("Anisotropic Filtering");
+                ImGui::SameLine();
+                ShowHelpMarker("Higher values make textures viewed at oblique angles look sharper, but are more demanding on the GPU. This option only has a visible impact on mipmapped textures.");
+
+		    	ImGui::Text("Texture Filtering:");
+		    	ImGui::Columns(3, "textureFiltering", false);
+		    	OptionRadioButton("Default", config::TextureFiltering, 0, "Use the game's default texture filtering");
+            	ImGui::NextColumn();
+		    	OptionRadioButton("Force Nearest-Neighbor", config::TextureFiltering, 1, "Force nearest-neighbor filtering for all textures. Crisper appearance, but may cause various rendering issues. This option usually does not affect performance.");
+            	ImGui::NextColumn();
+		    	OptionRadioButton("Force Linear", config::TextureFiltering, 2, "Force linear filtering for all textures. Smoother appearance, but may cause various rendering issues. This option usually does not affect performance.");
+		    	ImGui::Columns(1, nullptr, false);
+
 #ifndef TARGET_IPHONE
 		    	OptionCheckbox("VSync", config::VSync, "Synchronizes the frame rate with the screen refresh rate. Recommended");
 		    	ImGui::Indent();
@@ -1727,8 +1781,6 @@ static void gui_display_settings()
 	            	resLabels[i] += " (" + scalingsText[i] + ")";
 	            }
 
-                ImGuiStyle& style = ImGui::GetStyle();
-                float innerSpacing = style.ItemInnerSpacing.x;
                 ImGui::PushItemWidth(ImGui::CalcItemWidth() - innerSpacing * 2.0f - ImGui::GetFrameHeight() * 2.0f);
                 if (ImGui::BeginCombo("##Resolution", resLabels[selected].c_str(), ImGuiComboFlags_NoArrowButton))
                 {
@@ -1744,7 +1796,7 @@ static void gui_display_settings()
                 }
                 ImGui::PopItemWidth();
                 ImGui::SameLine(0, innerSpacing);
-                
+
                 if (ImGui::ArrowButton("##Decrease Res", ImGuiDir_Left))
                 {
                     if (selected > 0)
@@ -1757,7 +1809,7 @@ static void gui_display_settings()
                     	config::RenderResolution = vres[selected + 1];
                 }
                 ImGui::SameLine(0, style.ItemInnerSpacing.x);
-                
+
                 ImGui::Text("Internal Resolution");
                 ImGui::SameLine();
                 ShowHelpMarker("Internal render resolution. Higher is better but more demanding");

--- a/core/rend/vulkan/texture.h
+++ b/core/rend/vulkan/texture.h
@@ -84,14 +84,20 @@ public:
 		const auto& it = samplers.find(samplerHash);
 		if (it != samplers.end())
 			return it->second.get();
-		vk::Filter filter = tsp.FilterMode == 0 ? vk::Filter::eNearest : vk::Filter::eLinear;
+		vk::Filter filter;
+		if (config::TextureFiltering == 0) {
+			filter = tsp.FilterMode == 0 ? vk::Filter::eNearest : vk::Filter::eLinear;
+		} else if (config::TextureFiltering == 1) {
+			filter = vk::Filter::eNearest;
+		} else {
+			filter = vk::Filter::eLinear;
+		}
 		vk::SamplerAddressMode uRepeat = tsp.ClampU ? vk::SamplerAddressMode::eClampToEdge
 				: tsp.FlipU ? vk::SamplerAddressMode::eMirroredRepeat : vk::SamplerAddressMode::eRepeat;
 		vk::SamplerAddressMode vRepeat = tsp.ClampV ? vk::SamplerAddressMode::eClampToEdge
 				: tsp.FlipV ? vk::SamplerAddressMode::eMirroredRepeat : vk::SamplerAddressMode::eRepeat;
 
-		bool anisotropicFiltering = config::AnisotropicFiltering > 1 && VulkanContext::Instance()->SupportsSamplerAnisotropy()
-				&& filter == vk::Filter::eLinear;
+		bool anisotropicFiltering = config::AnisotropicFiltering > 1 && VulkanContext::Instance()->SupportsSamplerAnisotropy();
 #ifndef __APPLE__
 		float mipLodBias = D_Adjust_LoD_Bias[tsp.MipMapD];
 #else

--- a/shell/libretro/libretro_core_options.h
+++ b/shell/libretro/libretro_core_options.h
@@ -400,7 +400,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       CORE_OPTION_NAME "_anisotropic_filtering",
       "Anisotropic Filtering",
       NULL,
-      "Enhance the quality of textures on surfaces that are at oblique viewing angles with respect to the camera.",
+      "Enhance the quality of textures on surfaces that are at oblique viewing angles with respect to the camera. Higher values are more demanding on the GPU. Changes to this setting only apply after restarting.",
       NULL,
       "video",
       {
@@ -412,6 +412,21 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { NULL, NULL },
       },
       "4",
+   },
+   {
+      CORE_OPTION_NAME "_texture_filtering",
+      "Texture Filtering",
+      NULL,
+      "The texture filtering mode to use. This can be used to force a certain texture filtering mode on all textures to get a crisper (or smoother) appearance than Default. Values other than Default may cause various rendering issues. Changes to this setting only apply after restarting.",
+      NULL,
+      "video",
+      {
+         { "0", "Default" },
+         { "1",  "Force Nearest-Neighbor" },
+         { "2",  "Force Linear" },
+         { NULL, NULL },
+      },
+      "0",
    },
    {
       CORE_OPTION_NAME "_delay_frame_swapping",

--- a/shell/libretro/option.cpp
+++ b/shell/libretro/option.cpp
@@ -85,6 +85,7 @@ Option<int> RenderResolution("", 480);
 Option<bool> VSync("", true);
 Option<bool> ThreadedRendering(CORE_OPTION_NAME "_threaded_rendering", true);
 Option<int> AnisotropicFiltering(CORE_OPTION_NAME "_anisotropic_filtering");
+Option<int> TextureFiltering(CORE_OPTION_NAME "_texture_filtering");
 Option<bool> PowerVR2Filter(CORE_OPTION_NAME "_pvr2_filtering");
 Option<u64> PixelBufferSize("", 512 * 1024 * 1024);
 


### PR DESCRIPTION
The new texture filter option can be set to:

- Default (keeps the game's intended filter mode).
- Force Nearest-Neighbor (crisper appearance).
- Force Linear (smoother appearance).

Additionally, mipmapping can now be enabled on nearest neighbor-filtered textures (which is used if nearest-neighbor filtering is enabled, including with anisotropic filtering).

Anisotropic filtering was already implemented in both OpenGL and Vulkan, but it was not exposed in the GUI.

I've only tested this on one game so far. Also, apologies for the relatively large change, but it was easier for me to consolidate both the texture filtering setting and anisotropic filtering changes. I can make two separate PRs if desired.

This closes https://github.com/flyinghead/flycast/issues/563.

## TODO

- Implement on Direct3D. I don't have a Windows development setup around, so I can't test it though. Alternatively, I could hide the texture filtering option on Direct3D until someone else implements it.