### PR TITLE
android: bump min sdk

### DIFF
--- a/shell/android-studio/flycast/build.gradle
+++ b/shell/android-studio/flycast/build.gradle
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         applicationId "com.flycast.emulator"
-        minSdk 16
+        minSdk 17
         targetSdk 29
         versionCode 8
         versionName getVersionName()


### PR DESCRIPTION
https://github.com/flyinghead/flycast/blob/92fa4c041d3e51ac08d7d5b94435fbb5182ba8f4/shell/android-studio/flycast/src/main/java/com/reicast/emulator/emu/NativeGLView.java#L79-L80

```
Call requires API level 17 (current min is 16): 'android.view.View#getDisplay'
```