### PR TITLE
Cleanup metainfo file

### DIFF
--- a/shell/linux/org.flycast.Flycast.metainfo.xml
+++ b/shell/linux/org.flycast.Flycast.metainfo.xml
@@ -9,10 +9,9 @@
     <p>Flycast is a multi-platform Sega Dreamcast, Naomi and Atomiswave emulator derived from reicast.</p>
   </description>
   <content_rating type="oars-1.1" />
-  <launchable type="desktop-id">org.flycast.Flycast.desktop</launchable>
+  <launchable type="desktop-id">flycast.desktop</launchable>
   <provides>
     <binary>flycast</binary>
-    <id>flycast.desktop</id>
   </provides>
   <screenshots>
     <screenshot type="default"><image>https://raw.githubusercontent.com/flyinghead/flycast/master/shell/imgs/screenshot1.png</image></screenshot>


### PR DESCRIPTION
Remove some superfluous entries.
I built successfully the Flatpak with this file, which already renames `flycast.desktop` to `org.flycast.Flycast.desktop`.
In this repository only `flycast.desktop` exists.