### PR TITLE
macOS: Enable clipboard functions and corresponding menu items

### DIFF
--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -165,6 +165,9 @@ static ImGuiKey keycodeToImGuiKey(u8 keycode)
 		case 0xE1:
 		case 0xE5:
 			return ImGuiMod_Shift;
+		case 0xE3:
+		case 0xE7:
+			return ImGuiMod_Super;
 		default: return ImGuiKey_None;
 	}
 }

--- a/shell/apple/emulator-osx/emulator-osx/SDLMain.mm
+++ b/shell/apple/emulator-osx/emulator-osx/SDLMain.mm
@@ -73,6 +73,57 @@ static NSString *getApplicationName(void)
     SDL_PushEvent(&event);
 }
 
+- (void)undoAction:(id)sender
+{
+    gui_keyboard_key(0xE3, true); // Cmd
+    gui_keyboard_key(0x1D, true); // Z
+    gui_keyboard_key(0x1D, false);
+    gui_keyboard_key(0xE3, false);
+}
+
+- (void)redoAction:(id)sender
+{
+    gui_keyboard_key(0xE3, true); // Cmd
+    gui_keyboard_key(0xE1, true); // Shift
+    gui_keyboard_key(0x1D, true); // Z
+    gui_keyboard_key(0x1D, false);
+    gui_keyboard_key(0xE1, false);
+    gui_keyboard_key(0xE3, false);
+}
+
+- (void)cutAction:(id)sender
+{
+    gui_keyboard_key(0xE3, true); // Cmd
+    gui_keyboard_key(0x1B, true); // X
+    gui_keyboard_key(0x1B, false);
+    gui_keyboard_key(0xE3, false);
+}
+
+- (void)copyAction:(id)sender
+{
+    gui_keyboard_key(0xE3, true); // Cmd
+    gui_keyboard_key(0x06, true); // C
+    gui_keyboard_key(0x06, false);
+    gui_keyboard_key(0xE3, false);
+}
+
+- (void)pasteAction:(id)sender
+{
+    gui_keyboard_key(0xE3, true); // Cmd
+    gui_keyboard_key(0x19, true); // V
+    gui_keyboard_key(0x19, false);
+    gui_keyboard_key(0xE3, false);
+}
+
+- (void)selectAllAction:(id)sender
+{
+    gui_keyboard_key(0xE3, true); // Cmd
+    gui_keyboard_key(0x04, true); // A
+    gui_keyboard_key(0x04, false);
+    gui_keyboard_key(0xE3, false);
+}
+
+
 @end
 
 /* The main class of the application, the application's delegate */
@@ -146,12 +197,26 @@ static void setApplicationMenu(void)
     [menuItem setSubmenu:appleMenu];
     [[NSApp mainMenu] addItem:menuItem];
     
+    NSMenuItem *editMenuItem = [[NSMenuItem alloc] initWithTitle:@"" action:nil keyEquivalent:@""];
+    NSMenu *editMenu = [[NSMenu alloc] initWithTitle:@"Edit"];
+    [editMenu addItemWithTitle:@"Undo" action:@selector(undoAction:) keyEquivalent:@"z"];
+    [editMenu addItemWithTitle:@"Redo" action:@selector(redoAction:) keyEquivalent:@"Z"];
+    [editMenu addItem:[NSMenuItem separatorItem]];
+    [editMenu addItemWithTitle:@"Cut" action:@selector(cutAction:) keyEquivalent:@"x"];
+    [editMenu addItemWithTitle:@"Copy" action:@selector(copyAction:) keyEquivalent:@"c"];
+    [editMenu addItemWithTitle:@"Paste" action:@selector(pasteAction:) keyEquivalent:@"v"];
+    [editMenu addItemWithTitle:@"Select All" action:@selector(selectAllAction:) keyEquivalent:@"a"];
+    [editMenuItem setSubmenu:editMenu];
+    [[NSApp mainMenu] addItem:editMenuItem];
+    
     /* Tell the application object that this is now the application menu */
     [NSApp setAppleMenu:appleMenu];
     
     /* Finally give up our references to the objects */
     [appleMenu release];
     [menuItem release];
+    [editMenuItem release];
+    [editMenu release];
 }
 
 /* Create a window menu */

--- a/shell/apple/emulator-osx/emulator-osx/osx-main.mm
+++ b/shell/apple/emulator-osx/emulator-osx/osx-main.mm
@@ -51,6 +51,10 @@ void os_SetWindowText(const char * text) {
 }
 
 void os_DoEvents() {
+#if defined(USE_SDL)
+	NSMenuItem *editMenuItem = [[NSApp mainMenu] itemAtIndex:1];
+	[editMenuItem setEnabled:SDL_IsTextInputActive()];
+#endif
 }
 
 void UpdateInputState() {


### PR DESCRIPTION
<img width="294" alt="image" src="https://github.com/flyinghead/flycast/assets/602245/d2860f76-d289-4014-b7dd-5f228f8d2253">

Menu search:
<img width="361" alt="image" src="https://github.com/flyinghead/flycast/assets/602245/2752d7e6-d9ae-4a6c-8448-0a2ab5bc0694">


When using hotkey:
![Jul-06-2023 20-14-43](https://github.com/flyinghead/flycast/assets/602245/811ccdce-6133-4682-9f5f-0ee268b129df)



- Is the implementation of `NSMenu`'s action necessary?
   - Yes, it is required for accessibility / automation / menu searching
- Is disabling the Edit menu when "text input is not in focus" necessary?
   - No, but it is just a simple toggle. The proper way of implementing it would be detecting if text is actually highlighted before enabling the Copy menu. (like TextEdit)


