### PR TITLE
(Libretro) Allow a DX11 only core to be built.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -893,6 +893,8 @@ target_sources(${PROJECT_NAME} PRIVATE
 
 target_sources(${PROJECT_NAME} PRIVATE
         core/wsi/context.h
+        core/wsi/libretro.cpp
+        core/wsi/libretro.h
         core/wsi/switcher.cpp)
 
 if(USE_OPENGL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -904,8 +904,6 @@ if(USE_OPENGL)
 	        core/wsi/egl.h
 	        core/wsi/gl_context.cpp
 	        core/wsi/gl_context.h
-            core/wsi/libretro.cpp
-            core/wsi/libretro.h
 	        core/wsi/osx.cpp
 	        core/wsi/osx.h
 	        core/wsi/sdl.cpp

--- a/core/rend/dx11/dx11context_lr.cpp
+++ b/core/rend/dx11/dx11context_lr.cpp
@@ -23,6 +23,8 @@
 
 DX11Context theDX11Context;
 
+GraphicsContext *GraphicsContext::instance;
+
 bool DX11Context::init(ID3D11Device *device, ID3D11DeviceContext *deviceContext, pD3DCompile D3DCompile, D3D_FEATURE_LEVEL featureLevel)
 {
 	NOTICE_LOG(RENDERER, "DX11 Context initializing");

--- a/core/rend/dx11/dx11context_lr.cpp
+++ b/core/rend/dx11/dx11context_lr.cpp
@@ -23,8 +23,6 @@
 
 DX11Context theDX11Context;
 
-GraphicsContext *GraphicsContext::instance;
-
 bool DX11Context::init(ID3D11Device *device, ID3D11DeviceContext *deviceContext, pD3DCompile D3DCompile, D3D_FEATURE_LEVEL featureLevel)
 {
 	NOTICE_LOG(RENDERER, "DX11 Context initializing");

--- a/core/wsi/libretro.cpp
+++ b/core/wsi/libretro.cpp
@@ -19,7 +19,10 @@
 #include "libretro.h"
 
 #ifdef LIBRETRO
+
+#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
 LibretroGraphicsContext theGLContext;
+#endif
 
 GraphicsContext *GraphicsContext::instance;
 #endif

--- a/core/wsi/libretro.h
+++ b/core/wsi/libretro.h
@@ -17,7 +17,7 @@
     along with Flycast.  If not, see <https://www.gnu.org/licenses/>.
 */
 #pragma once
-#if defined(LIBRETRO) && defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
+#if defined(LIBRETRO) && (defined(HAVE_OPENGL) || defined(HAVE_OPENGLES))
 #include "gl_context.h"
 #include <libretro.h>
 #include <glsm/glsm.h>

--- a/core/wsi/libretro.h
+++ b/core/wsi/libretro.h
@@ -17,7 +17,7 @@
     along with Flycast.  If not, see <https://www.gnu.org/licenses/>.
 */
 #pragma once
-#ifdef LIBRETRO
+#if defined(LIBRETRO) && defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
 #include "gl_context.h"
 #include <libretro.h>
 #include <glsm/glsm.h>

--- a/shell/libretro/libretro.cpp
+++ b/shell/libretro/libretro.cpp
@@ -36,6 +36,7 @@
 
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
 #include <glsm/glsm.h>
+#include "wsi/gl_context.h"
 #endif
 #ifdef HAVE_VULKAN
 #include "rend/vulkan/vulkan_context.h"
@@ -62,7 +63,6 @@
 #include "rend/CustomTexture.h"
 #include "rend/osd.h"
 #include "cfg/option.h"
-#include "wsi/gl_context.h"
 #include "version.h"
 
 constexpr char slash = path_default_slash_c();


### PR DESCRIPTION
Since it's possible to build a Vulkan only core, I figured why not offer the option for a DX11 only core?

This is mainly intended to be used with Xbox systems since DX11 is the only usable API for those systems.

As this is my first pull request, any reviews or comments are welcomed.