### PR TITLE
sdl: use _WIN32

### DIFF
--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -3,7 +3,7 @@
 #include "types.h"
 #include "cfg/cfg.h"
 #include "sdl/sdl.h"
-#ifdef WIN32
+#ifdef _WIN32
 #include <SDL_syswm.h>
 #endif
 #include <SDL_video.h>


### PR DESCRIPTION
_WIN32 is one of the predefined macros https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170
See also https://stackoverflow.com/a/74084728