### PR TITLE
sdl: use target SDL2main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,6 +368,12 @@ if(NOT LIBRETRO)
 			set(SDL2_FOUND 1)
 		endif()
 
+		# SDL2::SDL2main may or may not be available. It is e.g. required by Windows GUI applications
+		if(TARGET SDL2::SDL2main)
+			# It has an implicit dependency on SDL2 functions, so it MUST be added before SDL2::SDL2 (or SDL2::SDL2-static)
+			target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2main)
+		endif()
+
 		if((APPLE OR WIN32) AND TARGET SDL2::SDL2-static)
 			target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2-static)
 		elseif(TARGET SDL2::SDL2)

--- a/core/windows/winmain.cpp
+++ b/core/windows/winmain.cpp
@@ -51,9 +51,14 @@
 #endif
 #include "profiler/fc_profiler.h"
 
+#if defined(USE_SDL) || defined(DEF_CONSOLE)
+#include <nowide/args.hpp>
+#endif
+
 #include <windows.h>
 #include <windowsx.h>
 
+#if !defined(USE_SDL) && !defined(DEF_CONSOLE)
 static PCHAR*
 	commandLineToArgvA(
 	PCHAR CmdLine,
@@ -147,6 +152,7 @@ static PCHAR*
 	(*_argc) = argc;
 	return argv;
 }
+#endif
 
 #ifndef USE_SDL
 
@@ -844,10 +850,12 @@ int remove(char const *name)
 }
 
 }
+#endif
 
-extern "C" int SDL_main(int argc, char* argv[])
+#ifdef USE_SDL
+int main(int argc, char* argv[])
 {
-
+	nowide::args _(argc, argv);
 
 #elif defined(DEF_CONSOLE)
 // DEF_CONSOLE allows you to override linker subsystem and therefore default console
@@ -856,6 +864,7 @@ extern "C" int SDL_main(int argc, char* argv[])
 
 int main(int argc, char** argv)
 {
+	nowide::args _(argc, argv);
 
 #else
 #pragma comment(linker, "/subsystem:windows")


### PR DESCRIPTION
And `nowide::args` to convert arguments to UTF-8