### PR TITLE
(UWP) Build Tweaks

### DIFF
--- a/.github/workflows/uwp.yml
+++ b/.github/workflows/uwp.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: CMake
         run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 17 2022" -A x64 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.22000.0 -DCMAKE_SYSTEM_PROCESSOR=AMD64 -DCMAKE_CROSSCOMPILING=OFF -DUSE_VULKAN=OFF -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake
+          cmake -B build -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 17 2022" -A x64 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.22000.0 -DCMAKE_SYSTEM_PROCESSOR=AMD64 -DCMAKE_CROSSCOMPILING=OFF -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake
           cmake --build build --config Release --parallel 2
         shell: cmd
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ endif()
 
 if(WINDOWS_STORE)
 	set(USE_OPENGL OFF)
+	set(USE_VULKAN OFF)
     target_compile_features(${PROJECT_NAME} PRIVATE c_std_11 cxx_std_17)
 else()
     target_compile_features(${PROJECT_NAME} PRIVATE c_std_11 cxx_std_11)


### PR DESCRIPTION
This disables the Vulkan renderer for UWP builds directly on the CMakeLists.txt file rather than disabling it during build time. 
Since this is how it's handled for the Switch workflow, I figured UWP could be handled like this as well. Not to mention that having to input one less build flag is certainly a nice thing to have. :)

Since Vulkan was always disabled for UWP anyway, there shouldn't be any differences in the final builds.