### PR TITLE
Fix Spout2 MinGW libzip error

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           # Unlink and re-link to prevent errors when github mac runner images install python outside of brew. See https://github.com/actions/setup-python/issues/577
           brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
-          brew update
+          brew update || :
           brew install libao ldid ninja pulseaudio
           VULKAN_VER=1.3.250.1 && aria2c https://sdk.lunarg.com/sdk/download/$VULKAN_VER/mac/vulkansdk-macos-$VULKAN_VER.dmg
           hdiutil attach ./vulkansdk-macos-*.dmg

--- a/.gitmodules
+++ b/.gitmodules
@@ -27,4 +27,4 @@
 	url=https://github.com/vkedwardli/Syphon-Framework.git
 [submodule "core/deps/Spout"]
 	path = core/deps/Spout
-	url = https://github.com/leadedge/Spout2.git
+	url = https://github.com/vkedwardli/Spout2.git


### PR DESCRIPTION
Fix libzip error `rend/gui.cpp:2941 E[BOOT]: Cannot open xxxxx.zip`, caused by Spout2 MinGW build linking MSVC Universal C Runtime.

Updated Spout2 to use remove the UCRT dependency

p.s. Ignore `brew update` error also