### PR TITLE
Readme Updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ![flycast logo](https://github.com/flyinghead/flycast/raw/master/shell/linux/flycast.png)
 
-**Flycast** is a multi-platform Sega Dreamcast, Naomi and Atomiswave emulator derived from [**reicast**](https://reicast.com/).
+**Flycast** is a multi-platform Sega Dreamcast, Naomi and Atomiswave emulator derived from [**reicast**](https://github.com/skmp/reicast-emulator)
 
 Information about configuration and supported features can be found on [**TheArcadeStriker's flycast wiki**](https://github.com/TheArcadeStriker/flycast-wiki/wiki).
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ![flycast logo](https://github.com/flyinghead/flycast/raw/master/shell/linux/flycast.png)
 
-**Flycast** is a multi-platform Sega Dreamcast, Naomi and Atomiswave emulator derived from [**reicast**](https://github.com/skmp/reicast-emulator)
+**Flycast** is a multi-platform Sega Dreamcast, Naomi, Naomi 2, and Atomiswave emulator derived from [**reicast**](https://github.com/skmp/reicast-emulator).
 
 Information about configuration and supported features can be found on [**TheArcadeStriker's flycast wiki**](https://github.com/TheArcadeStriker/flycast-wiki/wiki).
 
@@ -17,21 +17,21 @@ Join us on our [**Discord server**](https://discord.gg/X8YWP8w) for a chat.
 
 ### Flatpak (Linux)
 
-1. [Set up Flatpak](https://www.flatpak.org/setup/)
+1. [Set up Flatpak](https://www.flatpak.org/setup/).
 
-2. Install Flycast from [Flathub](https://flathub.org/apps/details/org.flycast.Flycast)
+2. Install Flycast from [Flathub](https://flathub.org/apps/details/org.flycast.Flycast):
 
 `flatpak install -y org.flycast.Flycast`
 
-3. Run Flycast
+3. Run Flycast:
 
 `flatpak run org.flycast.Flycast`
 
 ### Homebrew (MacOS)
 
-1. [Set up Homebrew](https://brew.sh)
+1. [Set up Homebrew](https://brew.sh).
 
-2. Install Flycast via Homebrew
+2. Install Flycast via Homebrew:
 
 `brew install --cask flycast`
 


### PR DESCRIPTION
- The original reicast link is down, so I think it's better to link the archived GitHub repo for those interested in checking the emulator for historical purposes.
- We can now emulate Naomi 2! So why not have the Readme reflect that?
- Small formatting touches.