### PR TITLE
Add Aspect Fit & Aspect Fill description for Widescreen and Super Widescreen

### DIFF
--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1676,7 +1676,7 @@ static void gui_display_settings()
 		    			"Enable modifier volumes, usually used for shadows");
 		    	OptionCheckbox("Fog", config::Fog, "Enable fog effects");
 		    	OptionCheckbox("Widescreen", config::Widescreen,
-		    			"Draw geometry outside of the normal 4:3 aspect ratio. May produce graphical glitches in the revealed areas");
+		    			"Draw geometry outside of the normal 4:3 aspect ratio. May produce graphical glitches in the revealed areas.\nAspect Fit and shows the full 16:9 content.");
 		    	if (!config::Widescreen)
 		    	{
 			        ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
@@ -1684,7 +1684,7 @@ static void gui_display_settings()
 		    	}
 		    	ImGui::Indent();
 		    	OptionCheckbox("Super Widescreen", config::SuperWidescreen,
-		    			"Use the full width of the screen or window when its aspect ratio is greater than 16:9");
+		    			"Use the full width of the screen or window when its aspect ratio is greater than 16:9.\nAspect Fill and remove black bars.");
 		    	ImGui::Unindent();
 		    	if (!config::Widescreen)
 		    	{


### PR DESCRIPTION
<img width="465" alt="image" src="https://user-images.githubusercontent.com/602245/196903600-9a541542-119d-4e58-b6cf-40f428bc043a.png">
<img width="534" alt="image" src="https://user-images.githubusercontent.com/602245/196903659-e1d55593-6042-4b13-a7bc-497ff67ae392.png">

Make it easier for user to discover how to remove black bars, related: #768 