### PR TITLE
Add Dreamcast 32MB RAM Mod

### DIFF
--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -121,6 +121,7 @@ Option<int> GDBPort("Debug.GDBPort", debugger::DEFAULT_PORT);
 Option<bool> GDBWaitForConnection("Debug.GDBWaitForConnection");
 Option<bool> UseReios("UseReios");
 Option<bool> FastGDRomLoad("FastGDRomLoad", false);
+Option<bool> RamMod32MB("Dreamcast.RamMod32MB", false);
 
 Option<bool> OpenGlChecks("OpenGlChecks", false, "validate");
 

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -480,6 +480,7 @@ extern Option<int> GDBPort;
 extern Option<bool> GDBWaitForConnection;
 extern Option<bool> UseReios;
 extern Option<bool> FastGDRomLoad;
+extern Option<bool> RamMod32MB;
 
 extern Option<bool> OpenGlChecks;
 

--- a/core/emulator.cpp
+++ b/core/emulator.cpp
@@ -420,7 +420,7 @@ static void setPlatform(int platform)
 	switch (platform)
 	{
 	case DC_PLATFORM_DREAMCAST:
-		settings.platform.ram_size = 16_MB;
+		settings.platform.ram_size = config::RamMod32MB ? 32_MB : 16_MB;
 		settings.platform.vram_size = 8_MB;
 		settings.platform.aram_size = 2_MB;
 		settings.platform.bios_size = 2_MB;

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -2423,9 +2423,11 @@ static void gui_display_settings()
 	            OptionCheckbox("Serial Console", config::SerialConsole,
 	            		"Dump the Dreamcast serial console to stdout");
 #endif
-				OptionCheckbox("Dreamcast 32MB RAM Mod", config::RamMod32MB,
-	            		"Enables 32MB RAM Mod for Dreamcast. May affect compatibility");
-
+				{
+					DisabledScope scope(game_started);
+					OptionCheckbox("Dreamcast 32MB RAM Mod", config::RamMod32MB,
+						"Enables 32MB RAM Mod for Dreamcast. May affect compatibility");
+				}
 	            OptionCheckbox("Dump Textures", config::DumpTextures,
 	            		"Dump all textures into data/texdump/<game id>");
 

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -2423,6 +2423,9 @@ static void gui_display_settings()
 	            OptionCheckbox("Serial Console", config::SerialConsole,
 	            		"Dump the Dreamcast serial console to stdout");
 #endif
+				OptionCheckbox("Dreamcast 32MB RAM Mod", config::RamMod32MB,
+	            		"Enables 32MB RAM Mod for Dreamcast. May affect compatibility");
+
 	            OptionCheckbox("Dump Textures", config::DumpTextures,
 	            		"Dump all textures into data/texdump/<game id>");
 

--- a/core/serialize.h
+++ b/core/serialize.h
@@ -101,6 +101,13 @@ public:
 			throw Exception("Unsupported version");
 		if (_version > Current)
 			throw Exception("Version too recent");
+
+		if(_version >= V41 && settings.platform.isConsole()) {
+			deserialize(_ram_size);
+			if (_ram_size != settings.platform.ram_size) {
+				throw Exception("Select RAM Size doesn't match Save State");
+		}
+	}
 	}
 
 	template<typename T>
@@ -148,6 +155,7 @@ private:
 	}
 
 	Version _version;
+	u32 _ram_size;
 	const u8 *data;
 };
 
@@ -162,6 +170,8 @@ public:
 	{
 		Version v = Current;
 		serialize(v);
+		if (settings.platform.isConsole())
+			serialize(settings.platform.ram_size);
 	}
 
 	template<typename T>

--- a/core/serialize.h
+++ b/core/serialize.h
@@ -67,7 +67,8 @@ public:
 		V39,
 		V40,
 		V41,
-		Current = V41,
+		V42,
+		Current = V42,
 
 		Next = Current + 1,
 	};
@@ -102,7 +103,7 @@ public:
 		if (_version > Current)
 			throw Exception("Version too recent");
 
-		if(_version >= V41 && settings.platform.isConsole())
+		if(_version >= V42 && settings.platform.isConsole())
 		{
 			u32 ramSize;
 			deserialize(ramSize);

--- a/core/serialize.h
+++ b/core/serialize.h
@@ -102,10 +102,12 @@ public:
 		if (_version > Current)
 			throw Exception("Version too recent");
 
-		if(_version >= V41 && settings.platform.isConsole()) {
-			deserialize(_ram_size);
-			if (_ram_size != settings.platform.ram_size) {
-				throw Exception("Select RAM Size doesn't match Save State");
+		if(_version >= V41 && settings.platform.isConsole())
+		{
+			u32 ramSize;
+			deserialize(ramSize);
+			if (ramSize != settings.platform.ram_size) {
+				throw Exception("Selected RAM Size doesn't match Save State");
 		}
 	}
 	}
@@ -155,7 +157,6 @@ private:
 	}
 
 	Version _version;
-	u32 _ram_size;
 	const u8 *data;
 };
 

--- a/shell/libretro/libretro_core_options.h
+++ b/shell/libretro/libretro_core_options.h
@@ -690,6 +690,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
 #endif
    },
    {
+      CORE_OPTION_NAME "_dc_32mb_mod",
+      "Dreamcast 32MB RAM Mod",
+      NULL,
+      "Enables 32MB RAM Mod for Dreamcast. May affect compatibility",
+      NULL,
+      "hacks",
+      {
+         { "disabled", NULL },
+         { "enabled", NULL },
+         {  NULL, NULL },
+      },
+      "disabled",
+   },
+   {
       CORE_OPTION_NAME "_sh4clock",
       "SH4 CPU under/overclock",
       NULL,

--- a/shell/libretro/option.cpp
+++ b/shell/libretro/option.cpp
@@ -101,6 +101,7 @@ Option<bool> UseReios(CORE_OPTION_NAME "_hle_bios");
 
 Option<bool> OpenGlChecks("", false);
 Option<bool> FastGDRomLoad(CORE_OPTION_NAME "_gdrom_fast_loading", false);
+Option<bool> RamMod32MB(CORE_OPTION_NAME "_dc_32mb_mod", false);
 
 //Option<std::vector<std::string>, false> ContentPath("");
 //Option<bool, false> HideLegacyNaomiRoms("", true);

--- a/tests/src/serialize_test.cpp
+++ b/tests/src/serialize_test.cpp
@@ -32,7 +32,7 @@ TEST_F(SerializeTest, SizeTest)
 	std::vector<char> data(30000000);
 	Serializer ser(data.data(), data.size());
 	dc_serialize(ser);
-	ASSERT_EQ(28191378u, ser.size());
+	ASSERT_EQ(28191382u, ser.size());
 }
 
 


### PR DESCRIPTION
This change adds support for the Dreamcast 32MB Mod as detailed here: [tsowell's original blog post](https://blog.ldtlb.com/2020/06/21/dreamcast-32mb-ram-upgrade.html) and 
[32MB Mod Wiki Page](https://dreamcast.wiki/32MB_RAM_expansion)

Image showing new setting:
![image](https://github.com/flyinghead/flycast/assets/2065936/f48b4f3e-ce0a-41b9-bc06-90bd6f4b0743)

[Support was added to KallistiOS](https://github.com/KallistiOS/KallistiOS/pull/82) (Open Source SDK for Dreamcast/NAOMI) for detection and usage of the 32MB modification in Janurary. 

Tested using the [KOS memtest32](https://github.com/KallistiOS/KallistiOS/blob/master/examples/dreamcast/basic/memtest32/main.c) example program.

32MB Mod Disabled:
```
This console has 16777216 bytes of system memory,
 with top of memory located at 0x8d000000.

Beginning memtest routine...
 Base address: 0x8c100000
 Number of bytes to test: 15663104
  memTestDataBus: PASS
  memTestAddressBus: PASS
  memTestDevice: PASS
Test passed!
```

32MB Mod Enabled:
```
This console has 33554432 bytes of system memory,
 with top of memory located at 0x8e000000.

Beginning memtest routine...
 Base address: 0x8c100000
 Number of bytes to test: 32440320
  memTestDataBus: PASS
  memTestAddressBus: PASS
  memTestDevice: PASS
Test passed!
```
