### PR TITLE
Homebrew dev improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(LIBRETRO "Build libretro core" OFF)
 option(USE_OPENGL "Use OpenGL API" ON)
 option(USE_VIDEOCORE "RPI: use the legacy Broadcom GLES libraries" OFF)
 option(APPLE_BREAKPAD "macOS: Build breakpad client and dump symbols" OFF)
+option(BUILD_MULTIPROCESSOR "win: Compile with multiple cores" ON)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/shell/cmake")
 
@@ -51,6 +52,10 @@ endif()
 if(IOS AND NOT LIBRETRO)
 	set(CMAKE_Swift_LANGUAGE_VERSION 5.0)
 	enable_language(Swift)
+endif()
+
+if(BUILD_MULTIPROCESSOR AND MSVC)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 endif()
 
 find_package(Git)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ option(USE_GLES2 "Use GLES2 API" OFF)
 option(USE_HOST_LIBZIP "Use host libzip" ON)
 option(USE_OPENMP "Use OpenMP if available" ON)
 option(USE_VULKAN "Build with Vulkan support" ON)
+option(USE_DX9 "Build with Direct3D 9 support" ON)
+option(USE_DX11 "Build with Direct3D 11 support" ON)
 option(LIBRETRO "Build libretro core" OFF)
 option(USE_OPENGL "Use OpenGL API" ON)
 option(USE_VIDEOCORE "RPI: use the legacy Broadcom GLES libraries" OFF)
@@ -1175,7 +1177,7 @@ if(USE_VULKAN)
 	endif()
 endif()
 
-if(WIN32 AND NOT LIBRETRO AND NOT WINDOWS_STORE)
+if(WIN32 AND USE_DX9 AND NOT LIBRETRO AND NOT WINDOWS_STORE)
 	set(REND_DX9_FILES
 		core/rend/dx9/d3d_overlay.h
 		core/rend/dx9/d3d_overlay.cpp
@@ -1201,13 +1203,12 @@ if(WIN32 AND NOT LIBRETRO AND NOT WINDOWS_STORE)
 		endif()
 	endif()
 
+	target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_D3D9)
 	target_link_libraries(${PROJECT_NAME} PUBLIC d3d9 d3dx9)
 endif()
 
-if(WIN32)
-	if(LIBRETRO)
-		target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_D3D11)
-	else()
+if(WIN32 AND USE_DX11)
+	if(NOT LIBRETRO)
 		target_sources(${PROJECT_NAME} PRIVATE
 			core/rend/dx11/imgui_impl_dx11.cpp
 			core/rend/dx11/imgui_impl_dx11.h)
@@ -1235,6 +1236,8 @@ if(WIN32)
 		core/rend/dx11/oit/dx11_oitrenderer.cpp
 		core/rend/dx11/oit/dx11_oitshaders.cpp
 		core/rend/dx11/oit/dx11_oitshaders.h)
+
+	target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_D3D11)
 	target_link_libraries(${PROJECT_NAME} PRIVATE d3d11 d3dcompiler)
 endif()
 

--- a/core/build.h
+++ b/core/build.h
@@ -222,11 +222,13 @@
 #if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
 #define TARGET_UWP
 #endif
-#if !defined(LIBRETRO) && !defined(TARGET_UWP)
+#ifdef HAVE_D3D9
 #define USE_DX9
 #endif
+#ifdef HAVE_D3D11
+#define USE_DX11
 #endif
-
+#endif
 
 #if !defined(LIBRETRO) && !defined(TARGET_NO_EXCEPTIONS)
 #define USE_GGPO

--- a/core/cfg/cl.cpp
+++ b/core/cfg/cl.cpp
@@ -12,43 +12,56 @@
 static int setconfig(char *arg[], int cl)
 {
 	int rv=0;
-	for(;;)
+
+	if (cl < 1)
 	{
-		if (cl<1)
-		{
-			WARN_LOG(COMMON, "-config : invalid number of parameters, format is section:key=value");
-			break;
-		}
-		std::string value(arg[1]);
+		WARN_LOG(COMMON, "-config : invalid number of parameters, format is section:key=value,section:key=value,...");
+		return rv;
+	}
+
+	std::string value(arg[1]);
+	for(;;)
+	{		
 		auto seppos = value.find(':');
 		if (seppos == std::string::npos)
 		{
-			WARN_LOG(COMMON, "-config : invalid parameter %s, format is section:key=value", value.c_str());
+			WARN_LOG(COMMON, "-config : invalid parameter %s, format is section:key=value,section:key=value,...", value.c_str());
 			break;
 		}
 		auto eqpos = value.find('=', seppos);
 		if (eqpos == std::string::npos)
 		{
-			WARN_LOG(COMMON, "-config : invalid parameter %s, format is section:key=value", value.c_str());
+			WARN_LOG(COMMON, "-config : invalid parameter %s, format is section:key=value,section:key=value,...", value.c_str());
 			break;
 		}
 
+		auto commapos = value.find(',', eqpos);
+
 		std::string sect = trim_ws(value.substr(0, seppos));
 		std::string key = trim_ws(value.substr(seppos + 1, eqpos - seppos - 1));
-		value = trim_ws(value.substr(eqpos + 1));
+		auto endofcurrent = (commapos == std::string::npos) ? value.size() : commapos;
+		std::string next = (commapos == std::string::npos) ? "" : trim_ws(value.substr(endofcurrent + 1, value.size() - endofcurrent));
+		value = trim_ws(value.substr(eqpos + 1, endofcurrent - eqpos - 1));
 
 		if (sect.empty() || key.empty())
 		{
-			WARN_LOG(COMMON, "-config : invalid parameter, format is section:key=value");
+			WARN_LOG(COMMON, "-config : invalid parameter, format is section:key=value,section:key=value,...");
 			break;
 		}
 
 		INFO_LOG(COMMON, "Virtual cfg %s:%s=%s", sect.c_str(), key.c_str(), value.c_str());
 
 		cfgSetVirtual(sect, key, value);
-		rv++;
 
-		if (cl>=3 && strcmp(arg[2],",")==0)
+		if (commapos == std::string::npos)
+			rv++;
+
+		if (commapos != std::string::npos)
+		{
+			value = next;
+			continue;
+		}
+		else if (cl>=3 && strcmp(arg[2],",")==0)
 		{
 			cl-=2;
 			arg+=2;

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -417,7 +417,7 @@ public:
 	RendererOption()
 #ifdef USE_DX9
 		: Option<RenderType>("pvr.rend", RenderType::DirectX9) {}
-#elif defined(TARGET_UWP)
+#elif defined(USE_DX11)
 		: Option<RenderType>("pvr.rend", RenderType::DirectX11) {}
 #else
 		: Option<RenderType>("pvr.rend", RenderType::OpenGL) {}

--- a/core/hw/pvr/Renderer_if.cpp
+++ b/core/hw/pvr/Renderer_if.cpp
@@ -150,7 +150,7 @@ static void rend_create_renderer()
 		renderer = rend_DirectX9();
 		break;
 #endif
-#if (defined(_WIN32) && !defined(LIBRETRO)) || defined(HAVE_D3D11)
+#ifdef USE_DX11
 	case RenderType::DirectX11:
 		renderer = rend_DirectX11();
 		break;

--- a/core/hw/sh4/modules/serial.cpp
+++ b/core/hw/sh4/modules/serial.cpp
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 #else
+#include <Windows.h>
 #include <io.h>
 #endif
 #include "types.h"
@@ -164,9 +165,9 @@ struct PTYPipe : public SerialPipe
 
 	void init()
 	{
-#if defined(__unix__) || defined(__APPLE__)
 		if (config::SerialConsole && config::SerialPTY && tty == 1)
 		{
+#if defined(__unix__) || defined(__APPLE__)
 			tty = open("/dev/ptmx", O_RDWR | O_NDELAY | O_NOCTTY | O_NONBLOCK);
 			if (tty < 0)
 			{
@@ -179,8 +180,23 @@ struct PTYPipe : public SerialPipe
 				unlockpt(tty);
 				NOTICE_LOG(BOOT, "Pseudoterminal is at %s", ptsname(tty));
 			}
-		}
+#elif defined(_WIN32)
+			if (AllocConsole())
+			{
+				SetConsoleTitle("Flycast Serial Output");
+
+				// Pipe stdout
+				HANDLE hStd = GetStdHandle(STD_OUTPUT_HANDLE);
+				tty = _open_osfhandle((intptr_t)hStd, _O_TEXT);
+				_dup2(tty, fileno(stdout));
+				SetStdHandle(STD_OUTPUT_HANDLE, (HANDLE)_get_osfhandle(fileno(stdout)));
+			}
+			else
+			{
+				ERROR_LOG(BOOT, "Cannot AllocConsole(): errno %d", GetLastError());
+			}
 #endif
+		}
 		serial_setPipe(this);
 	}
 

--- a/core/rend/dx11/dx11context_lr.cpp
+++ b/core/rend/dx11/dx11context_lr.cpp
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Flycast.  If not, see <https://www.gnu.org/licenses/>.
 */
-#ifdef HAVE_D3D11
+#ifdef LIBRETRO
 #include "dx11context_lr.h"
 #include <dxgi1_2.h>
 #include "rend/osd.h"

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1781,7 +1781,7 @@ static void gui_display_settings()
 					#ifdef USE_OPENGL
 						+ 1
 					#endif
-					#ifdef _WIN32
+					#ifdef USE_DX11
 						+ 1
 					#endif
 						;
@@ -1808,7 +1808,7 @@ static void gui_display_settings()
 					ImGui::RadioButton("DirectX 9", &renderApi, 2);
 					ImGui::NextColumn();
 #endif
-#ifdef _WIN32
+#ifdef USE_DX11
 					ImGui::RadioButton("DirectX 11", &renderApi, 3);
 					ImGui::NextColumn();
 #endif

--- a/core/wsi/switcher.cpp
+++ b/core/wsi/switcher.cpp
@@ -46,7 +46,7 @@ void initRenderApi(void *window, void *display)
 		config::RendererType = RenderType::OpenGL;
 	}
 #endif
-#ifdef _WIN32
+#ifdef USE_DX11
 	if (config::RendererType == RenderType::DirectX11 || config::RendererType == RenderType::DirectX11_OIT)
 	{
 		theDX11Context.setWindow(window, display);


### PR DESCRIPTION
Various quality of life improvements for quick iteration when doing homebrew development:

1. Gates off D3D9 config in CMake so we don't need the DirectX 9.0c SDK installed
2. Adds /MP option when compiling on Windows, else it takes forever to build
3. External serial console window on Windows (project is not configured with /SUBSYSTEM:CONSOLE, so terminal becomes detached on startup)
4. Support for short-handed "-config section:key=value,section:key=value,..." args so command line isn't so verbose