### PR TITLE
Fixing Steam Deck's wrong dpi caused by incorrect 60mm * 60mm EDID

### DIFF
--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -736,7 +736,7 @@ bool VulkanContext::init()
 		int displayIndex = SDL_GetWindowDisplayIndex(sdlWin);
 		SDL_DisplayMode mode;
 		SDL_GetDisplayMode(displayIndex, 0, &mode);
-		if ( displayIndex == 0 && strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U") && mode.w == 1280 && mode.h == 800 )
+		if ( displayIndex == 0 && strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U 3\"") == 0 && mode.w == 1280 && mode.h == 800 )
 			settings.display.dpi = 206;
 	}
 #endif

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -728,6 +728,18 @@ bool VulkanContext::init()
 	float hdpi, vdpi;
 	if (!SDL_GetDisplayDPI(SDL_GetWindowDisplayIndex(sdlWin), nullptr, &hdpi, &vdpi))
 		settings.display.dpi = roundf(std::max(hdpi, vdpi));
+
+#ifdef __linux__
+	// Fixing Steam Deck's incorrect 60mm * 60mm EDID 
+	if (settings.display.dpi > 500)
+	{
+		int displayIndex = SDL_GetWindowDisplayIndex(sdlWin);
+		SDL_DisplayMode mode;
+		SDL_GetDisplayMode(displayIndex, 0, &mode);
+		if ( displayIndex == 0 && strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U") && mode.w == 1280 && mode.h == 800 )
+			settings.display.dpi = 206;
+	}
+#endif
 #elif defined(_WIN32)
 	vk::Win32SurfaceCreateInfoKHR createInfo(vk::Win32SurfaceCreateFlagsKHR(), GetModuleHandle(NULL), (HWND)window);
 	surface = instance->createWin32SurfaceKHRUnique(createInfo);

--- a/core/wsi/sdl.cpp
+++ b/core/wsi/sdl.cpp
@@ -84,6 +84,18 @@ bool SDLGLGraphicsContext::init()
 	float hdpi, vdpi;
 	if (!SDL_GetDisplayDPI(SDL_GetWindowDisplayIndex(sdlWindow), nullptr, &hdpi, &vdpi))
 		settings.display.dpi = roundf(std::max(hdpi, vdpi));
+	
+#ifdef __linux__
+	// Fixing Steam Deck's incorrect 60mm * 60mm EDID
+	if (settings.display.dpi > 500)
+	{
+		int displayIndex = SDL_GetWindowDisplayIndex(sdlWindow);
+		SDL_DisplayMode mode;
+		SDL_GetDisplayMode(displayIndex, 0, &mode);
+		if ( displayIndex == 0 && strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U") && mode.w == 1280 && mode.h == 800 )
+			settings.display.dpi = 206;
+	}
+#endif
 
 	INFO_LOG(RENDERER, "Created SDL Window and GL Context successfully");
 

--- a/core/wsi/sdl.cpp
+++ b/core/wsi/sdl.cpp
@@ -92,7 +92,7 @@ bool SDLGLGraphicsContext::init()
 		int displayIndex = SDL_GetWindowDisplayIndex(sdlWindow);
 		SDL_DisplayMode mode;
 		SDL_GetDisplayMode(displayIndex, 0, &mode);
-		if ( displayIndex == 0 && strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U") && mode.w == 1280 && mode.h == 800 )
+		if ( displayIndex == 0 && strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U 3\"") == 0 && mode.w == 1280 && mode.h == 800 )
 			settings.display.dpi = 206;
 	}
 #endif


### PR DESCRIPTION
Dirty fix for #769, verified by a gundam tester
Since patching the EDID by every user is a bit tedious...

Before the patch:
<img width="220" alt="image" src="https://user-images.githubusercontent.com/602245/198270350-3d72f0ae-167c-4b00-8dd2-105c78b23113.png">

After the patch:
<img width="502" alt="image" src="https://user-images.githubusercontent.com/602245/198270598-a9562268-070b-45ce-aef3-d99468b3ceb1.png">

