### PR TITLE
lua: set minimum version required to 5.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,7 +435,7 @@ if(NOT LIBRETRO)
 		target_link_libraries(${PROJECT_NAME} PRIVATE ZLIB::ZLIB)
 	endif()
 
-	find_package(Lua)
+	find_package(Lua 5.2)
 	if(NOT APPLE AND LUA_FOUND)
 		target_compile_definitions(${PROJECT_NAME} PRIVATE USE_LUA)
 		target_include_directories(${PROJECT_NAME} PRIVATE ${LUA_INCLUDE_DIR} core/deps/luabridge/Source)


### PR DESCRIPTION
https://github.com/flyinghead/flycast/blob/cb91ad3ae0c1291485892bf3a9663a2fd303ce83/core/lua/lua.cpp#L22
lua.hpp was added in lua 5.2

Fix Nintendo Switch compilation with latest devkitpro docker image (which includes lua 5.1)