### PR TITLE
[Libretro] Remove some "Invalid value" errors

### DIFF
--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -412,7 +412,11 @@ extern Option<bool> VmuSound;
 
 class RendererOption : public Option<RenderType> {
 public:
+#ifdef LIBRETRO
+	RendererOption() : Option<RenderType>("",
+#else
 	RendererOption() : Option<RenderType>("pvr.rend",
+#endif
 #if defined(USE_DX11)
 			RenderType::DirectX11
 #elif defined(USE_DX9)

--- a/shell/libretro/option.cpp
+++ b/shell/libretro/option.cpp
@@ -70,7 +70,7 @@ Option<int> ScreenStretching("", 100);
 Option<bool> Fog(CORE_OPTION_NAME "_fog", true);
 Option<bool> FloatVMUs("");
 Option<bool> Rotate90("");
-Option<bool> PerStripSorting("rend.PerStripSorting");
+Option<bool> PerStripSorting("");
 Option<bool> DelayFrameSwapping(CORE_OPTION_NAME "_delay_frame_swapping");
 Option<bool> WidescreenGameHacks(CORE_OPTION_NAME "_widescreen_cheats");
 std::array<Option<int>, 4> CrosshairColor {


### PR DESCRIPTION
Suppresses the following errors when the core is checking the core options:

> [ERROR] [Environ]: GET_VARIABLE: pvr.rend - Invalid value.
[ERROR] [Environ]: GET_VARIABLE: rend.PerStripSorting - Invalid value.