### PR TITLE
macos: fix cmake post build command with ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,21 +248,42 @@ if(NOT LIBRETRO)
 		target_compile_definitions(${PROJECT_NAME} PRIVATE USE_BREAKPAD)
 		add_custom_target(dump_syms COMMAND xcodebuild -project ${CMAKE_CURRENT_SOURCE_DIR}/core/deps/breakpad/src/tools/mac/dump_syms/dump_syms.xcodeproj -target dump_syms -configuration Release CONFIGURATION_BUILD_DIR=${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad)
 		ADD_DEPENDENCIES(${PROJECT_NAME} dump_syms)
-		add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-			COMMAND sleep 20
-			COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad/dump_syms
-				-a x86_64
-				-g ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app.dSYM
-				${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app/Contents/MacOS/Flycast > Flycast.sym
-			COMMAND mkdir -p ../symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
-			COMMAND mv Flycast.sym ../symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
-			COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad/dump_syms
-				-a arm64
-				-g ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app.dSYM
-				${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app/Contents/MacOS/Flycast > Flycast.sym
-			COMMAND mkdir -p ../symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
-			COMMAND mv Flycast.sym ../symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
-		)
+
+		if(${CMAKE_GENERATOR} MATCHES "^Xcode.*")
+			add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+				COMMAND sleep 20
+				COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad/dump_syms
+					-a x86_64
+					-g ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app.dSYM
+					${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app/Contents/MacOS/Flycast > Flycast.sym
+				COMMAND mkdir -p ../symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
+				COMMAND mv Flycast.sym ../symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
+				COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad/dump_syms
+					-a arm64
+					-g ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app.dSYM
+					${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app/Contents/MacOS/Flycast > Flycast.sym
+				COMMAND mkdir -p ../symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
+				COMMAND mv Flycast.sym ../symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
+			)
+		else()
+			add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+				COMMAND sleep 20
+				COMMAND dsymutil ${CMAKE_CURRENT_BINARY_DIR}/Flycast.app/Contents/MacOS/Flycast
+					-o ${CMAKE_CURRENT_BINARY_DIR}/Flycast.app.dSYM
+				COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad/dump_syms
+					-a x86_64
+					-g ${CMAKE_CURRENT_BINARY_DIR}/Flycast.app.dSYM
+					${CMAKE_CURRENT_BINARY_DIR}/Flycast.app/Contents/MacOS/Flycast > Flycast.sym
+				COMMAND mkdir -p ../symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
+				COMMAND mv Flycast.sym ../symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
+				COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build/breakpad/dump_syms
+					-a arm64
+					-g ${CMAKE_CURRENT_BINARY_DIR}/Flycast.app.dSYM
+					${CMAKE_CURRENT_BINARY_DIR}/Flycast.app/Contents/MacOS/Flycast > Flycast.sym
+				COMMAND mkdir -p ../symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
+				COMMAND mv Flycast.sym ../symbols/Flycast/`head -1 Flycast.sym | awk '{ print $4 }'`
+			)
+		endif()
 	endif()
 endif()
 
@@ -1499,9 +1520,15 @@ if(NOT LIBRETRO)
 				${IOSURFACE_LIBRARY}
 				${MULTITOUCH_SUPPORT_LIBRARY})
 
-			add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-				COMMAND ${CMAKE_COMMAND} -E copy "$ENV{VULKAN_SDK}/lib/libMoltenVK.dylib"
+			if(${CMAKE_GENERATOR} MATCHES "^Xcode.*")
+				add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+					COMMAND ${CMAKE_COMMAND} -E copy "$ENV{VULKAN_SDK}/lib/libMoltenVK.dylib"
 					${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/Flycast.app/Contents/Frameworks/libvulkan.dylib)
+			else()
+				add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+					COMMAND ${CMAKE_COMMAND} -E copy "$ENV{VULKAN_SDK}/lib/libMoltenVK.dylib"
+					${CMAKE_CURRENT_BINARY_DIR}/Flycast.app/Contents/Frameworks/libvulkan.dylib)
+			endif()
 		endif()
 	elseif(UNIX OR NINTENDO_SWITCH)
 		if(NOT BUILD_TESTING)


### PR DESCRIPTION
- Copy-paste the post build commands without `$<CONFIG>` which does not work with Ninja
- `dsymutil` command added to generate the dSYM file. Ninja does not generated this file automatically like Xcode
