### PR TITLE
Fix crash on GGPO disconnecting, when resetting elan memory

### DIFF
--- a/core/emulator.cpp
+++ b/core/emulator.cpp
@@ -346,7 +346,10 @@ void dc_reset(bool hard)
 {
 	NetworkHandshake::term();
 	if (hard)
+	{
 		_vmem_unprotect_vram(0, VRAM_SIZE);
+		memwatch::elanWatcher.unprotectMem(0, 0xffffffff);
+	}
 	sh4_sched_reset(hard);
 	pvr::reset(hard);
 	libAICA_Reset(hard);

--- a/core/hw/mem/mem_watch.h
+++ b/core/hw/mem/mem_watch.h
@@ -155,10 +155,10 @@ class ElanRamWatcher : public Watcher<ElanRamWatcher>
 
 protected:
 	void protectMem(u32 addr, u32 size);
-	void unprotectMem(u32 addr, u32 size);
 	u32 getMemOffset(void *p);
 
 public:
+	void unprotectMem(u32 addr, u32 size);
 	void *getMemPage(u32 addr)
 	{
 		return &elan::RAM[addr];


### PR DESCRIPTION
When GGPO is active, `elanWatcher.protect()` -> `ElanRamWatcher::protectMem()` is called

Peer disconnecting will call `dc_reset(true)`, elan ram will be reinitialized to 0, and would crash since it is still protected.

elan.cpp:
```cpp
void reset(bool hard)
{
	if (hard)
	{
		memset(RAM, 0, ELAN_RAM_SIZE);
		state.reset();
	}
}
```

This is an attempt to fix this issue without a deep understanding, please close the PR and consider this as an issue if appropriate. 