### PR TITLE
Fixing Steam Deck's wrong dpi caused by incorrect 6cm * 5cm EDID (Game Mode)

### DIFF
--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -736,7 +736,7 @@ bool VulkanContext::init()
 		int displayIndex = SDL_GetWindowDisplayIndex(sdlWin);
 		SDL_DisplayMode mode;
 		SDL_GetDisplayMode(displayIndex, 0, &mode);
-		if ( displayIndex == 0 && strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U 3\"") == 0 && mode.w == 1280 && mode.h == 800 )
+		if ( displayIndex == 0 && (strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U 3\"") == 0 || strcmp(SDL_GetDisplayName(displayIndex), "XWAYLAND0 3\"") == 0) && mode.w == 1280 && mode.h == 800 )
 			settings.display.dpi = 206;
 	}
 #endif

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -736,7 +736,7 @@ bool VulkanContext::init()
 		int displayIndex = SDL_GetWindowDisplayIndex(sdlWin);
 		SDL_DisplayMode mode;
 		SDL_GetDisplayMode(displayIndex, 0, &mode);
-		if ( displayIndex == 0 && strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U") && mode.w == 1280 && mode.h == 800 )
+		if ( displayIndex == 0 && strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U 3\"") == 0 && mode.w == 1280 && mode.h == 800 )
 			settings.display.dpi = 206;
 	}
 #endif

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -728,6 +728,18 @@ bool VulkanContext::init()
 	float hdpi, vdpi;
 	if (!SDL_GetDisplayDPI(SDL_GetWindowDisplayIndex(sdlWin), nullptr, &hdpi, &vdpi))
 		settings.display.dpi = roundf(std::max(hdpi, vdpi));
+
+#ifdef __linux__
+	// Fixing Steam Deck's incorrect 60mm * 60mm EDID 
+	if (settings.display.dpi > 500)
+	{
+		int displayIndex = SDL_GetWindowDisplayIndex(sdlWin);
+		SDL_DisplayMode mode;
+		SDL_GetDisplayMode(displayIndex, 0, &mode);
+		if ( displayIndex == 0 && strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U") && mode.w == 1280 && mode.h == 800 )
+			settings.display.dpi = 206;
+	}
+#endif
 #elif defined(_WIN32)
 	vk::Win32SurfaceCreateInfoKHR createInfo(vk::Win32SurfaceCreateFlagsKHR(), GetModuleHandle(NULL), (HWND)window);
 	surface = instance->createWin32SurfaceKHRUnique(createInfo);

--- a/core/wsi/sdl.cpp
+++ b/core/wsi/sdl.cpp
@@ -92,7 +92,7 @@ bool SDLGLGraphicsContext::init()
 		int displayIndex = SDL_GetWindowDisplayIndex(sdlWindow);
 		SDL_DisplayMode mode;
 		SDL_GetDisplayMode(displayIndex, 0, &mode);
-		if ( displayIndex == 0 && strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U 3\"") == 0 && mode.w == 1280 && mode.h == 800 )
+		if ( displayIndex == 0 && (strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U 3\"") == 0 || strcmp(SDL_GetDisplayName(displayIndex), "XWAYLAND0 3\"") == 0) && mode.w == 1280 && mode.h == 800 )
 			settings.display.dpi = 206;
 	}
 #endif

--- a/core/wsi/sdl.cpp
+++ b/core/wsi/sdl.cpp
@@ -84,6 +84,18 @@ bool SDLGLGraphicsContext::init()
 	float hdpi, vdpi;
 	if (!SDL_GetDisplayDPI(SDL_GetWindowDisplayIndex(sdlWindow), nullptr, &hdpi, &vdpi))
 		settings.display.dpi = roundf(std::max(hdpi, vdpi));
+	
+#ifdef __linux__
+	// Fixing Steam Deck's incorrect 60mm * 60mm EDID
+	if (settings.display.dpi > 500)
+	{
+		int displayIndex = SDL_GetWindowDisplayIndex(sdlWindow);
+		SDL_DisplayMode mode;
+		SDL_GetDisplayMode(displayIndex, 0, &mode);
+		if ( displayIndex == 0 && strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U") && mode.w == 1280 && mode.h == 800 )
+			settings.display.dpi = 206;
+	}
+#endif
 
 	INFO_LOG(RENDERER, "Created SDL Window and GL Context successfully");
 

--- a/core/wsi/sdl.cpp
+++ b/core/wsi/sdl.cpp
@@ -92,7 +92,7 @@ bool SDLGLGraphicsContext::init()
 		int displayIndex = SDL_GetWindowDisplayIndex(sdlWindow);
 		SDL_DisplayMode mode;
 		SDL_GetDisplayMode(displayIndex, 0, &mode);
-		if ( displayIndex == 0 && strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U") && mode.w == 1280 && mode.h == 800 )
+		if ( displayIndex == 0 && strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U 3\"") == 0 && mode.w == 1280 && mode.h == 800 )
 			settings.display.dpi = 206;
 	}
 #endif


### PR DESCRIPTION
For unknown reason, EDID is hidden in Game Mode, so xrandr cannot fetch the 60mm * 60mm dimension in `Detailed Timing Block`, and `Display Product Name`

As a fallback, Game Mode would use the `Screen Size` info instead, and the emulated name `XWAYLAND0`

Unlike the incorrect 60mm * 60mm dimension inside the Timing Block, only some Steam Deck's `Screen Size` has the incorrect 6cm * 5cm dimension (usually it would report as 10cm * 15cm, depends on manufacturing batch)

This is an update of https://github.com/flyinghead/flycast/pull/796, fixes https://github.com/flyinghead/flycast/issues/769 again