### PR TITLE
chat: disable window timeout after you respond to message

### DIFF
--- a/core/rend/gui_chat.h
+++ b/core/rend/gui_chat.h
@@ -109,6 +109,7 @@ public:
 					lines.push_back(std::make_pair(WHITE, line));
 					buf[0] = '\0';
 					newMessage = true;
+					enable_timeout = false;
 				}
 				ImGui::SetKeyboardFocusHere(-1);
 			}
@@ -125,7 +126,7 @@ public:
 
 	void receive(int playerNum, const std::string& msg)
 	{
-		if (config::GGPOChat)
+		if (config::GGPOChat && !visible)
 		{
 			visible = true;
 			toggle_timeout();


### PR DESCRIPTION
* DIsables chat window timeout after you respond to chat message. Prevents it from disappearing during actual conversation.