### PR TITLE
libomp.rb: update and set min macosx version to 10.9

### DIFF
--- a/shell/apple/libomp.rb
+++ b/shell/apple/libomp.rb
@@ -1,8 +1,8 @@
 class Libomp < Formula
   desc "LLVM's OpenMP runtime library"
   homepage "https://openmp.llvm.org/"
-  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/openmp-14.0.0.src.tar.xz"
-  sha256 "28a1cbdd3dfdd331e4ed2dda2b4477fc418e455c883bd0d1d6acc331118e4688"
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/openmp-14.0.6.src.tar.xz"
+  sha256 "4f731ff202add030d9d68d4c6daabd91d3aeed9812e6a5b4968815cfdff0eb1f"
   license "MIT"
 
   livecheck do
@@ -11,12 +11,12 @@ class Libomp < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_monterey: "cf1058b26e1a778e523d51562c99b4145aea1b1cb89f1c60b3315677a86c7a08"
-    sha256 cellar: :any,                 arm64_big_sur:  "bbf77a1a151f00a18e340ab1f655fb87fe787a85834518f1dc44bf0c52ae7d4c"
-    sha256 cellar: :any,                 monterey:       "e66d2009d6d205c19499dcb453dfac4376ab6bdba805987be00ddbbab65a0818"
-    sha256 cellar: :any,                 big_sur:        "ed9dc636a5fc8c2a0cfb1643f7932d742ae4805c3f193a9e56cab7d7cf7342e7"
-    sha256 cellar: :any,                 catalina:       "c72ce9beecde09052e7eac3550b0286ed9bfb2d14f1dd5954705ab5fb25f231b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9fe14d5f4c8b472de1fad74278da6ba38da7322775b8a88ac61de0c373c4ad10"
+    sha256 cellar: :any,                 arm64_monterey: "b36b1393289e7d98fc03425b6c23a63c4f5e9290ecf0922d45e6fde2973ba8fb"
+    sha256 cellar: :any,                 arm64_big_sur:  "f00a5f352167b2fd68ad25b1959ef66a346023c6dbeb50892b386381d7ebe183"
+    sha256 cellar: :any,                 monterey:       "a423e0bc90a9d0f0feff08eb197768287ba4722b88d4624c2d8306e443ff6fdb"
+    sha256 cellar: :any,                 big_sur:        "46e5838f0061cfe1901c485987fc5649464cfa3b2150f2ac54dd5e61eb3342a4"
+    sha256 cellar: :any,                 catalina:       "63cdbb3a70c4b85a6a92a55c8ab2384ded244d37568cd769409dee00a14b581d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "470c1338f8c1bc8ef1a41e86bb9beddcff9c353947a2073b2c2b4f584db9bd20"
   end
 
   depends_on "cmake" => :build
@@ -30,7 +30,6 @@ class Libomp < Formula
   def install
     # Disable LIBOMP_INSTALL_ALIASES, otherwise the library is installed as
     # libgomp alias which can conflict with GCC's libgomp.
-    
     args = ["-DLIBOMP_INSTALL_ALIASES=OFF"]
     args << "-DOPENMP_ENABLE_LIBOMPTARGET=OFF" if OS.linux?
 
@@ -38,6 +37,7 @@ class Libomp < Formula
     ENV.permit_arch_flags
     ENV.runtime_cpu_detection
     args << "-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64"
+    args << "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9"
 
     # system "cmake", "-S", "openmp-#{version}.src", "-B", "build/shared", *std_cmake_args, *args
     # system "cmake", "--build", "build/shared"


### PR DESCRIPTION
Fix the following warnings:
- https://github.com/flyinghead/flycast/actions/runs/3188477252/jobs/5201189329#step:8:11
```
Warning: libomp 14.0.6 is available and more recent than version 14.0.0.
```
- https://github.com/flyinghead/flycast/actions/runs/3188477252/jobs/5201189329#step:10:15422
```
ld: warning: object file (/usr/local/lib/libomp.a(kmp_csupport.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_ftn_cdecl.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(ompt-general.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_alloc.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_global.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_lock.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_runtime.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_barrier.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_error.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_debug.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(z_Linux_util.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_dispatch.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_i18n.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_tasking.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_cancel.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_utility.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_str.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_settings.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_atomic.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_affinity.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_threadprivate.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_io.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_environment.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(z_Linux_asm.S.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_version.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
ld: warning: object file (/usr/local/lib/libomp.a(kmp_wait_release.cpp.o)) was built for newer macOS version (11.0) than being linked (10.9)
```