### PR TITLE
macOS Breakpad

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -67,7 +67,7 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - name: Compile a universal OpenMP
+      - name: Compile a universal OpenMP (macOS)
         run: export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1; brew reinstall --build-from-source --formula ./shell/apple/libomp.rb
         if: runner.os == 'macOS'
 
@@ -130,7 +130,7 @@ jobs:
         shell: bash
         if: ${{ steps.aws-credentials.outputs.aws-account-id != '' }}
 
-      - name: Upload symbols to S3
+      - name: Upload symbols to S3 (Windows-MinGW, macOS)
         run: aws s3 sync symbols s3://flycast-symbols/${{ matrix.config.destDir }} --follow-symlinks
         shell: bash
-        if: ${{ steps.aws-credentials.outputs.aws-account-id != '' && matrix.config.name == 'x86_64-w64-mingw32' }}
+        if: ${{ steps.aws-credentials.outputs.aws-account-id != '' && (matrix.config.name == 'x86_64-w64-mingw32' || matrix.config.name == 'apple-darwin') }}

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         config:
           - {name: i686-pc-windows-msvc, os: windows-latest, shell: cmd, arch: x86, cmakeArgs: -G Ninja, buildType: Release}
-          - {name: apple-darwin, os: macos-latest, shell: sh, cmakeArgs: -G Xcode, destDir: osx, buildType: Release}
+          - {name: apple-darwin, os: macos-latest, shell: sh, cmakeArgs: -G Xcode -DAPPLE_BREAKPAD=ON, destDir: osx, buildType: RelWithDebInfo}
           - {name: apple-ios, os: macos-latest, shell: sh, cmakeArgs: -DCMAKE_SYSTEM_NAME=iOS -G Xcode, destDir: ios, buildType: Release}
           - {name: x86_64-pc-linux-gnu, os: ubuntu-latest, shell: sh, cmakeArgs: -G Ninja, buildType: Release}
           - {name: x86_64-pc-windows-msvc, os: windows-latest, shell: cmd, arch: x64, cmakeArgs: -G Ninja, buildType: Release}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,14 +216,14 @@ if(NOT LIBRETRO)
 				-a x86_64
 				-g ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app.dSYM
 				${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app/Contents/MacOS/Flycast > Flycast.sym
-			COMMAND mkdir -p symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
-			COMMAND mv Flycast.sym symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
+			COMMAND mkdir -p ../symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
+			COMMAND mv Flycast.sym ../symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
 			COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad/dump_syms
 				-a arm64
 				-g ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app.dSYM
 				${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app/Contents/MacOS/Flycast > Flycast.sym
-			COMMAND mkdir -p symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
-			COMMAND mv Flycast.sym symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
+			COMMAND mkdir -p ../symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
+			COMMAND mv Flycast.sym ../symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
 		)
 	endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,16 +200,49 @@ if(NOT LIBRETRO)
 		target_link_libraries(${PROJECT_NAME} PUBLIC breakpad_client)
 		target_compile_definitions(${PROJECT_NAME} PRIVATE USE_BREAKPAD)
 	elseif(APPLE AND NOT IOS AND APPLE_BREAKPAD)
-		add_custom_target(breakpad COMMAND xcodebuild -project ${CMAKE_CURRENT_SOURCE_DIR}/core/deps/breakpad/src/client/mac/Breakpad.xcodeproj -target Breakpad -configuration Release CONFIGURATION_BUILD_DIR=${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad)
-		add_custom_target(dump_syms COMMAND xcodebuild -project ${CMAKE_CURRENT_SOURCE_DIR}/core/deps/breakpad/src/tools/mac/dump_syms/dump_syms.xcodeproj -target dump_syms -configuration Release CONFIGURATION_BUILD_DIR=${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad)
-		ADD_DEPENDENCIES(${PROJECT_NAME} breakpad)
-		ADD_DEPENDENCIES(${PROJECT_NAME} dump_syms)
+		target_sources(${PROJECT_NAME} PRIVATE
+			core/deps/breakpad/src/client/minidump_file_writer-inl.h
+			core/deps/breakpad/src/client/minidump_file_writer.cc
+			core/deps/breakpad/src/client/minidump_file_writer.h
+			core/deps/breakpad/src/client/mac/handler/breakpad_nlist_64.cc
+			core/deps/breakpad/src/client/mac/handler/breakpad_nlist_64.h
+			core/deps/breakpad/src/client/mac/handler/dynamic_images.cc
+			core/deps/breakpad/src/client/mac/handler/dynamic_images.h
+			core/deps/breakpad/src/client/mac/handler/exception_handler.cc
+			core/deps/breakpad/src/client/mac/handler/exception_handler.h
+			core/deps/breakpad/src/client/mac/handler/minidump_generator.cc
+			core/deps/breakpad/src/client/mac/handler/minidump_generator.h
+			core/deps/breakpad/src/client/mac/handler/protected_memory_allocator.cc
+			core/deps/breakpad/src/client/mac/handler/protected_memory_allocator.h
+			core/deps/breakpad/src/client/mac/crash_generation/ConfigFile.h
+			core/deps/breakpad/src/client/mac/crash_generation/ConfigFile.mm
+			core/deps/breakpad/src/client/mac/crash_generation/client_info.h
+			core/deps/breakpad/src/client/mac/crash_generation/crash_generation_client.h
+			core/deps/breakpad/src/client/mac/crash_generation/crash_generation_client.cc
+			core/deps/breakpad/src/common/convert_UTF.cc
+			core/deps/breakpad/src/common/convert_UTF.h
+			core/deps/breakpad/src/common/md5.cc
+			core/deps/breakpad/src/common/string_conversion.cc
+			core/deps/breakpad/src/common/string_conversion.h
+			core/deps/breakpad/src/common/mac/file_id.cc
+			core/deps/breakpad/src/common/mac/file_id.h
+			core/deps/breakpad/src/common/mac/MachIPC.mm
+			core/deps/breakpad/src/common/mac/MachIPC.h
+			core/deps/breakpad/src/common/mac/bootstrap_compat.cc
+			core/deps/breakpad/src/common/mac/bootstrap_compat.h
+			core/deps/breakpad/src/common/mac/macho_id.cc
+			core/deps/breakpad/src/common/mac/macho_id.h
+			core/deps/breakpad/src/common/mac/macho_utilities.cc
+			core/deps/breakpad/src/common/mac/macho_utilities.h
+			core/deps/breakpad/src/common/mac/macho_walker.cc
+			core/deps/breakpad/src/common/mac/macho_walker.h
+			core/deps/breakpad/src/common/mac/string_utilities.cc
+			core/deps/breakpad/src/common/mac/string_utilities.h
+		)
 		target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/core/deps/breakpad/src)
-		target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad/Breakpad.framework)
 		target_compile_definitions(${PROJECT_NAME} PRIVATE USE_BREAKPAD)
-		add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-            	COMMAND ditto "${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad/Breakpad.framework"
-            		${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app/Contents/Frameworks/Breakpad.framework)
+		add_custom_target(dump_syms COMMAND xcodebuild -project ${CMAKE_CURRENT_SOURCE_DIR}/core/deps/breakpad/src/tools/mac/dump_syms/dump_syms.xcodeproj -target dump_syms -configuration Release CONFIGURATION_BUILD_DIR=${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad)
+		ADD_DEPENDENCIES(${PROJECT_NAME} dump_syms)
 		add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
 			COMMAND sleep 20
 			COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad/dump_syms
@@ -1538,5 +1571,5 @@ if(UNIX AND NOT APPLE AND NOT ANDROID AND NOT LIBRETRO)
 	endforeach()
 endif()
 
-file(GLOB_RECURSE SRC_FILES *.h *.cpp *.c *.mm)
+file(GLOB_RECURSE SRC_FILES *.h *.cpp *.c *.cc *.mm)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(USE_VULKAN "Build with Vulkan support" ON)
 option(LIBRETRO "Build libretro core" OFF)
 option(USE_OPENGL "Use Open GL API" ON)
 option(USE_VIDEOCORE "RPI: use the legacy Broadcom GLES libraries" OFF)
+option(APPLE_BREAKPAD "macOS: Build breakpad client and dump symbols" OFF)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/shell/cmake")
 
@@ -198,6 +199,32 @@ if(NOT LIBRETRO)
 		endif()
 		target_link_libraries(${PROJECT_NAME} PUBLIC breakpad_client)
 		target_compile_definitions(${PROJECT_NAME} PRIVATE USE_BREAKPAD)
+	elseif(APPLE AND NOT IOS AND APPLE_BREAKPAD)
+		add_custom_target(breakpad COMMAND xcodebuild -project ${CMAKE_CURRENT_SOURCE_DIR}/core/deps/breakpad/src/client/mac/Breakpad.xcodeproj -target Breakpad -configuration Release CONFIGURATION_BUILD_DIR=${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad)
+		add_custom_target(dump_syms COMMAND xcodebuild -project ${CMAKE_CURRENT_SOURCE_DIR}/core/deps/breakpad/src/tools/mac/dump_syms/dump_syms.xcodeproj -target dump_syms -configuration Release CONFIGURATION_BUILD_DIR=${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad)
+		ADD_DEPENDENCIES(${PROJECT_NAME} breakpad)
+		ADD_DEPENDENCIES(${PROJECT_NAME} dump_syms)
+		target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/core/deps/breakpad/src)
+		target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad/Breakpad.framework)
+		target_compile_definitions(${PROJECT_NAME} PRIVATE USE_BREAKPAD)
+		add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            	COMMAND ditto "${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad/Breakpad.framework"
+            		${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app/Contents/Frameworks/Breakpad.framework)
+		add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+			COMMAND sleep 20
+			COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad/dump_syms
+				-a x86_64
+				-g ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app.dSYM
+				${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app/Contents/MacOS/Flycast > Flycast.sym
+			COMMAND mkdir -p symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
+			COMMAND mv Flycast.sym symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
+			COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad/dump_syms
+				-a arm64
+				-g ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app.dSYM
+				${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app/Contents/MacOS/Flycast > Flycast.sym
+			COMMAND mkdir -p symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
+			COMMAND mv Flycast.sym symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
+		)
 	endif()
 endif()
 
@@ -1382,6 +1409,10 @@ if(NOT LIBRETRO)
 				MACOSX_BUNDLE_SHORT_VERSION_STRING "1.0"
 				MACOSX_BUNDLE_BUNDLE_VERSION "1"
 				MACOSX_BUNDLE_COPYRIGHT "Copyright © 2019 Flycast contributors. All rights reserved."
+				XCODE_ATTRIBUTE_DEBUG_INFORMATION_FORMAT "dwarf"
+				XCODE_ATTRIBUTE_DEBUG_INFORMATION_FORMAT[variant=RelWithDebInfo] "dwarf-with-dsym"
+				XCODE_ATTRIBUTE_CLANG_DEBUG_INFORMATION_LEVEL[variant=RelWithDebInfo] "line-tables-only"
+				XCODE_ATTRIBUTE_DEPLOYMENT_POSTPROCESSING[variant=RelWithDebInfo] YES
 				XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon"
 				XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.flyinghead.Flycast"
 				BUILD_WITH_INSTALL_RPATH TRUE

--- a/shell/apple/emulator-osx/emulator-osx/SDLMain.mm
+++ b/shell/apple/emulator-osx/emulator-osx/SDLMain.mm
@@ -325,7 +325,7 @@ static void CustomApplicationMain (int argc, char **argv)
 #ifdef USE_BREAKPAD
 static bool dumpCallback(const char *dump_dir, const char *minidump_id, void *context, bool succeeded)
 {
-    printf("Minidump saved to '%s'\n", dump_dir);
+    printf("Minidump saved to '%s/%s.dmp'\n", dump_dir, minidump_id);
     return succeeded;
 }
 #endif

--- a/shell/apple/emulator-osx/emulator-osx/SDLMain.mm
+++ b/shell/apple/emulator-osx/emulator-osx/SDLMain.mm
@@ -10,6 +10,10 @@
 #include <unistd.h>
 #include "rend/gui.h"
 
+#ifdef USE_BREAKPAD
+#include "client/mac/handler/exception_handler.h"
+#endif
+
 /* For some reaon, Apple removed setAppleMenu from the headers in 10.4,
  but the method still is there and works. To avoid warnings, we declare
  it ourselves here. */
@@ -318,6 +322,13 @@ static void CustomApplicationMain (int argc, char **argv)
 #endif
 
 
+#ifdef USE_BREAKPAD
+static bool dumpCallback(const char *dump_dir, const char *minidump_id, void *context, bool succeeded)
+{
+    printf("Minidump saved to '%s'\n", dump_dir);
+    return succeeded;
+}
+#endif
 /*
  * Catch document open requests...this lets us notice files when the app
  *  was launched by double-clicking a document, or when a document was
@@ -370,6 +381,10 @@ static void CustomApplicationMain (int argc, char **argv)
 /* Called when the internal event loop has just started running */
 - (void) applicationDidFinishLaunching: (NSNotification *) note
 {
+#if defined(USE_BREAKPAD)
+    google_breakpad::ExceptionHandler eh("/tmp", NULL, dumpCallback, NULL, true, NULL);
+#endif
+    
     int status;
     
     /* Set the working directory to the .app's parent directory */

--- a/shell/apple/emulator-osx/emulator-osx/SDLMain.mm
+++ b/shell/apple/emulator-osx/emulator-osx/SDLMain.mm
@@ -381,8 +381,9 @@ static bool dumpCallback(const char *dump_dir, const char *minidump_id, void *co
 /* Called when the internal event loop has just started running */
 - (void) applicationDidFinishLaunching: (NSNotification *) note
 {
-#if defined(USE_BREAKPAD)
+#ifdef USE_BREAKPAD
     google_breakpad::ExceptionHandler eh("/tmp", NULL, dumpCallback, NULL, true, NULL);
+    task_set_exception_ports(mach_task_self(), EXC_MASK_BAD_ACCESS, MACH_PORT_NULL, EXCEPTION_DEFAULT, 0);
 #endif
     
     int status;


### PR DESCRIPTION
- ~Build & link Breakpad.framework~
- Build Breakpad from source
- dump crashlog to `/tmp` during exception (by using `ExceptionHandler` manually instead of following the official guide's `BreakpadCreate()`)
- Build dump_syms and create sym file with dSYM 