### PR TITLE
load game: destroy old maple devices before create call

### DIFF
--- a/core/emulator.cpp
+++ b/core/emulator.cpp
@@ -505,6 +505,7 @@ void Emulator::loadGame(const char *path, LoadProgress *progress)
 			// Reload the BIOS in case a game-specific region is set
 			naomi_cart_LoadBios(path);
 		}
+		mcfg_DestroyDevices();
 		mcfg_CreateDevices();
 		if (settings.platform.isNaomi())
 			// Must be done after the maple devices are created and EEPROM is accessible


### PR DESCRIPTION
* Prevents extra maple devices from being loaded when switching between systems between games (i.e., Arcade -> DC)