### PR TITLE
Set `header()` and `OptionArrowButtons()` alpha to 1.0f

### DIFF
--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -650,9 +650,11 @@ static void gui_display_commands()
 inline static void header(const char *title)
 {
 	ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.f, 0.5f)); // Left
+	ImGui::PushStyleVar(ImGuiStyleVar_DisabledAlpha, 1.0f);
 	ImGui::BeginDisabled();
 	ImGui::ButtonEx(title, ImVec2(-1, 0));
 	ImGui::EndDisabled();
+	ImGui::PopStyleVar();
 	ImGui::PopStyleVar();
 }
 

--- a/core/rend/gui_util.cpp
+++ b/core/rend/gui_util.cpp
@@ -521,9 +521,11 @@ bool OptionArrowButtons(const char *name, config::Option<int>& option, int min, 
 	ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyle().Colors[ImGuiCol_FrameBg]);
 	float width = ImGui::CalcItemWidth() - innerSpacing * 2.0f - ImGui::GetFrameHeight() * 2.0f;
 	std::string id = "##" + std::string(name);
+	ImGui::PushStyleVar(ImGuiStyleVar_DisabledAlpha, 1.0f);
 	ImGui::BeginDisabled();
 	ImGui::ButtonEx((std::to_string((int)option) + id).c_str(), ImVec2(width, 0));
 	ImGui::EndDisabled();
+	ImGui::PopStyleVar();
 	ImGui::PopStyleColor();
 	ImGui::PopStyleVar();
 


### PR DESCRIPTION
So it doesn't look like disabled
<img width="526" alt="image" src="https://github.com/flyinghead/flycast/assets/602245/776e6532-2311-4040-8205-bb29680928fb">
