### PR TITLE
make Xbox display scale scale with res instead of just switching between 2 presets for 1080p and 4k

### DIFF
--- a/core/rend/dx11/dx11context.cpp
+++ b/core/rend/dx11/dx11context.cpp
@@ -51,11 +51,7 @@ bool DX11Context::init(bool keepCurrentWindow)
 		NOTICE_LOG(RENDERER, "HDMI resolution: %d x %d", displayMode->ResolutionWidthInRawPixels, displayMode->ResolutionHeightInRawPixels);
 		settings.display.width = displayMode->ResolutionWidthInRawPixels;
 		settings.display.height = displayMode->ResolutionHeightInRawPixels;
-		if (settings.display.width == 3840)
-			// 4K
-			settings.display.uiScale = 2.8f;
-		else
-			settings.display.uiScale = 1.4f;
+		settings.display.uiScale = settings.display.width / 1920.0f * 1.4f;
 	}
 #endif
 


### PR DESCRIPTION
Currently the ui switches between 2 different ui scales depending on if the display is 4k or something else.
This leads to the UI being too big at 720p and too small at 1440p.

This pr fixes that by taking the display width, dividing it by 1920p and then using that as a multiplier for the display scale.

4k without the pr:
![Screenshot_2022-11-25_17-11-384k](https://user-images.githubusercontent.com/26260613/204033119-28e9fc6b-3023-44e4-a931-20188c1d2103.png)
1440p without the pr:
![Screenshot_2022-11-25_17-12-371440](https://user-images.githubusercontent.com/26260613/204033125-ad445ae3-dc69-4034-a6a8-aeb661797fde.png)
1080p without the pr:
![Screenshot_2022-11-25_17-13-061080](https://user-images.githubusercontent.com/26260613/204033130-4989d0b8-bf6e-43d2-929e-667886bdaab7.png)
720p without the pr:
![Screenshot_2022-11-25_17-13-38720](https://user-images.githubusercontent.com/26260613/204033137-5475fbfb-07e1-4e08-9016-84494b348b0b.png)

720p with the pr:
![Screenshot_2022-11-25_17-29-29](https://user-images.githubusercontent.com/26260613/204033393-9018e9b6-a4b3-4580-8b91-53699a32f79d.png)
1080p with the pr:
![Screenshot_2022-11-25_17-30-08](https://user-images.githubusercontent.com/26260613/204033433-a3463dad-c17c-4482-a073-f11517e69cb4.png)
1440p with the pr:
![Screenshot_2022-11-25_17-30-51](https://user-images.githubusercontent.com/26260613/204033536-2d6d3bd3-9f72-44ca-8124-16cc64a1edf5.png)
4k with the pr:
![Screenshot_2022-11-25_17-31-37](https://user-images.githubusercontent.com/26260613/204033627-b5d874cf-393d-4023-8c5b-942ced0090fb.png)
