### PR TITLE
Typo in GUI.

### DIFF
--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1593,7 +1593,7 @@ static void gui_display_settings()
 #endif // !TARGET_IPHONE
 
 			OptionCheckbox("Box Art Game List", config::BoxartDisplayMode,
-					"Display game covert art in the game list.");
+					"Display game cover art in the game list.");
 			OptionCheckbox("Fetch Box Art", config::FetchBoxart,
 					"Fetch cover images from TheGamesDB.net.");
 			if (OptionCheckbox("Hide Legacy Naomi Roms", config::HideLegacyNaomiRoms,


### PR DESCRIPTION
"Covert art" → "cover art".

Despite how intriguing the concept of covert art may sound.