### PR TITLE
[input] fix LT2/RT2 mapping save

### DIFF
--- a/core/input/mapping.cpp
+++ b/core/input/mapping.cpp
@@ -50,8 +50,8 @@ button_list[] =
 	{ EMU_BTN_FFORWARD, "emulator", "btn_fforward" },
 	{ DC_AXIS_LT, "compat", "btn_trigger_left" },
 	{ DC_AXIS_RT, "compat", "btn_trigger_right" },
-	{ DC_AXIS_LT2, "compat", "btn_trigger_left2" },
-	{ DC_AXIS_RT2, "compat", "btn_trigger_right2" },
+	{ DC_AXIS_LT2, "compat", "btn_trigger2_left" },
+	{ DC_AXIS_RT2, "compat", "btn_trigger2_right" },
 	{ DC_AXIS_UP, "compat", "btn_analog_up" },
 	{ DC_AXIS_DOWN, "compat", "btn_analog_down" },
 	{ DC_AXIS_LEFT, "compat", "btn_analog_left" },
@@ -87,8 +87,8 @@ axis_list[] =
 	{ DC_AXIS3_DOWN,  "", "axis3_down", "", "" },
 	{ DC_AXIS_LT, "dreamcast", "axis_trigger_left",  "compat", "axis_trigger_left_inverted" },
 	{ DC_AXIS_RT, "dreamcast", "axis_trigger_right", "compat", "axis_trigger_right_inverted" },
-	{ DC_AXIS_LT2, "dreamcast", "axis_trigger_left2",   "compat", "axis_trigger_left2_inverted" },
-	{ DC_AXIS_RT2, "dreamcast", "axis_trigger_right2", "compat", "axis_trigger_right2_inverted" },
+	{ DC_AXIS_LT2, "dreamcast", "axis_trigger2_left",   "compat", "axis_trigger2_left_inverted" },
+	{ DC_AXIS_RT2, "dreamcast", "axis_trigger2_right", "compat", "axis_trigger2_right_inverted" },
 
 	// legacy (v2)
 	{ DC_AXIS_RIGHT, "dreamcast", "axis_x", "compat", "axis_x_inverted" },


### PR DESCRIPTION
`btn_trigger_left2` and `btn_trigger_right2` were mapped to port2.
So rename them to `btn_trigger2_left`, `btn_trigger2_right`.