### PR TITLE
deps: update sdl to version 2.28.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,7 +398,7 @@ if(NOT LIBRETRO)
 
 	if(NOT ANDROID AND NOT IOS)
 		if(USE_HOST_SDL)
-			find_package(SDL2)
+			find_package(SDL2 2.0.9)
 		endif()
 		if(NOT SDL2_FOUND)
 			add_subdirectory(core/deps/SDL EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Set minimum version required to 2.0.9 because of SDL_JoystickRumble

https://github.com/libsdl-org/SDL/releases/tag/release-2.28.5