### PR TITLE
Fix macOS accent menu

### DIFF
--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -44,6 +44,9 @@
 #include "lua/lua.h"
 #include "gui_chat.h"
 #include "imgui_driver.h"
+#if defined(USE_SDL)
+#include "sdl/sdl.h"
+#endif
 
 static bool game_started;
 
@@ -373,6 +376,15 @@ static void gui_newFrame()
 
 	if (showOnScreenKeyboard != nullptr)
 		showOnScreenKeyboard(io.WantTextInput);
+
+	if (io.WantTextInput && !SDL_IsTextInputActive())
+	{
+		SDL_StartTextInput();
+	}
+	else if (!io.WantTextInput && SDL_IsTextInputActive())
+	{
+		SDL_StopTextInput();
+	}
 }
 
 static void delayedKeysUp()

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1372,6 +1372,15 @@ static void gui_display_settings()
                 if (ImGui::Button("Change"))
                 	gui_state = GuiState::Onboarding;
 #endif
+#if defined(__APPLE__) && TARGET_OS_OSX
+                ImGui::SameLine(ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize("Reveal in Finder").x - ImGui::GetStyle().FramePadding.x);
+                if (ImGui::Button("Reveal in Finder"))
+                {
+                    char temp[512];
+                    sprintf(temp, "open \"%s\"", get_writable_config_path("").c_str());
+                    system(temp);
+                }
+#endif
                 ImGui::ListBoxFooter();
             }
             ImGui::SameLine();


### PR DESCRIPTION
![Capture d’écran, le 2019-05-07 à 19 42 28](https://user-images.githubusercontent.com/45190261/57340003-f886ca80-7101-11e9-87ea-296d58c2d463.png)
Fix accent menu by enabling `SDL_StartTextInput()` on demand instead of always on 
https://github.com/flyinghead/flycast/issues/699#issuecomment-1200647981

Hope it won't break the on screen keyboard (I haven't tested and I don't have the relevant knowledge)

Seems calling `SDL_StopTextInput()` on all platforms could save some CPU cycles for each keyboard keypress
ref: http://thelittleengineerthatcould.blogspot.com/2018/05/the-curious-case-of-fps-jitter.html
⠀
⠀

<img width="234" alt="image" src="https://user-images.githubusercontent.com/602245/182456057-eba5cdf1-acae-468c-be87-3387b0632867.png">
Add `Reveal in Finder` button for macOS