### PR TITLE
remove unused iconv.h include

### DIFF
--- a/core/log/StringUtil.h
+++ b/core/log/StringUtil.h
@@ -7,7 +7,6 @@ constexpr u32 CODEPAGE_WINDOWS_1252 = 1252;
 #else
 #include <codecvt>
 #include <errno.h>
-#include <iconv.h>
 #include <locale.h>
 #endif
 


### PR DESCRIPTION
Simplify building for OpenBSD otherwise:
> -I/usr/local/include is needed for the compiler to find iconv.h, as the base compiler does not look under /usr/local/include by default.

Source: https://citra-emu.org/wiki/building-for-openbsd/