### PR TITLE
Only compile x86_64 for osx-x86_64, rather than universal

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@
 .core-defs-osx-x64:
   extends: .core-defs
   variables:
-    CORE_ARGS: -DLIBRETRO=ON -G Xcode -DCMAKE_BUILD_TYPE=Release
+    CORE_ARGS: -DLIBRETRO=ON -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=x86_64
     EXTRA_PATH: Release
 
 .core-defs-osx-arm64:


### PR DESCRIPTION
When setting up the libretro steam pipeline, because some cores have different build settings across x86_64/arm64, it's easier to build them individually.