### PR TITLE
cmake: exclude nowide tests from unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -592,7 +592,7 @@ target_sources(${PROJECT_NAME} PRIVATE
 		core/deps/chdpsr/cdipsr.cpp
 		core/deps/chdpsr/cdipsr.h)
 
-add_subdirectory(core/deps/nowide)
+add_subdirectory(core/deps/nowide EXCLUDE_FROM_ALL)
 target_compile_definitions(nowide PRIVATE $<$<BOOL:${NINTENDO_SWITCH}>:_DEFAULT_SOURCE>)
 target_link_libraries(${PROJECT_NAME} PRIVATE nowide::nowide)
 


### PR DESCRIPTION
https://github.com/flyinghead/flycast/actions/runs/5477993379/jobs/9977856592#step:12:209