### PR TITLE
openbsd patches

### DIFF
--- a/core/hw/aica/dsp_x64.cpp
+++ b/core/hw/aica/dsp_x64.cpp
@@ -35,7 +35,9 @@ constexpr size_t CodeBufferSize = 32 * 1024;
 static u8 *CodeBuffer;
 #else
 alignas(4096) static u8 CodeBuffer[CodeBufferSize]
-	#if defined(__unix__)
+	#if defined(__OpenBSD__)
+		__attribute__((section(".openbsd.mutable")));
+	#elif defined(__unix__)
 		__attribute__((section(".text")));
 	#elif defined(__APPLE__)
 		__attribute__((section("__TEXT,.text")));

--- a/core/hw/arm7/arm7_rec.cpp
+++ b/core/hw/arm7/arm7_rec.cpp
@@ -51,6 +51,8 @@ void (*EntryPoints[ARAM_SIZE_MAX / 4])();
 
 #if defined(_WIN32) || defined(TARGET_IPHONE) || defined(TARGET_ARM_MAC)
 static u8 *ARM7_TCB;
+#elif defined(__OpenBSD__)
+alignas(4096) static u8 ARM7_TCB[ICacheSize] __attribute__((section(".openbsd.mutable")));
 #elif defined(__unix__) || defined(__SWITCH__)
 alignas(4096) static u8 ARM7_TCB[ICacheSize] __attribute__((section(".text")));
 #elif defined(__APPLE__)

--- a/core/hw/naomi/naomi_m3comm.cpp
+++ b/core/hw/naomi/naomi_m3comm.cpp
@@ -53,10 +53,12 @@ struct CommBoardStat
 	u16 dummy[7];
 };
 
+#if !defined(__OpenBSD__)
 static inline u16 swap16(u16 w)
 {
 	return (w >> 8) | (w << 8);
 }
+#endif
 
 static void vblankCallback(Event event, void *param) {
 	((NaomiM3Comm *)param)->vblank();

--- a/core/hw/sh4/dyna/driver.cpp
+++ b/core/hw/sh4/dyna/driver.cpp
@@ -22,7 +22,9 @@
 static u8 *SH4_TCB;
 #else
 static u8 SH4_TCB[CODE_SIZE + TEMP_CODE_SIZE + 4096]
-#if defined(__unix__) || defined(__SWITCH__)
+#if defined(__OpenBSD__)
+	__attribute__((section(".openbsd.mutable")));
+#elif defined(__unix__) || defined(__SWITCH__)
 	__attribute__((section(".text")));
 #elif defined(__APPLE__)
 	__attribute__((section("__TEXT,.text")));

--- a/core/khronos/GL4/gl3w.c
+++ b/core/khronos/GL4/gl3w.c
@@ -115,7 +115,11 @@ static GL3WglProc (*glx_get_proc_address)(const GLubyte *);
 
 static int open_libgl(void)
 {
+#if defined(__OpenBSD__)
+	libgl = dlopen("libGL.so", RTLD_LAZY | RTLD_LOCAL);
+#elif
 	libgl = dlopen("libGL.so.1", RTLD_LAZY | RTLD_LOCAL);
+#endif
 	if (!libgl)
 		return GL3W_ERROR_LIBRARY_OPEN;
 

--- a/core/khronos/GL4/gl3w.c
+++ b/core/khronos/GL4/gl3w.c
@@ -117,7 +117,7 @@ static int open_libgl(void)
 {
 #if defined(__OpenBSD__)
 	libgl = dlopen("libGL.so", RTLD_LAZY | RTLD_LOCAL);
-#elif
+#else
 	libgl = dlopen("libGL.so.1", RTLD_LAZY | RTLD_LOCAL);
 #endif
 	if (!libgl)

--- a/core/linux/context.cpp
+++ b/core/linux/context.cpp
@@ -21,7 +21,11 @@
 
 //////
 
+#if defined(__OpenBSD__)
 #define MCTX(p) (((ucontext_t *)(segfault_ctx)) p)
+#else
+#define MCTX(p) (((ucontext_t *)(segfault_ctx))->uc_mcontext p)
+#endif
 template <bool ToSegfault, typename Tctx, typename Tseg>
 static void bicopy(Tctx& ctx, Tseg& seg)
 {

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -202,7 +202,7 @@ void input_sdl_init()
 
 	checkRawInput();
 
-#ifdef __SWITCH__
+#if defined(__SWITCH__) || defined(__OpenBSD__)
     // when railed, both joycons are mapped to joystick #0,
     // else joycons are individually mapped to joystick #0, joystick #1, ...
     // https://github.com/devkitPro/SDL/blob/switch-sdl2/src/joystick/switch/SDL_sysjoystick.c#L45


### PR DESCRIPTION
Before I submit a port for OpenBSD for flycast, I would like to submit some patches. On OpenBSD 7.2 -current, BSS is now immutable and mprotect can't work. Mark it as mutable to allow mprotect to work. This is the main change for OpenBSD as of 7.2 -current (I had it working in 7.1.)

I applied a similar fix for the desmume port:
https://marc.info/?l=openbsd-ports&m=167055339501257&w=2

More information on mimmutable:
https://marc.info/?l=openbsd-tech&m=166874067828564&w=2

Moreover, I've included other fixes.  I'm able to run flycast on OpenBSD with this and some other cmakelists changes, which I have omitted for ease of review.

Original issue where you helped me: https://github.com/libretro/flycast/issues/624