### PR TITLE
(UWP) AppxManifest Tweaks

### DIFF
--- a/shell/uwp/package.appxManifest
+++ b/shell/uwp/package.appxManifest
@@ -38,9 +38,10 @@
 		<Capability Name="codeGeneration"/>
 		<Capability Name="internetClientServer"/>
 		<Capability Name="privateNetworkClientServer"/>
-    <rescap:Capability Name="runFullTrust"/>
-    <rescap:Capability Name="broadFileSystemAccess" />
-    <uap:Capability Name="removableStorage" />
-    <DeviceCapability Name="microphone"/>
+		<rescap:Capability Name="runFullTrust"/>
+		<rescap:Capability Name="broadFileSystemAccess" />
+		<rescap:Capability Name="expandedResources" />
+		<uap:Capability Name="removableStorage" />
+		<DeviceCapability Name="microphone"/>
 	</Capabilities>
 </Package>


### PR DESCRIPTION
- Fixes some indentation in the file.
- Adds back `expandedResources` which was originally removed in PR #753 since it seemed to cause a bug in the Xbox UI. Turns out the issue was not caused by this capability, but by an OS Update that caused this issue in Retail Mode only. This issue is not present in Dev Mode, so I might as well add it back.