### PR TITLE
cmake/macos: remove multitouch library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1392,7 +1392,6 @@ if(NOT LIBRETRO)
 			find_library(AUDIO_UNIT_LIBRARY AudioUnit)
 			find_library(FOUNDATION_LIBRARY Foundation)
 			find_library(AUDIO_TOOLBOX_LIBRARY AudioToolbox)
-			find_library(MULTITOUCH_SUPPORT_LIBRARY MultitouchSupport /System/Library/PrivateFrameworks)
 			find_library(OPENGL_LIBRARY OpenGL)
 			find_library(IOSURFACE_LIBRARY IOSurface)
 
@@ -1400,7 +1399,6 @@ if(NOT LIBRETRO)
 				${AUDIO_UNIT_LIBRARY}
 				${FOUNDATION_LIBRARY}
 				${AUDIO_TOOLBOX_LIBRARY}
-				${MULTITOUCH_SUPPORT_LIBRARY}
 				${OPENGL_LIBRARY}
 				${IOSURFACE_LIBRARY})
 


### PR DESCRIPTION
This library has been added in commit 043175ae with multitouch support in osx_keyboard.h. Then, this file has been removed in commit da3ed74c so the multitouch library is no longer required.