### PR TITLE
Enabled GDB server, compile fix for MSVC, added GDB option to config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(LIBRETRO "Build libretro core" OFF)
 option(USE_OPENGL "Use OpenGL API" ON)
 option(USE_VIDEOCORE "RPI: use the legacy Broadcom GLES libraries" OFF)
 option(APPLE_BREAKPAD "macOS: Build breakpad client and dump symbols" OFF)
+option(ENABLE_GDB_SERVER "Build with GDB debugging support" ON)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/shell/cmake")
 
@@ -80,6 +81,10 @@ endif()
 
 string(TIMESTAMP BUILD_TIMESTAMP UTC)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/core/version.h.in" "${CMAKE_CURRENT_SOURCE_DIR}/core/version.h" @ONLY)
+
+if(LIBRETRO OR WINDOWS_STORE OR ANDROID OR IOS)
+	set(ENABLE_GDB_SERVER OFF)
+endif()
 
 if(NINTENDO_SWITCH)
 	set(USE_VULKAN OFF)
@@ -1243,6 +1248,14 @@ if(WIN32)
 		core/rend/dx11/oit/dx11_oitshaders.cpp
 		core/rend/dx11/oit/dx11_oitshaders.h)
 	target_link_libraries(${PROJECT_NAME} PRIVATE d3d11 d3dcompiler)
+endif()
+
+if(ENABLE_GDB_SERVER)
+
+	target_sources(${PROJECT_NAME} PRIVATE
+		core/debug/gdb_server.cpp)
+
+	target_compile_definitions(${PROJECT_NAME} PRIVATE GDB_SERVER)
 endif()
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)" AND NOT APPLE)

--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -113,6 +113,7 @@ Option<bool> SerialConsole("Debug.SerialConsoleEnabled");
 Option<bool> SerialPTY("Debug.SerialPTY");
 Option<bool> GDB("Debug.GDBEnabled");
 Option<int> GDBPort("Debug.GDBPort", debugger::DEFAULT_PORT);
+Option<bool> GDBWaitForConnection("Debug.GDBWaitForConnection");
 Option<bool> UseReios("UseReios");
 Option<bool> FastGDRomLoad("FastGDRomLoad", false);
 

--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -18,6 +18,7 @@
 */
 #include "option.h"
 #include "network/naomi_network.h"
+#include "debug/gdb_server.h"
 
 namespace config {
 
@@ -110,6 +111,8 @@ Option<bool> EmulateFramebuffer("rend.EmulateFramebuffer", false);
 
 Option<bool> SerialConsole("Debug.SerialConsoleEnabled");
 Option<bool> SerialPTY("Debug.SerialPTY");
+Option<bool> GDB("Debug.GDBEnabled");
+Option<int> GDBPort("Debug.GDBPort", debugger::DEFAULT_PORT);
 Option<bool> UseReios("UseReios");
 Option<bool> FastGDRomLoad("FastGDRomLoad", false);
 

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -472,6 +472,8 @@ extern Option<bool> EmulateFramebuffer;
 
 extern Option<bool> SerialConsole;
 extern Option<bool> SerialPTY;
+extern Option<bool> GDB;
+extern Option<int> GDBPort;
 extern Option<bool> UseReios;
 extern Option<bool> FastGDRomLoad;
 

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -474,6 +474,7 @@ extern Option<bool> SerialConsole;
 extern Option<bool> SerialPTY;
 extern Option<bool> GDB;
 extern Option<int> GDBPort;
+extern Option<bool> GDBWaitForConnection;
 extern Option<bool> UseReios;
 extern Option<bool> FastGDRomLoad;
 

--- a/core/debug/debug_agent.h
+++ b/core/debug/debug_agent.h
@@ -34,6 +34,9 @@
 #define SIGBUS 7
 #endif
 
+#define SWAP_32(a) ((((a) & 0xff) << 24)  | (((a) & 0xff00) << 8) | (((a) >> 8) & 0xff00) | (((a) >> 24) & 0xff))
+#define SWAP_16(a) ((((a) & 0x00ff) << 8) | (((a) & 0xff00) >> 8))
+
 const std::array<Sh4RegType, 59> Sh4RegList {
 		reg_r0,
 		reg_r1,
@@ -95,9 +98,9 @@ public:
 		for (u32 i = 0; i < Sh4RegList.size(); i++)
 		{
 			if (Sh4RegList[i] == reg_sr_status)
-				allregs[i] = sh4_sr_GetFull();
+				allregs[i] = SWAP_32(sh4_sr_GetFull());
 			else if (Sh4RegList[i] != NoReg)
-				allregs[i] = *GetRegPtr(Sh4RegList[i]);
+				allregs[i] = SWAP_32(*GetRegPtr(Sh4RegList[i]));
 		}
 		*regs = &allregs[0];
 		return allregs.size();
@@ -107,7 +110,7 @@ public:
 	{
 		for (u32 i = 0; i < Sh4RegList.size(); i++)
 			if (Sh4RegList[i] != NoReg)
-				*GetRegPtr(Sh4RegList[i]) = regs[i];
+				*GetRegPtr(Sh4RegList[i]) = SWAP_32(regs[i]);
 	}
 
 	u32 readReg(u32 regNum)
@@ -116,9 +119,9 @@ public:
 			return 0;
 		Sh4RegType reg = Sh4RegList[regNum];
 		if (reg == reg_sr_status)
-			return sh4_sr_GetFull();
+			return SWAP_32(sh4_sr_GetFull());
 		if (reg != NoReg)
-			return *GetRegPtr(reg);
+			return SWAP_32(*GetRegPtr(reg));
 		return 0;
 	}
 	void writeReg(u32 regNum, u32 value)
@@ -127,9 +130,9 @@ public:
 			return;
 		Sh4RegType reg = Sh4RegList[regNum];
 		if (reg == reg_sr_status)
-			sh4_sr_SetFull(value);
+			sh4_sr_SetFull(SWAP_32(value));
 		else if (reg != NoReg)
-			*GetRegPtr(reg) = value;
+			*GetRegPtr(reg) = SWAP_32(value);
 	}
 
 	const u8 *readMem(u32 addr, u32 len)
@@ -141,14 +144,14 @@ public:
 		{
 			if (len >= 4 && (addr & 3) == 0)
 			{
-				*(u32 *)p = ReadMem32_nommu(addr);
+				*(u32 *)p = SWAP_32(ReadMem32_nommu(addr));
 				addr += 4;
 				len -= 4;
 				p += 4;
 			}
 			else if (len >= 2 && (addr & 1) == 0)
 			{
-				*(u16 *)p = ReadMem16_nommu(addr);
+				*(u16 *)p = SWAP_16(ReadMem16_nommu(addr));
 				addr += 2;
 				len -= 2;
 				p += 2;
@@ -170,14 +173,14 @@ public:
 		{
 			if (len >= 4 && (addr & 3) == 0)
 			{
-				WriteMem32_nommu(addr, *(u32 *)p);
+				WriteMem32_nommu(addr, SWAP_32(*(u32 *)p));
 				addr += 4;
 				len -= 4;
 				p += 4;
 			}
 			else if (len >= 2 && (addr & 3) == 0)
 			{
-				WriteMem16_nommu(addr, *(u16 *)p);
+				WriteMem16_nommu(addr, SWAP_16(*(u16 *)p));
 				addr += 2;
 				len -= 2;
 				p += 2;

--- a/core/debug/gdb_server.cpp
+++ b/core/debug/gdb_server.cpp
@@ -22,6 +22,7 @@
 #include "gdb_server.h"
 #include "debug_agent.h"
 #include "network/net_platform.h"
+#include "cfg/option.h"
 #include <stdexcept>
 #include <thread>
 #include <chrono>
@@ -95,10 +96,15 @@ public:
 
 	void run()
 	{
-		if (!initialised)
+		if (!initialised || thread.joinable())
 			return;
 		DEBUG_LOG(COMMON, "GdbServer starting");
 		thread = std::thread(&GdbServer::serverThread, this);
+		if (config::GDBWaitForConnection)
+		{
+			DEBUG_LOG(COMMON, "Waiting for GDB connection...");
+			agent.interrupt();
+		}
 	}
 
 	void stop()

--- a/core/debug/gdb_server.cpp
+++ b/core/debug/gdb_server.cpp
@@ -613,11 +613,11 @@ private:
 			sendPacket("OK");
 			agent.kill();
 		}
-		else if (pkt.rfind("vMustReplyEmpty", 0) == 0)
-			// Reply empty packet
-			sendPacket("");
 		else
+		{
 			WARN_LOG(COMMON, "unknown v packet: %s", pkt.c_str());
+			sendPacket("");
+		}
 	}
 
 	void restart()

--- a/core/debug/gdb_server.h
+++ b/core/debug/gdb_server.h
@@ -23,9 +23,11 @@ namespace debugger {
 // exception thrown in response to trap
 struct Stop { };
 
+	static const int DEFAULT_PORT = 3263;
+
 #ifdef GDB_SERVER
 
-	void init();
+	void init(int port);
 	void term();
 	void run();
 	void debugTrap(u32 event);
@@ -33,7 +35,7 @@ struct Stop { };
 	void subroutineReturn();
 
 #else
-	static inline void init() {}
+	static inline void init(int port) {}
 	static inline void term() {}
 	static inline void run() {}
 	static inline void debugTrap(u32 event) {}

--- a/core/emulator.cpp
+++ b/core/emulator.cpp
@@ -529,6 +529,9 @@ void Emulator::loadGame(const char *path, LoadProgress *progress)
 					LoadHle();
 				}
 			}
+
+			if (progress)
+				progress->progress = 1.0f;
 		}
 		else if (settings.platform.isArcade())
 		{
@@ -562,6 +565,15 @@ void Emulator::loadGame(const char *path, LoadProgress *progress)
 				dc_loadstate(config::SavestateSlot);
 		}
 		EventManager::event(Event::Start);
+
+		if (progress)
+		{
+			if(config::GDBWaitForConnection)
+				progress->label = "Waiting for debugger...";
+			else
+				progress->label = "Starting...";
+		}
+
 		state = Loaded;
 	} catch (...) {
 		state = Error;

--- a/core/emulator.cpp
+++ b/core/emulator.cpp
@@ -800,7 +800,7 @@ void Emulator::start()
 		Get_Sh4Interpreter(&sh4_cpu);
 		INFO_LOG(DYNAREC, "Using Interpreter");
 	}
-	EventManager::event(Event::Resume);
+
 	memwatch::protect();
 
 	if (config::ThreadedRendering)
@@ -831,6 +831,8 @@ void Emulator::start()
 	{
 		InitAudio();
 	}
+
+	EventManager::event(Event::Resume);
 }
 
 bool Emulator::checkStatus()

--- a/core/emulator.cpp
+++ b/core/emulator.cpp
@@ -568,9 +568,11 @@ void Emulator::loadGame(const char *path, LoadProgress *progress)
 
 		if (progress)
 		{
+#ifdef GDB_SERVER
 			if(config::GDBWaitForConnection)
 				progress->label = "Waiting for debugger...";
 			else
+#endif
 				progress->label = "Starting...";
 		}
 

--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -48,7 +48,8 @@ int flycast_init(int argc, char* argv[])
 	os_CreateWindow();
 	os_SetupInput();
 
-	debugger::init();
+	if(config::GDB)
+		debugger::init(config::GDBPort);
 	lua::init();
 
 	return 0;

--- a/core/rend/dx11/dx11_driver.h
+++ b/core/rend/dx11/dx11_driver.h
@@ -38,9 +38,9 @@ public:
     	ImGui_ImplDX11_NewFrame();
 	}
 
-	void renderDrawData(ImDrawData *drawData) override {
+	void renderDrawData(ImDrawData *drawData, bool gui_open) override {
 		theDX11Context.EndImGuiFrame();
-		if (gui_is_open())
+		if (gui_open)
 			frameRendered = true;
 	}
 

--- a/core/rend/dx9/dx9_driver.h
+++ b/core/rend/dx9/dx9_driver.h
@@ -37,9 +37,9 @@ public:
     	ImGui_ImplDX9_NewFrame();
 	}
 
-	void renderDrawData(ImDrawData *drawData) override {
+	void renderDrawData(ImDrawData *drawData, bool gui_open) override {
 		theDXContext.EndImGuiFrame();
-		if (gui_is_open())
+		if (gui_open)
 			frameRendered = true;
 	}
 

--- a/core/rend/gles/opengl_driver.cpp
+++ b/core/rend/gles/opengl_driver.cpp
@@ -158,10 +158,10 @@ void OpenGLDriver::newFrame()
 	ImGui_ImplOpenGL3_NewFrame();
 }
 
-void OpenGLDriver::renderDrawData(ImDrawData* drawData)
+void OpenGLDriver::renderDrawData(ImDrawData* drawData, bool gui_open)
 {
 	ImGui_ImplOpenGL3_RenderDrawData(drawData);
-	if (gui_is_open())
+	if (gui_open)
 		frameRendered = true;
 }
 

--- a/core/rend/gles/opengl_driver.h
+++ b/core/rend/gles/opengl_driver.h
@@ -31,7 +31,7 @@ public:
 	void displayCrosshairs() override;
 
 	void newFrame() override;
-	void renderDrawData(ImDrawData* drawData) override;
+	void renderDrawData(ImDrawData* drawData, bool gui_open) override;
 	void present() override;
 
 	void setFrameRendered() override {

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -400,10 +400,10 @@ static void delayedKeysUp()
 	memset(keysUpNextFrame, 0, sizeof(keysUpNextFrame));
 }
 
-static void gui_endFrame()
+static void gui_endFrame(bool gui_open)
 {
     ImGui::Render();
-    imguiDriver->renderDrawData(ImGui::GetDrawData());
+    imguiDriver->renderDrawData(ImGui::GetDrawData(), gui_open);
     delayedKeysUp();
 }
 
@@ -2673,6 +2673,15 @@ static void gui_display_loadscreen()
     ImGui::AlignTextToFramePadding();
     ImGui::SetCursorPosX(20.f * settings.display.uiScale);
 	try {
+		const char *label = gameLoader.getProgress().label;
+		if (label == nullptr)
+		{
+			if (gameLoader.ready())
+				label = "Starting...";
+			else
+				label = "Loading...";
+		}
+
 		if (gameLoader.ready())
 		{
 			if (NetworkHandshake::instance != nullptr)
@@ -2683,14 +2692,11 @@ static void gui_display_loadscreen()
 			else
 			{
 				gui_state = GuiState::Closed;
-				ImGui::Text("Starting...");
+				ImGui::Text("%s", label);
 			}
 		}
 		else
 		{
-			const char *label = gameLoader.getProgress().label;
-			if (label == nullptr)
-				label = "Loading...";
 			ImGui::Text("%s", label);
 			ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(0.557f, 0.268f, 0.965f, 1.f));
 			ImGui::ProgressBar(gameLoader.getProgress().progress, ImVec2(-1, 20.f * settings.display.uiScale), "");
@@ -2735,6 +2741,7 @@ void gui_display_ui()
 	gui_newFrame();
 	ImGui::NewFrame();
 	error_msg_shown = false;
+	bool gui_open = gui_is_open();
 
 	switch (gui_state)
 	{
@@ -2777,7 +2784,7 @@ void gui_display_ui()
 		break;
 	}
 	error_popup();
-	gui_endFrame();
+	gui_endFrame(gui_open);
 
 	if (gui_state == GuiState::Closed)
 		emu.start();
@@ -2844,7 +2851,7 @@ void gui_display_osd()
 		}
 		lua::overlay();
 
-		gui_endFrame();
+		gui_endFrame(gui_is_open());
 	}
 }
 

--- a/core/rend/imgui_driver.h
+++ b/core/rend/imgui_driver.h
@@ -31,7 +31,7 @@ public:
 	virtual ~ImGuiDriver() = default;
 
 	virtual void newFrame() = 0;
-	virtual void renderDrawData(ImDrawData* drawData) = 0;
+	virtual void renderDrawData(ImDrawData* drawData, bool gui_open) = 0;
 
 	virtual void displayVmus() {}
 	virtual void displayCrosshairs() {}

--- a/core/rend/vulkan/vulkan_driver.h
+++ b/core/rend/vulkan/vulkan_driver.h
@@ -35,7 +35,7 @@ public:
 	void newFrame() override {
 	}
 
-	void renderDrawData(ImDrawData *drawData) override
+	void renderDrawData(ImDrawData *drawData, bool gui_open) override
 	{
 		VulkanContext *context = getContext();
 		if (!context->IsValid())


### PR DESCRIPTION
Pulls in missing gdb_server.cpp and initialises GDB based on a config option, as well as an option to specify the listen port.

Added as a CMake option so that it can be disabled for consoles, mobiles, and store releases.