### PR TITLE
msvc: fix linking issues in debug build

### DIFF
--- a/core/hw/aica/aica.cpp
+++ b/core/hw/aica/aica.cpp
@@ -233,6 +233,7 @@ void WriteAicaReg(u32 reg, T data)
 
 template void WriteAicaReg<>(u32 reg, u8 data);
 template void WriteAicaReg<>(u32 reg, u16 data);
+template void WriteAicaReg<>(u32 reg, u32 data);
 
 //misc :p
 s32 libAICA_Init()

--- a/core/hw/aica/aica_mem.cpp
+++ b/core/hw/aica/aica_mem.cpp
@@ -64,6 +64,7 @@ T aicaReadReg(u32 addr)
 }
 template u8 aicaReadReg<u8>(u32 addr);
 template u16 aicaReadReg<u16>(u32 addr);
+template u32 aicaReadReg<u32>(u32 addr);
 
 static void writeCommonReg8(u32 reg, u8 data)
 {
@@ -185,6 +186,7 @@ void aicaWriteReg(u32 addr, T data)
 }
 template void aicaWriteReg<>(u32 addr, u8 data);
 template void aicaWriteReg<>(u32 addr, u16 data);
+template void aicaWriteReg<>(u32 addr, u32 data);
 
 void init_mem()
 {


### PR DESCRIPTION
```
aica_if.cpp.obj : error LNK2019: unresolved external symbol "unsigned int __cdecl aicaReadReg<unsigned int>(unsigned int)" (??$aicaReadReg@I@@YAII@Z) referenced in function "unsigned int __cdecl ReadMem_aica_reg<unsigned int>(unsigned int)" (??$ReadMem_aica_reg@I@@YAII@Z)
arm_mem.cpp.obj : error LNK2001: unresolved external symbol "unsigned int __cdecl aicaReadReg<unsigned int>(unsigned int)" (??$aicaReadReg@I@@YAII@Z)
aica_if.cpp.obj : error LNK2019: unresolved external symbol "void __cdecl aicaWriteReg<unsigned int>(unsigned int,unsigned int)" (??$aicaWriteReg@I@@YAXII@Z) referenced in function "void __cdecl WriteMem_aica_reg<unsigned int>(unsigned int,unsigned int)" (??$WriteMem_aica_reg@I@@YAXII@Z)
arm_mem.cpp.obj : error LNK2001: unresolved external symbol "void __cdecl aicaWriteReg<unsigned int>(unsigned int,unsigned int)" (??$aicaWriteReg@I@@YAXII@Z)
```
and also
```
aica_mem.cpp.obj : error LNK2019: unresolved external symbol "void __cdecl WriteAicaReg<unsigned int>(unsigned int,unsigned int)" (??$WriteAicaReg@I@@YAXII@Z) referenced in function "void __cdecl aicaWriteReg<unsigned int>(unsigned int,unsigned int)" (??$aicaWriteReg@I@@YAXII@Z)
```