### PR TITLE
Increase L2+ / R2+ trigger sensitivity for digital buttons

### DIFF
--- a/core/input/gamepad_device.cpp
+++ b/core/input/gamepad_device.cpp
@@ -296,7 +296,11 @@ bool GamepadDevice::gamepad_axis_input(u32 code, int value)
 		{
 			//printf("B-AXIS %d Mapped to %d -> %d\n", key, value, v);
 			// TODO hysteresis?
-			if (std::abs(v) < 16384)
+			int threshold = 16384;
+			if ( code == leftTrigger || code == rightTrigger )
+				threshold = 100;
+				
+			if (std::abs(v) < threshold)
 				kcode[port] |=  key; // button released
 			else
 				kcode[port] &= ~key; // button pressed

--- a/core/input/gamepad_device.h
+++ b/core/input/gamepad_device.h
@@ -110,6 +110,8 @@ protected:
 	std::shared_ptr<InputMapping> input_mapper;
 	bool rumbleEnabled = false;
 	int rumblePower = 100;
+	u32 leftTrigger = ~0;
+	u32 rightTrigger = ~0;
 
 private:
 	bool handleButtonInput(int port, DreamcastKey key, bool pressed);

--- a/core/sdl/sdl_gamepad.h
+++ b/core/sdl/sdl_gamepad.h
@@ -413,8 +413,6 @@ private:
 	float vib_inclination = 0;
 	double vib_stop_time = 0;
 	SDL_GameController *sdl_controller = nullptr;
-	u32 leftTrigger = ~0;
-	u32 rightTrigger = ~0;
 	static std::map<SDL_JoystickID, std::shared_ptr<SDLGamepad>> sdl_gamepads;
 };
 

--- a/shell/android-studio/flycast/src/main/jni/src/android_gamepad.h
+++ b/shell/android-studio/flycast/src/main/jni/src/android_gamepad.h
@@ -72,7 +72,7 @@ template<bool Arcade = false, bool Gamepad = false>
 class DefaultInputMapping : public InputMapping
 {
 public:
-	DefaultInputMapping(const AndroidGamepadDevice& gamepad);
+	DefaultInputMapping(AndroidGamepadDevice& gamepad);
 };
 
 class ShieldRemoteInputMapping : public InputMapping
@@ -216,6 +216,12 @@ public:
 		}
 	}
 
+	void set_trigger_axes(u32 left_axis_code, u32 right_axis_code)
+	{
+		leftTrigger = left_axis_code;
+		rightTrigger = right_axis_code;
+	}
+
 	static std::shared_ptr<AndroidGamepadDevice> GetAndroidGamepad(int id)
 	{
 		auto it = android_gamepads.find(id);
@@ -338,7 +344,7 @@ private:
 std::map<int, std::shared_ptr<AndroidGamepadDevice>> AndroidGamepadDevice::android_gamepads;
 
 template<bool Arcade, bool Gamepad>
-inline DefaultInputMapping<Arcade, Gamepad>::DefaultInputMapping(const AndroidGamepadDevice& gamepad)
+inline DefaultInputMapping<Arcade, Gamepad>::DefaultInputMapping(AndroidGamepadDevice& gamepad)
 {
 	name = Arcade ? Gamepad ? "Arcade Gamepad" : "Arcade Hitbox" : "Default";
 	int ltAxis = AXIS_LTRIGGER;
@@ -453,6 +459,8 @@ inline DefaultInputMapping<Arcade, Gamepad>::DefaultInputMapping(const AndroidGa
 	set_axis(DC_AXIS_RIGHT, AXIS_X, true);
 	set_axis(DC_AXIS_UP, AXIS_Y, false);
 	set_axis(DC_AXIS_DOWN, AXIS_Y, true);
+
+	gamepad.set_trigger_axes(ltAxis, rtAxis);
 
 	dirty = false;
 }


### PR DESCRIPTION
Only reduce the threshold for Dreamcast digital buttons, when the target axis is L2 (leftTrigger) or R2 (rightTrigger).

Fixes #1188.