### PR TITLE
(UWP) Add Additional Rescap Capabilities

### DIFF
--- a/shell/uwp/package.appxManifest
+++ b/shell/uwp/package.appxManifest
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package
 	xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"	xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
-	xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-	IgnorableNamespaces="uap mp">
+	xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+	IgnorableNamespaces="uap mp rescap">
 
 	<Identity Name="AF75D068-D5AC-3D3C-B52A-2791C2F3491A" Publisher="CN=Flyinghead" Version="9.9.9.9" />
 	<mp:PhoneIdentity PhoneProductId="AF75D068-D5AC-3D3C-B52A-2791C2F3491A" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
@@ -38,6 +38,9 @@
 		<Capability Name="codeGeneration"/>
 		<Capability Name="internetClientServer"/>
 		<Capability Name="privateNetworkClientServer"/>
+    <rescap:Capability Name="runFullTrust"/>
+    <rescap:Capability Name="broadFileSystemAccess" />
+    <rescap:Capability Name="expandedResources" />
     <uap:Capability Name="removableStorage" />
     <DeviceCapability Name="microphone"/>
 	</Capabilities>


### PR DESCRIPTION
This adds three UWP app capability declarations to Flycast, these being `runFullTrust`, `broadFileSystemAccess`, and `expandedResources`.

`runFullTrust` gives Flycast full trust permission rights to the device it's installed, while `broadFileSystemAccess` allows Flycast's built-in file explorer to take advantage of the full trust permissions it has. This fixes Flycast's built-in File Explorer, allowing the user to choose more than two directories to store their games in.

`expandedResources` gives Flycast access to more of the system's CPU capabilities, which can result in performance boosts since we can now use more of the CPU's power than before.