### PR TITLE
(Libretro) Actually allow DX11 only cores. / Update Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,13 @@ Join us on our [**Discord server**](https://discord.gg/X8YWP8w) for a chat.
 
 `brew install --cask flycast`
 
-### Xbox One
+### Xbox One/Series
 
-Open [**gamr13's github page**](https://gamr13.github.io/) from your console.
+#### Retail:
+Open [**gamr13's github page**](https://gamr13.github.io/) from your Xbox console.
+
+#### Dev Mode:
+Grab the latest build from [**the builds page**](https://flyinghead.github.io/flycast-builds/), or the [**GitHub Actions**](https://github.com/flyinghead/flycast/actions/workflows/uwp.yml). Then install it using the **Xbox Device Portal**.
 
 ### Binaries
 

--- a/core/wsi/libretro.cpp
+++ b/core/wsi/libretro.cpp
@@ -24,5 +24,9 @@
 LibretroGraphicsContext theGLContext;
 #endif
 
+#if defined(HAVE_D3D11) && !(defined(HAVE_OPENGL) || defined(HAVE_OPENGLES))
+#include "context.h"
+#endif
+
 GraphicsContext *GraphicsContext::instance;
 #endif


### PR DESCRIPTION
Turns out a few changes were still needed to the `wsi/libretro.cpp` file for DX11 builds to be built. Better finish my job than leave it incomplete.

Also decided to retouch the Xbox section of the Readme.