### PR TITLE
Fixes for libretro on Mac

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,12 @@
     CORE_ARGS: -DLIBRETRO=ON -G Xcode -DCMAKE_BUILD_TYPE=Release
     EXTRA_PATH: Release
 
+.core-defs-osx-arm64:
+  extends: .core-defs
+  variables:
+    CORE_ARGS: -DLIBRETRO=ON -G Xcode -DCMAKE_BUILD_TYPE=Release
+    EXTRA_PATH: Release
+
 .core-defs-android:
   extends: .core-defs
   script:
@@ -42,6 +48,10 @@ include:
   # MacOS
   - project: 'libretro-infrastructure/ci-templates'
     file: 'osx-cmake-x86.yml'
+
+  # MacOS arm64
+  - project: 'libretro-infrastructure/ci-templates'
+    file: 'osx-cmake-arm64.yml'
 
   # Linux
   - project: 'libretro-infrastructure/ci-templates'
@@ -97,6 +107,12 @@ libretro-build-osx-x64:
   extends:
     - .libretro-osx-cmake-x86
     - .core-defs-osx-x64
+
+# MacOS arm 64-bit
+libretro-build-osx-arm64:
+  extends:
+    - .libretro-osx-cmake-arm64
+    - .core-defs-osx-arm64
 
 ################################### CELLULAR #################################
 # Android ARMv7a

--- a/core/emulator.cpp
+++ b/core/emulator.cpp
@@ -425,7 +425,7 @@ static void setPlatform(int platform)
 
 void Emulator::init()
 {
-	if (state != Uninitialized)
+	if (state != Uninitialized && state != Terminated)
 	{
 		verify(state == Init);
 		return;

--- a/core/emulator.cpp
+++ b/core/emulator.cpp
@@ -425,7 +425,7 @@ static void setPlatform(int platform)
 
 void Emulator::init()
 {
-	if (state != Uninitialized && state != Terminated)
+	if (state != Uninitialized)
 	{
 		verify(state == Init);
 		return;

--- a/shell/libretro/libretro.cpp
+++ b/shell/libretro/libretro.cpp
@@ -328,6 +328,12 @@ void retro_init()
 	init_disk_control_interface();
 	retro_audio_init();
 
+#if defined(__APPLE__)
+    char *data_dir = NULL;
+    if (environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &data_dir) && data_dir)
+        set_user_data_dir(std::string(data_dir) + "/");
+#endif
+
 	if (!_vmem_reserve())
 		ERROR_LOG(VMEM, "Cannot reserve memory space");
 

--- a/shell/libretro/libretro.cpp
+++ b/shell/libretro/libretro.cpp
@@ -340,7 +340,7 @@ void retro_init()
 	os_InstallFaultHandler();
 	MapleConfigMap::UpdateVibration = updateVibration;
 
-#if defined(__GNUC__) && defined(__linux__) && !defined(__ANDROID__)
+#if defined(__APPLE__) || (defined(__GNUC__) && defined(__linux__) && !defined(__ANDROID__))
 	if (!emuInited)
 #endif
 		emu.init();
@@ -359,7 +359,7 @@ void retro_deinit()
 	}
 	os_UninstallFaultHandler();
 	
-#if defined(__GNUC__) && defined(__linux__) && !defined(__ANDROID__)
+#if defined(__APPLE__) || (defined(__GNUC__) && defined(__linux__) && !defined(__ANDROID__))
 	_vmem_release();
 #else
 	emu.term();

--- a/shell/libretro/libretro.cpp
+++ b/shell/libretro/libretro.cpp
@@ -1113,6 +1113,7 @@ static bool loadGame()
 	} catch (const FlycastException& e) {
 		ERROR_LOG(BOOT, "%s", e.what());
 		gui_display_notification(e.what(), 5000);
+        retro_unload_game();
 		return false;
 	}
 


### PR DESCRIPTION
Static variables can get left around and reused following dlclose/dlopen (the manpage for dlclose is deliberately unclear about whether that will happen). RetroArch on OSX crashes when trying to load flycast a second time because the core fails to reinitialize, because it thinks it is terminated.