### PR TITLE
macOS Optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1645,8 +1645,8 @@ if(NOT LIBRETRO)
 
 			target_sources(${PROJECT_NAME} PRIVATE
 					shell/apple/common/http_client.mm
-					shell/apple/emulator-osx/emulator-osx/SDLMain.h
-					shell/apple/emulator-osx/emulator-osx/SDLMain.mm
+					shell/apple/emulator-osx/emulator-osx/SDLApplicationDelegate.h
+					shell/apple/emulator-osx/emulator-osx/SDLApplicationDelegate.mm
 					shell/apple/emulator-osx/emulator-osx/osx-main.mm)
 			set(ASSETS shell/apple/emulator-osx/emulator-osx/Images.xcassets)
 			target_sources(${PROJECT_NAME} PRIVATE ${ASSETS})

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -467,6 +467,10 @@ void input_sdl_handle()
 			case SDL_JOYDEVICEREMOVED:
 				sdl_close_joystick((SDL_JoystickID)event.jdevice.which);
 				break;
+				
+			case SDL_DROPFILE:
+				gui_start_game(event.drop.file);
+				break;
 		}
 	}
 }

--- a/shell/apple/emulator-osx/MacOSXBundleInfo.plist.in
+++ b/shell/apple/emulator-osx/MacOSXBundleInfo.plist.in
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>chd</string>
+				<string>gdi</string>
+				<string>cdi</string>
+				<string>cue</string>
+				<string>zip</string>
+				<string>7z</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+		</dict>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>

--- a/shell/apple/emulator-osx/emulator-osx/SDLApplicationDelegate.h
+++ b/shell/apple/emulator-osx/emulator-osx/SDLApplicationDelegate.h
@@ -9,7 +9,7 @@
 
 #import <Cocoa/Cocoa.h>
 
-@interface SDLMain : NSObject <NSApplicationDelegate>
+@interface SDLApplicationDelegate : NSObject <NSApplicationDelegate>
 @end
 
 #endif /* _SDLMain_h_ */


### PR DESCRIPTION
- Register file extensions for `openFile`, and supports the following actions
    - Drag ROM to Application icon to launch the app
    - Drag ROM to the running app's dock icon
    - Drag ROM to the running app's window (applicable to all SDL platform by `SDL_DROPFILE`)
- Update `setupWorkingDirectory`
    - macOS default cwd is a nonsense "/" for non-terminal application 
- Rename `SDLMain` to `SDLApplicationDelegate` to avoid confusion with the function `SDL_main()`
- some code cleanup