### PR TITLE
vulkan: lower shader version requirement

### DIFF
--- a/core/rend/vulkan/utils.h
+++ b/core/rend/vulkan/utils.h
@@ -89,7 +89,7 @@ static const char GouraudSource[] = R"(
 class VulkanSource : public ShaderSource
 {
 public:
-	VulkanSource() : ShaderSource("#version 450") {}
+	VulkanSource() : ShaderSource("#version 430") {}
 };
 
 


### PR DESCRIPTION
Verified with `glslangValidator`, `#version 430` can be used instead of `#version 450`