### PR TITLE
GGPO Chat Window Timeout

### DIFF
--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -128,6 +128,8 @@ Option<int> GGPODelay("GGPODelay", 0, "network");
 Option<bool> NetworkStats("Stats", true, "network");
 Option<int> GGPOAnalogAxes("GGPOAnalogAxes", 0, "network");
 Option<bool> GGPOChat("GGPOChat", true, "network");
+Option<bool> GGPOChatTimeoutToggle("GGPOChatTimeoutToggle", true, "network");
+Option<int> GGPOChatTimeout("GGPOChatTimeout", 10, "network");
 
 #ifdef SUPPORT_DISPMANX
 Option<bool> DispmanxMaintainAspect("maintain_aspect", true, "dispmanx");

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -486,6 +486,8 @@ extern Option<int> GGPODelay;
 extern Option<bool> NetworkStats;
 extern Option<int> GGPOAnalogAxes;
 extern Option<bool> GGPOChat;
+extern Option<bool> GGPOChatTimeoutToggle;
+extern Option<int> GGPOChatTimeout;
 
 #ifdef SUPPORT_DISPMANX
 extern Option<bool> DispmanxMaintainAspect;

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -2095,6 +2095,19 @@ static void gui_display_settings()
 					OptionRadioButton<int>("Full", config::GGPOAnalogAxes, 2, "Use the left thumbstick horizontal and vertical axes");
 
 					OptionCheckbox("Enable Chat", config::GGPOChat, "Open the chat window when a chat message is received");
+					if (config::GGPOChat)
+					{
+						OptionCheckbox("Enable Chat Window Timeout", config::GGPOChatTimeoutToggle, "Automatically close chat window after 20 seconds");
+						if (config::GGPOChatTimeoutToggle)
+						{
+							char chatTimeout[256];
+							sprintf(chatTimeout, "%d", (int)config::GGPOChatTimeout);
+							ImGui::InputText("Chat Window Timeout (seconds)", chatTimeout, sizeof(chatTimeout), ImGuiInputTextFlags_CharsDecimal, nullptr, nullptr);
+							ImGui::SameLine();
+							ShowHelpMarker("Sets duration that chat window stays open after new message is received.");
+							config::GGPOChatTimeout.set(atoi(chatTimeout));
+						}
+					}
 					OptionCheckbox("Network Statistics", config::NetworkStats,
 			    			"Display network statistics on screen");
 		    	}


### PR DESCRIPTION
Adds auto chat window timeout option. For players using arcade cabinets who are unable to reach keyboard to exit chat window.