### PR TITLE
Remove top & bottom black bars with new Aspect Fill option

### DIFF
--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -86,6 +86,7 @@ Option<bool> DelayFrameSwapping("rend.DelayFrameSwapping", false);
 Option<bool> DelayFrameSwapping("rend.DelayFrameSwapping", true);
 #endif
 Option<bool> WidescreenGameHacks("rend.WidescreenGameHacks");
+Option<bool> AspectFill("rend.AspectFill", false);
 std::array<Option<int>, 4> CrosshairColor {
 	Option<int>("rend.CrossHairColor1"),
 	Option<int>("rend.CrossHairColor2"),

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -454,6 +454,7 @@ extern Option<bool> Rotate90;
 extern Option<bool> PerStripSorting;
 extern Option<bool> DelayFrameSwapping;	// Delay swapping frame until FB_R_SOF matches FB_W_SOF
 extern Option<bool> WidescreenGameHacks;
+extern Option<bool> AspectFill;
 extern std::array<Option<int>, 4> CrosshairColor;
 extern Option<int> SkipFrame;
 extern Option<int> MaxThreads;

--- a/core/rend/dx11/dx11_renderer.cpp
+++ b/core/rend/dx11/dx11_renderer.cpp
@@ -509,7 +509,7 @@ void DX11Renderer::renderFramebuffer()
 		std::swap(outwidth, outheight);
 	int dy = 0;
 	int dx = 0;
-	if (renderAR > screenAR)
+	if (renderAR > screenAR && config::AspectFill == false)
 		dy = (int)roundf(outheight * (1 - screenAR / renderAR) / 2.f);
 	else
 		dx = (int)roundf(outwidth * (1 - renderAR / screenAR) / 2.f);

--- a/core/rend/dx9/d3d_renderer.cpp
+++ b/core/rend/dx9/d3d_renderer.cpp
@@ -1107,7 +1107,7 @@ void D3DRenderer::renderFramebuffer()
 	float screenAR = (float)settings.display.width / settings.display.height;
 	int dx = 0;
 	int dy = 0;
-	if (renderAR > screenAR)
+	if (renderAR > screenAR && config::AspectFill == false)
 		dy = (int)roundf(settings.display.height * (1 - screenAR / renderAR) / 2.f);
 	else
 		dx = (int)roundf(settings.display.width * (1 - renderAR / screenAR) / 2.f);

--- a/core/rend/gles/gldraw.cpp
+++ b/core/rend/gles/gldraw.cpp
@@ -716,7 +716,7 @@ bool render_output_framebuffer()
 
 	int dx = 0;
 	int dy = 0;
-	if (renderAR > screenAR)
+	if (renderAR > screenAR && config::AspectFill == false)
 		dy = (int)roundf(settings.display.height * (1 - screenAR / renderAR) / 2.f);
 	else
 		dx = (int)roundf(settings.display.width * (1 - renderAR / screenAR) / 2.f);

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1771,6 +1771,8 @@ static void gui_display_settings()
 		    			"Useful to avoid flashing screen or glitchy videos. Not recommended on slow platforms");
 		    	OptionCheckbox("Native Depth Interpolation", config::NativeDepthInterpolation,
 		    			"Helps with texture corruption and depth issues on AMD GPUs. Can also help Intel GPUs in some cases.");
+		    	OptionCheckbox("Aspect Fill", config::AspectFill,
+                        "Content fills up the entire window while keeping aspect ratio, can remove top & bottom black bars but content might be cropped.");
 		    	constexpr int apiCount = 0
 					#ifdef USE_VULKAN
 		    			+ 1

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -866,7 +866,7 @@ void VulkanContext::DrawFrame(vk::ImageView imageView, const vk::Extent2D& exten
 	float screenAR = (float)width / height;
 	float dx = 0;
 	float dy = 0;
-	if (renderAR > screenAR)
+	if (renderAR > screenAR && config::AspectFill == false)
 		dy = height * (1 - screenAR / renderAR) / 2;
 	else
 		dx = width * (1 - renderAR / screenAR) / 2;

--- a/shell/libretro/option.cpp
+++ b/shell/libretro/option.cpp
@@ -73,6 +73,7 @@ Option<bool> Rotate90("");
 Option<bool> PerStripSorting("rend.PerStripSorting");
 Option<bool> DelayFrameSwapping(CORE_OPTION_NAME "_delay_frame_swapping");
 Option<bool> WidescreenGameHacks(CORE_OPTION_NAME "_widescreen_cheats");
+Option<bool> AspectFill("", false);
 std::array<Option<int>, 4> CrosshairColor {
 	Option<int>(""),
 	Option<int>(""),


### PR DESCRIPTION
As reported by end users, the new version of Flycast has many black areas:
![image](https://user-images.githubusercontent.com/602245/194015361-20860e86-c951-4532-9aa7-343c3e53ef85.png)


This PR adds an option to crop the content by "Aspect Fill" to remove the top and black bars:
<img width="493" alt="image" src="https://user-images.githubusercontent.com/602245/194015985-36b58bbd-a4f5-4c6f-8f64-f195cc1141b0.png">
