### PR TITLE
Support for comma separated "-config section:key=value,section:key=va…

### DIFF
--- a/core/cfg/cl.cpp
+++ b/core/cfg/cl.cpp
@@ -12,43 +12,56 @@
 static int setconfig(char *arg[], int cl)
 {
 	int rv=0;
-	for(;;)
+
+	if (cl < 1)
 	{
-		if (cl<1)
-		{
-			WARN_LOG(COMMON, "-config : invalid number of parameters, format is section:key=value");
-			break;
-		}
-		std::string value(arg[1]);
+		WARN_LOG(COMMON, "-config : invalid number of parameters, format is section:key=value,section:key=value,...");
+		return rv;
+	}
+
+	std::string value(arg[1]);
+	for(;;)
+	{		
 		auto seppos = value.find(':');
 		if (seppos == std::string::npos)
 		{
-			WARN_LOG(COMMON, "-config : invalid parameter %s, format is section:key=value", value.c_str());
+			WARN_LOG(COMMON, "-config : invalid parameter %s, format is section:key=value,section:key=value,...", value.c_str());
 			break;
 		}
 		auto eqpos = value.find('=', seppos);
 		if (eqpos == std::string::npos)
 		{
-			WARN_LOG(COMMON, "-config : invalid parameter %s, format is section:key=value", value.c_str());
+			WARN_LOG(COMMON, "-config : invalid parameter %s, format is section:key=value,section:key=value,...", value.c_str());
 			break;
 		}
 
+		auto commapos = value.find(',', eqpos);
+
 		std::string sect = trim_ws(value.substr(0, seppos));
 		std::string key = trim_ws(value.substr(seppos + 1, eqpos - seppos - 1));
-		value = trim_ws(value.substr(eqpos + 1));
+		auto endofcurrent = (commapos == std::string::npos) ? value.size() : commapos;
+		std::string next = (commapos == std::string::npos) ? "" : trim_ws(value.substr(endofcurrent + 1, value.size() - endofcurrent));
+		value = trim_ws(value.substr(eqpos + 1, endofcurrent - eqpos - 1));
 
 		if (sect.empty() || key.empty())
 		{
-			WARN_LOG(COMMON, "-config : invalid parameter, format is section:key=value");
+			WARN_LOG(COMMON, "-config : invalid parameter, format is section:key=value,section:key=value,...");
 			break;
 		}
 
 		INFO_LOG(COMMON, "Virtual cfg %s:%s=%s", sect.c_str(), key.c_str(), value.c_str());
 
 		cfgSetVirtual(sect, key, value);
-		rv++;
 
-		if (cl>=3 && strcmp(arg[2],",")==0)
+		if (commapos == std::string::npos)
+			rv++;
+
+		if (commapos != std::string::npos)
+		{
+			value = next;
+			continue;
+		}
+		else if (cl>=3 && strcmp(arg[2],",")==0)
 		{
 			cl-=2;
 			arg+=2;


### PR DESCRIPTION
Adds support for specifying multiple comma separated -config options on the command line in a more natural format, so that command lines aren't so verbose.

Usage:

`-config section:key=value,section:key=value`