### PR TITLE
Support for GDB vCont and ranged stepping

### DIFF
--- a/core/emulator.h
+++ b/core/emulator.h
@@ -131,6 +131,10 @@ public:
 	 */
 	void step();
 	/**
+	 * Execute instructions while PC is with range.
+	 */
+	void stepRange(u32 from, u32 to);
+	/**
 	 * Return whether the emulator is currently running.
 	 */
 	bool running() const {
@@ -171,6 +175,8 @@ private:
 	bool singleStep = false;
 	u64 startTime = 0;
 	bool renderTimeout = false;
+	u32 stepRangeFrom = 0;
+	u32 stepRangeTo = 0;
 };
 extern Emulator emu;
 


### PR DESCRIPTION
Implements ranged stepping using vCont packets, which is a much faster way to step over multiple instructions to get to the next source line (otherwise it's a flurry of step/stop/get pc/step/stop/get pc over the network, with all the thread stop/resume overhead that comes with it).

Fixed up the thread futures not being tested for validity - these get into a bad state with a combination of GDB start/stops.

I've also added an enum for breakpoint type, with a view to add support for the rest at a later date.