### PR TITLE
Add Vulkan download mirror and DRY

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           brew update
           brew install libao ldid ninja pulseaudio
-          wget https://sdk.lunarg.com/sdk/download/1.3.211.0/mac/vulkansdk-macos-1.3.211.0.dmg
+          VULKAN_VER=1.3.211.0 && aria2c --parameterized-uri=true https://{sdk.lunarg.com/sdk/download/$VULKAN_VER/mac,distfiles.macports.org/MoltenVK}/vulkansdk-macos-$VULKAN_VER.dmg
           hdiutil attach ./vulkansdk-macos-*.dmg
           sudo /Volumes/vulkansdk-macos-*/InstallVulkan.app/Contents/MacOS/InstallVulkan --root $HOME/VulkanSDK --accept-licenses --default-answer --confirm-command install
           hdiutil detach /Volumes/vulkansdk-macos-*

--- a/core/hw/maple/maple_cfg.cpp
+++ b/core/hw/maple/maple_cfg.cpp
@@ -209,7 +209,6 @@ static void mcfg_Create(MapleDeviceType type, u32 bus, u32 port, s32 player_num 
 
 static void createNaomiDevices()
 {
-	mcfg_DestroyDevices();
 	mcfg_Create(MDT_NaomiJamma, 0, 5);
 	if (settings.input.JammaSetup == JVS::Keyboard)
 	{
@@ -229,7 +228,6 @@ static void createNaomiDevices()
 
 static void createAtomiswaveDevices()
 {
-	mcfg_DestroyDevices();
 	// Looks like two controllers needs to be on bus 0 and 1 for digital inputs
 	// Then other devices on port 2 and 3 for analog axes, light guns, ...
 	mcfg_Create(MDT_SegaController, 0, 5);


### PR DESCRIPTION
- Add MacPorts as alternative link for Vulkan SDK
- `mcfg_DestroyDevices()` is no longer needed in `mcfg_CreateDevices()`