### PR TITLE
(UWP) Remove expandedResources

### DIFF
--- a/shell/uwp/package.appxManifest
+++ b/shell/uwp/package.appxManifest
@@ -40,7 +40,6 @@
 		<Capability Name="privateNetworkClientServer"/>
     <rescap:Capability Name="runFullTrust"/>
     <rescap:Capability Name="broadFileSystemAccess" />
-    <rescap:Capability Name="expandedResources" />
     <uap:Capability Name="removableStorage" />
     <DeviceCapability Name="microphone"/>
 	</Capabilities>


### PR DESCRIPTION
Seems this flag is only relevant when using an Xbox App, it does next to nothing for apps set as Games.

Plus it causes a very strange buggy behavior with any app that uses it, input isn't suspended when using the Xbox guide. So you can accidentally open a game in Flycast while checking your friends list and yeah, that's bad.