### PR TITLE
vk: modernize device properties retrieval

### DIFF
--- a/core/rend/vulkan/vulkan_context.h
+++ b/core/rend/vulkan/vulkan_context.h
@@ -103,8 +103,6 @@ public:
 	float GetMaxSamplerAnisotropy() const { return samplerAnisotropy ? maxSamplerAnisotropy : 1.f; }
 	bool SupportsDedicatedAllocation() const { return dedicatedAllocationSupported; }
 	const VMAllocator& GetAllocator() const { return allocator; }
-	bool IsUnifiedMemory() const { return unifiedMemory; }
-	u32 GetMaxStorageBufferRange() const { return maxStorageBufferRange; }
 	vk::DeviceSize GetMaxMemoryAllocationSize() const { return maxMemoryAllocationSize; }
 	u32 GetVendorID() const { return vendorID; }
 	vk::CommandBuffer PrepareOverlay(bool vmu, bool crosshair);
@@ -162,7 +160,6 @@ private:
 	u32 presentQueueIndex = 0;
 	vk::DeviceSize uniformBufferAlignment = 0;
 	vk::DeviceSize storageBufferAlignment = 0;
-	u32 maxStorageBufferRange = 0;
 	vk::DeviceSize maxMemoryAllocationSize = 0xFFFFFFFFu;
 	bool optimalTilingSupported565 = false;
 	bool optimalTilingSupported1555 = false;
@@ -171,7 +168,6 @@ private:
 	bool samplerAnisotropy = false;
 	float maxSamplerAnisotropy = 0.f;
 	bool dedicatedAllocationSupported = false;
-	bool unifiedMemory = false;
 	u32 vendorID = 0;
 	int swapInterval = 1;
 	vk::UniqueDevice device;


### PR DESCRIPTION
- Using Vulkan-Hpp, we can simplify some calls to retrieve device properties
- `vkGetPhysicalDeviceProperties2` (used by `physicalDevice.getProperties2<vk::PhysicalDeviceProperties2, vk::PhysicalDeviceMaintenance3Properties>();`) requires to check if the device api version is >= 1.1.
> Physical-device-level functionality or behavior added by a [new core version](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#versions) of the API must not be used unless it is supported by the physical device as determined by [VkPhysicalDeviceProperties](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkPhysicalDeviceProperties)::apiVersion and the specified version of [VkApplicationInfo](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkApplicationInfo)::apiVersion.

Source: https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fundamentals-validusage-versions
- Remove unused variables `maxStorageBufferRange` and `unifiedMemory`