### PR TITLE
Added USE_DX9 and USE_DX11 as configurable options in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ option(USE_GLES2 "Use GLES2 API" OFF)
 option(USE_HOST_LIBZIP "Use host libzip" ON)
 option(USE_OPENMP "Use OpenMP if available" ON)
 option(USE_VULKAN "Build with Vulkan support" ON)
+option(USE_DX9 "Build with Direct3D 9 support" ON)
+option(USE_DX11 "Build with Direct3D 11 support" ON)
 option(LIBRETRO "Build libretro core" OFF)
 option(USE_OPENGL "Use OpenGL API" ON)
 option(USE_VIDEOCORE "RPI: use the legacy Broadcom GLES libraries" OFF)
@@ -1181,7 +1183,7 @@ if(USE_VULKAN)
 	endif()
 endif()
 
-if(WIN32 AND NOT LIBRETRO AND NOT WINDOWS_STORE)
+if(WIN32 AND USE_DX9 AND NOT LIBRETRO AND NOT WINDOWS_STORE)
 	set(REND_DX9_FILES
 		core/rend/dx9/d3d_overlay.h
 		core/rend/dx9/d3d_overlay.cpp
@@ -1207,14 +1209,13 @@ if(WIN32 AND NOT LIBRETRO AND NOT WINDOWS_STORE)
 		endif()
 	endif()
 
+	target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_D3D9)
 	target_link_libraries(${PROJECT_NAME} PUBLIC d3d9 d3dx9)
 	target_compile_definitions(${PROJECT_NAME} PRIVATE USE_DX9)
 endif()
 
-if(WIN32)
-	if(LIBRETRO)
-		target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_D3D11)
-	else()
+if(WIN32 AND USE_DX11)
+	if(NOT LIBRETRO)
 		target_sources(${PROJECT_NAME} PRIVATE
 			core/rend/dx11/imgui_impl_dx11.cpp
 			core/rend/dx11/imgui_impl_dx11.h)
@@ -1242,6 +1243,8 @@ if(WIN32)
 		core/rend/dx11/oit/dx11_oitrenderer.cpp
 		core/rend/dx11/oit/dx11_oitshaders.cpp
 		core/rend/dx11/oit/dx11_oitshaders.h)
+
+	target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_D3D11)
 	target_link_libraries(${PROJECT_NAME} PRIVATE d3d11 d3dcompiler)
 endif()
 

--- a/core/build.h
+++ b/core/build.h
@@ -217,8 +217,13 @@
 #if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
 #define TARGET_UWP
 #endif
+#ifdef HAVE_D3D9
+#define USE_DX9
 #endif
-
+#ifdef HAVE_D3D11
+#define USE_DX11
+#endif
+#endif
 
 #if !defined(LIBRETRO) && !defined(TARGET_NO_EXCEPTIONS)
 #define USE_GGPO

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -417,7 +417,7 @@ public:
 	RendererOption()
 #ifdef USE_DX9
 		: Option<RenderType>("pvr.rend", RenderType::DirectX9) {}
-#elif defined(TARGET_UWP)
+#elif defined(USE_DX11)
 		: Option<RenderType>("pvr.rend", RenderType::DirectX11) {}
 #else
 		: Option<RenderType>("pvr.rend", RenderType::OpenGL) {}

--- a/core/hw/pvr/Renderer_if.cpp
+++ b/core/hw/pvr/Renderer_if.cpp
@@ -270,7 +270,7 @@ static void rend_create_renderer()
 		renderer = rend_DirectX9();
 		break;
 #endif
-#if (defined(_WIN32) && !defined(LIBRETRO)) || defined(HAVE_D3D11)
+#ifdef USE_DX11
 	case RenderType::DirectX11:
 		renderer = rend_DirectX11();
 		break;

--- a/core/rend/dx11/dx11context_lr.cpp
+++ b/core/rend/dx11/dx11context_lr.cpp
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Flycast.  If not, see <https://www.gnu.org/licenses/>.
 */
-#ifdef HAVE_D3D11
+#ifdef LIBRETRO
 #include "dx11context_lr.h"
 #include <dxgi1_2.h>
 #include "rend/osd.h"

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1784,7 +1784,7 @@ static void gui_display_settings()
 					#ifdef USE_OPENGL
 						+ 1
 					#endif
-					#ifdef _WIN32
+					#ifdef USE_DX11
 						+ 1
 					#endif
 						;
@@ -1811,7 +1811,7 @@ static void gui_display_settings()
 					ImGui::RadioButton("DirectX 9", &renderApi, 2);
 					ImGui::NextColumn();
 #endif
-#ifdef _WIN32
+#ifdef USE_DX11
 					ImGui::RadioButton("DirectX 11", &renderApi, 3);
 					ImGui::NextColumn();
 #endif

--- a/core/wsi/switcher.cpp
+++ b/core/wsi/switcher.cpp
@@ -46,7 +46,7 @@ void initRenderApi(void *window, void *display)
 		config::RendererType = RenderType::OpenGL;
 	}
 #endif
-#ifdef _WIN32
+#ifdef USE_DX11
 	if (config::RendererType == RenderType::DirectX11 || config::RendererType == RenderType::DirectX11_OIT)
 	{
 		theDX11Context.setWindow(window, display);


### PR DESCRIPTION
Adds D3D9 as a configurable option so we don't need to install the DirectX 9.0c SDK if we don't want it for development. Also added D3D11 for completion's sake only.