### PR TITLE
DX11: Use high performance GPU on Windows 10 (1803 or later)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1375,7 +1375,7 @@ if(WIN32 AND USE_DX11)
 		core/rend/dx11/oit/dx11_oitshaders.h)
 
 	target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_D3D11)
-	target_link_libraries(${PROJECT_NAME} PRIVATE d3d11 d3dcompiler)
+	target_link_libraries(${PROJECT_NAME} PRIVATE d3d11 d3dcompiler dxgi)
 endif()
 
 if(ENABLE_GDB_SERVER)


### PR DESCRIPTION
I found that some players are using the integrated GPU:
![telegram-cloud-photo-size-5-6307335568291380193-y](https://github.com/flyinghead/flycast/assets/602245/5dc3ea7e-da9e-46ac-84f2-c6b25e83f2f0)

This can be fixed by manually selecting the appropriate preference. 
![telegram-cloud-photo-size-5-6307335568291380232-y](https://github.com/flyinghead/flycast/assets/602245/b401d207-0bd3-4572-9ab9-bef076889b1b)

But I guess we should use the high performance GPU by default.

Things to verify:
- [x] UWP Build
- [x] Computer with single GPU
- [ ] Computer with iGPU + dGPU
- [ ] WIndows 7