### PR TITLE
cmake: execute git commands in the source directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,11 +55,13 @@ find_package(Git)
 if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
     execute_process(
         COMMAND ${GIT_EXECUTABLE} describe --tags --always
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         OUTPUT_VARIABLE GIT_VERSION
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     execute_process(
         COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         OUTPUT_VARIABLE GIT_HASH
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )


### PR DESCRIPTION
Found this while wondering why "About" screen shows a commit hash that doesn't seem to exist - turns out if you run CMake with the -S option to point at a directory with the source, then the git commands execute in the directory you ran the cmake command in, instead of in the repository directory.

This can fail or even succeed with a hash from an unrelated repository (in my case this is what happened, it fetched the [hash of the AUR package](https://aur.archlinux.org/cgit/aur.git/commit/?h=flycast-git&id=69ab6976b143f05249ffeaaa03bdefd1715e30d4) instead, and funnily enough I'm not the only person this happened to, see [last video on this list](https://www.restartsyndrome.com/replays.php?id=68&mode=Hard%20Mode) ).