### PR TITLE
macOS logging

### DIFF
--- a/core/log/ConsoleListenerNix.cpp
+++ b/core/log/ConsoleListenerNix.cpp
@@ -14,7 +14,7 @@
 
 ConsoleListener::ConsoleListener()
 {
-#ifdef LOG_TO_PTY
+#if defined(LOG_TO_PTY) || defined(__APPLE__)
   m_use_color = 1;
 #elif defined(__SWITCH__)
   m_use_color = 0;

--- a/core/log/LogManager.cpp
+++ b/core/log/LogManager.cpp
@@ -130,7 +130,7 @@ LogManager::LogManager()
 	SetLogLevel(static_cast<LogTypes::LOG_LEVELS>(verbosity));
 	if (cfgLoadBool("log", "LogToFile", false))
 	{
-#if defined(__ANDROID__) || defined(TARGET_IOS) || defined(TARGET_UWP)
+#if defined(__ANDROID__) || defined(__APPLE__) || defined(TARGET_UWP)
 		std::string logPath = get_writable_data_path("flycast.log");
 #else
 		std::string logPath = "flycast.log";

--- a/shell/apple/emulator-osx/emulator-osx/osx-main.mm
+++ b/shell/apple/emulator-osx/emulator-osx/osx-main.mm
@@ -30,8 +30,16 @@ int darw_printf(const char* text, ...)
     va_start(args, text);
     vsnprintf(temp, sizeof(temp), text, args);
     va_end(args);
-
-    NSLog(@"%s", temp);
+    
+    NSString* log = [NSString stringWithCString:temp encoding: NSUTF8StringEncoding];
+    if (getenv("TERM") == NULL) //Xcode console does not support colors
+    {
+        log = [log stringByReplacingOccurrencesOfString:@"\x1b[0m" withString:@""];
+        log = [log stringByReplacingOccurrencesOfString:@"\x1b[92m" withString:@"ℹ️ "];
+        log = [log stringByReplacingOccurrencesOfString:@"\x1b[91m" withString:@"⚠️ "];
+        log = [log stringByReplacingOccurrencesOfString:@"\x1b[93m" withString:@"🛑 "];
+    }
+    NSLog(@"%@", log);
 
     return 0;
 }


### PR DESCRIPTION
- Prints UTF-8 string properly
- Supports color (by emoji) in Console.app and Xcode console
- Fixes empty `flycast.log`