### PR TITLE
Create expansion device for "Racing Controller"

### DIFF
--- a/core/hw/maple/maple_cfg.cpp
+++ b/core/hw/maple/maple_cfg.cpp
@@ -305,7 +305,6 @@ static void createDreamcastDevices()
 		case MDT_MaracasController:
 		case MDT_FishingController:
 		case MDT_PopnMusicController:
-		case MDT_RacingController:
 		case MDT_DenshaDeGoController:
 		case MDT_Dreameye:
 			mcfg_Create(config::MapleMainDevices[bus], bus, 5);
@@ -317,6 +316,7 @@ static void createDreamcastDevices()
 		case MDT_LightGun:
 		case MDT_TwinStick:
 		case MDT_AsciiStick:
+		case MDT_RacingController:
 			mcfg_Create(config::MapleMainDevices[bus], bus, 5);
 			if (config::MapleExpansionDevices[bus][0] != MDT_None)
 				mcfg_Create(config::MapleExpansionDevices[bus][0], bus, 0);


### PR DESCRIPTION
Currently when using "Racing Controller" you can select an expansion device from the GUI but it's not being created, this small PR fixes this.