### PR TITLE
sentry: use new syntax for uploading files

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -87,7 +87,7 @@ jobs:
           VERSION=$(git describe --tags --always)
           sentry-cli releases new "$VERSION"
           sentry-cli releases set-commits "$VERSION" --auto
-          sentry-cli upload-dif symbols 
+          sentry-cli debug-files upload symbols
         shell: bash
         env:
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -172,7 +172,7 @@ jobs:
           VERSION=$(git describe --tags --always)
           sentry-cli releases new "$VERSION"
           sentry-cli releases set-commits "$VERSION" --auto
-          sentry-cli upload-dif symbols
+          sentry-cli debug-files upload symbols
         shell: bash
         env:
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}


### PR DESCRIPTION
The old command `upload-dif`/`upload-dsym` are [aliases](https://github.com/getsentry/sentry-cli/blob/da6b26a4769035059aae7d3ffa1710c883f8a2c6/src/commands/upload_dif.rs#L1) to the `debug-files upload` in `v2` of `sentry-cli`.

