### PR TITLE
(libretro) Add option to detect and notifiy frontend of internal frame rate changes (60 <-> 30 <-> 20 fps, etc.)

### DIFF
--- a/shell/libretro/libretro_core_options.h
+++ b/shell/libretro/libretro_core_options.h
@@ -474,6 +474,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled",
    },
    {
+      CORE_OPTION_NAME "_detect_vsync_swap_interval",
+      "Detect Frame Rate Changes",
+      NULL,
+      "Notify frontend when internal frame rate changes (e.g. from 60 fps to 30 fps). Improves frame pacing in games that run at a locked 30 fps or 20 fps, but should be disabled for games with unlocked (unstable) frame rates (e.g. Ecco the Dolphin, Unreal Tournament). Note: Unavailable when 'Auto Skip Frame' is enabled.",
+      NULL,
+      "video",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled",
+   },
+   {
       CORE_OPTION_NAME "_pvr2_filtering",
       "PowerVR2 Post-processing Filter",
       NULL,


### PR DESCRIPTION
This PR adds a new `Detect Frame Rate Changes` option to the libretro core. When enabled, the core will detect frame rate changes that are a factor of the nominal display refresh rate (e.g. 60 <-> 30 <-> 20 fps, etc. for NTSC content) and notify the frontend, such that the frontend can call `retro_run()` with proper timing instead of relying on over-saturation of the audio buffer to control game speed.

When used in conjunction with RetroArch's new automatic `VSync Swap Interval` feature (https://github.com/libretro/RetroArch/pull/13927), this enables **perfect** frame pacing for 30 fps and 20 fps games on a 60 Hz display (and for 30 fps content on a 120 Hz display).

Caveats:

- The `Detect Frame Rate Changes` option is only available when `Auto Skip Frame` is disabled
- Frame rate detection only works for games with locked frame rates. For the few games that run unlocked (e.g. Ecco the Dolphin, Unreal Tournament), the option should be disabled

@flyinghead I am not familiar enough with the codebase to know if there are better methods for detecting the internal frame rate - I though it appropriate to use the same metric that RetroArch itself uses (audio samples), and this seems to work very well for all the locked-frame rate games that I tested.

---

A brief summary for users who want to activate this:

- In RetroArch:
    - Enable `Settings > Video > Synchronization > Vertical Sync (VSync)`
    - Change `Settings > Video > Synchronization > VSync Swap Interval` to `Auto`
- In Flycast:
    - If `Threaded Rendering` is enabled, disable `Auto Skip Frame`
    - Enable `Detect Frame Rate Changes`

(This assumes that a non-VRR display is being used)