### PR TITLE
ci: update mathieu-bour/setup-sentry-cli

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -74,7 +74,7 @@ jobs:
         if: ${{ steps.aws-credentials.outputs.aws-account-id != '' }}
 
       - name: Setup Sentry CLI
-        uses: mathieu-bour/setup-sentry-cli@1.2.0
+        uses: mathieu-bour/setup-sentry-cli@v1
         env:
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
         with:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -157,7 +157,7 @@ jobs:
         if: ${{ steps.aws-credentials.outputs.aws-account-id != '' }}
 
       - name: Setup Sentry CLI
-        uses: mathieu-bour/setup-sentry-cli@1.2.0
+        uses: mathieu-bour/setup-sentry-cli@v1
         env:
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
         with:


### PR DESCRIPTION
Fix warnings from https://github.com/flyinghead/flycast/actions/runs/4192576505 and https://github.com/flyinghead/flycast/actions/runs/4192576503
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: mathieu-bour/setup-sentry-cli@1.2.0. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.