### PR TITLE
Ignore Mouse Capture when Left Ctrl or Left ALT is mapped to a Dreamcast Key

### DIFF
--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -254,7 +254,27 @@ void input_sdl_handle()
 				checkRawInput();
 				if (event.key.repeat == 0)
 				{
-					auto is_key_mapped = [](u32 code) -> bool { return (sdl_keyboard->get_input_mapping()->get_button_id(0, code) != EMU_BTN_NONE); };
+					auto is_key_mapped = [](u32 code) -> bool {
+#if defined(_WIN32) && !defined(TARGET_UWP)
+						if (config::UseRawInput)
+						{
+							for (int i = 0; i < GamepadDevice::GetGamepadCount(); i++)
+							{
+								auto gamepad = GamepadDevice::GetGamepad(i);
+								if (dynamic_cast<rawinput::RawKeyboard*>(gamepad.get()) != nullptr)
+								{
+									bool mapped = (gamepad->get_input_mapping()->get_button_id(0, code) != EMU_BTN_NONE);
+									if (mapped) return true;
+								}
+							}
+							return false;
+						}
+						else
+#endif
+						{
+							return (sdl_keyboard->get_input_mapping()->get_button_id(0, code) != EMU_BTN_NONE);
+						}
+					};
 					
 					if (event.type == SDL_KEYDOWN
 							&& ((event.key.keysym.sym == SDLK_RETURN && (event.key.keysym.mod & KMOD_ALT))

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -254,6 +254,8 @@ void input_sdl_handle()
 				checkRawInput();
 				if (event.key.repeat == 0)
 				{
+					auto is_key_mapped = [](u32 code) -> bool { return (sdl_keyboard->get_input_mapping()->get_button_id(0, code) != EMU_BTN_NONE); };
+					
 					if (event.type == SDL_KEYDOWN
 							&& ((event.key.keysym.sym == SDLK_RETURN && (event.key.keysym.mod & KMOD_ALT))
 									|| (event.key.keysym.sym == SDLK_F11 && (event.key.keysym.mod & (KMOD_ALT | KMOD_CTRL | KMOD_SHIFT | KMOD_GUI)) == 0)))
@@ -272,7 +274,7 @@ void input_sdl_handle()
 						}
 						window_fullscreen = !window_fullscreen;
 					}
-					else if (event.type == SDL_KEYDOWN && (event.key.keysym.mod & KMOD_LALT) && (event.key.keysym.mod & KMOD_LCTRL))
+					else if (event.type == SDL_KEYDOWN && (event.key.keysym.mod & KMOD_LALT) && (event.key.keysym.mod & KMOD_LCTRL) && !(is_key_mapped(SDL_SCANCODE_LALT) || is_key_mapped(SDL_SCANCODE_LCTRL)) )
 					{
 						captureMouse(!mouseCaptured);
 					}


### PR DESCRIPTION
Quick fix for #1202 without introducing new GUI Option, should be ok if game which requires mouse capture won't map Left Ctrl / Left ALT as input?