### PR TITLE
metainfo: fix wrong category name

### DIFF
--- a/shell/linux/org.flycast.Flycast.metainfo.xml
+++ b/shell/linux/org.flycast.Flycast.metainfo.xml
@@ -21,7 +21,7 @@
     <screenshot><image>https://raw.githubusercontent.com/flyinghead/flycast/master/shell/imgs/screenshot4.png</image></screenshot>
   </screenshots>
   <categories>
-    <category>Games</category>
+    <category>Game</category>
     <category>Emulator</category>
   </categories>
   <url type="homepage">https://github.com/flyinghead/flycast#readme</url>


### PR DESCRIPTION
```
$ appstreamcli validate org.flycast.Flycast.metainfo.xml
W: org.flycast.Flycast:~: category-invalid Games

✘ Validation failed: warnings: 1, pedantic: 5
```