### PR TITLE
Video Routing Revamp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	url = https://github.com/google/oboe.git
 [submodule "core/deps/Syphon"]
 	path = core/deps/Syphon
-	url=https://github.com/vkedwardli/Syphon-Framework.git
+	url = https://github.com/vkedwardli/Syphon-Framework.git
 [submodule "core/deps/Spout"]
 	path = core/deps/Spout
-	url = https://github.com/vkedwardli/Spout2.git
+	url = https://github.com/leadedge/Spout2.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -27,4 +27,4 @@
 	url = https://github.com/vkedwardli/Syphon-Framework.git
 [submodule "core/deps/Spout"]
 	path = core/deps/Spout
-	url = https://github.com/leadedge/Spout2.git
+	url = https://github.com/vkedwardli/Spout2.git

--- a/core/rend/dx11/dx11_renderer.cpp
+++ b/core/rend/dx11/dx11_renderer.cpp
@@ -1412,6 +1412,11 @@ void DX11Renderer::renderVideoRouting()
 		backBufferTexture->Release();
 		pResource->Release();
 	}
+	else
+	{
+		extern void os_VideoRoutingTermDX();
+		os_VideoRoutingTermDX();
+	}
 #endif
 }
 

--- a/core/rend/dx11/dx11context.cpp
+++ b/core/rend/dx11/dx11context.cpp
@@ -178,8 +178,6 @@ bool DX11Context::init(bool keepCurrentWindow)
 			NOTICE_LOG(RENDERER, "No system-provided shader cache");
 	}
 
-	initVideoRouting();
-
 	imguiDriver = std::unique_ptr<ImGuiDriver>(new DX11Driver(pDevice, pDeviceContext));
 	resize();
 	shaders.init(pDevice, &D3DCompile);
@@ -188,19 +186,6 @@ bool DX11Context::init(bool keepCurrentWindow)
 	if (!success)
 		term();
 	return success;
-}
-
-void DX11Context::initVideoRouting()
-{
-	#ifdef VIDEO_ROUTING
-	extern void os_VideoRoutingTermDX();
-	extern void os_VideoRoutingInitSpoutDXWithDevice(ID3D11Device* pDevice);
-	os_VideoRoutingTermDX();
-	if (config::VideoRouting)
-	{
-		os_VideoRoutingInitSpoutDXWithDevice(pDevice.get());
-	}
-	#endif
 }
 
 void DX11Context::term()

--- a/core/rend/dx11/dx11context.h
+++ b/core/rend/dx11/dx11context.h
@@ -33,7 +33,6 @@ class DX11Context : public GraphicsContext
 {
 public:
 	bool init(bool keepCurrentWindow = false);
-	void initVideoRouting() override;
 	void term() override;
 	void EndImGuiFrame();
 	void Present();

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -1472,6 +1472,11 @@ void OpenGLRenderer::renderVideoRouting()
 		extern void os_VideoRoutingPublishFrameTexture(GLuint texID, GLuint texTarget, float w, float h);
 		os_VideoRoutingPublishFrameTexture(gl.videorouting.framebuffer->getTexture(), GL_TEXTURE_2D, targetWidth, targetHeight);
 	}
+	else
+	{
+		extern void os_VideoRoutingTermGL();
+		os_VideoRoutingTermGL();
+	}
 #endif
 }
 

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -2241,24 +2241,19 @@ static void gui_display_settings()
 			((renderApi == 0) || (renderApi == 3)) ? header("Video Routing (Spout)") : header("Video Routing (Only available with OpenGL or DirectX 11)");
 #endif
 			{
-#ifdef __APPLE__
-				if (OptionCheckbox("Send video content to another application", config::VideoRouting,
-								   "e.g. Route GPU texture to OBS Studio directly instead of using CPU intensive Display/Window Capture"))
-#elif defined(_WIN32)
-				DisabledScope scope( !( (renderApi == 0) || (renderApi == 3)) );
-				if (OptionCheckbox("Send video content to another program", config::VideoRouting,
-								   "e.g. Route GPU texture to OBS Studio directly instead of using CPU intensive Display/Window Capture"))
+#ifdef _WIN32
+				DisabledScope scope(!((renderApi == 0) || (renderApi == 3)));
 #endif
-				{
-					GraphicsContext::Instance()->initVideoRouting();
-				}
+				OptionCheckbox("Send video content to another program", config::VideoRouting,
+					"e.g. Route GPU texture to OBS Studio directly instead of using CPU intensive Display/Window Capture");
+
 				{
 					DisabledScope scope(!config::VideoRouting);
 					OptionCheckbox("Scale down before sending", config::VideoRoutingScale, "Could increase performance when sharing a smaller texture, YMMV");
 					{
 						DisabledScope scope(!config::VideoRoutingScale);
 						static int vres = config::VideoRoutingVRes;
-						if( ImGui::InputInt("Output vertical resolution", &vres) )
+						if (ImGui::InputInt("Output vertical resolution", &vres))
 						{
 							config::VideoRoutingVRes = vres;
 						}

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -487,8 +487,6 @@ bool VulkanContext::InitDevice()
 				+ std::to_string(props.driverVersion / 10000) + "."
 				+ std::to_string((props.driverVersion % 10000) / 100) + "."
 				+ std::to_string(props.driverVersion % 100);
-		
-		initVideoRouting();
 #else
 		driverVersion = std::to_string(VK_API_VERSION_MAJOR(props.driverVersion)) + "."
 				+ std::to_string(VK_API_VERSION_MINOR(props.driverVersion)) + "."
@@ -511,19 +509,6 @@ bool VulkanContext::InitDevice()
 		ERROR_LOG(RENDERER, "Unknown error");
 	}
 	return false;
-}
-
-void VulkanContext::initVideoRouting()
-{
-#if defined(VIDEO_ROUTING) && defined(TARGET_MAC)
-	extern void os_VideoRoutingTermVk();
-	extern void os_VideoRoutingInitSyphonWithVkDevice(const vk::UniqueDevice& device);
-	os_VideoRoutingTermVk();
-	if (config::VideoRouting)
-	{
-		os_VideoRoutingInitSyphonWithVkDevice(device);
-	}
-#endif
 }
 
 void VulkanContext::CreateSwapChain()

--- a/core/rend/vulkan/vulkan_context.h
+++ b/core/rend/vulkan/vulkan_context.h
@@ -60,7 +60,6 @@ public:
 	void Present() noexcept;
 	void PresentFrame(vk::Image image, vk::ImageView imageView, const vk::Extent2D& extent, float aspectRatio) noexcept;
 	void PresentLastFrame();
-	void initVideoRouting() override;
 
 	vk::PhysicalDevice GetPhysicalDevice() const { return physicalDevice; }
 	vk::Device GetDevice() const { return *device; }

--- a/core/wsi/context.h
+++ b/core/wsi/context.h
@@ -34,7 +34,6 @@ public:
 	virtual std::string getDriverName() = 0;
 	virtual std::string getDriverVersion() = 0;
 	virtual bool hasPerPixel() { return false; }
-	virtual void initVideoRouting() {}
 
 	void setWindow(void *window, void *display = nullptr) {
 		this->window = window;

--- a/core/wsi/sdl.cpp
+++ b/core/wsi/sdl.cpp
@@ -108,27 +108,8 @@ bool SDLGLGraphicsContext::init()
 	}
 #endif
 	postInit();
-	initVideoRouting();
 	
 	return true;
-}
-
-void SDLGLGraphicsContext::initVideoRouting()
-{
-#ifdef VIDEO_ROUTING
-	extern void os_VideoRoutingTermGL();
-	os_VideoRoutingTermGL();
-	if (config::VideoRouting)
-	{
-#ifdef TARGET_MAC
-		extern void os_VideoRoutingInitSyphonWithGLContext(void* glContext);
-		os_VideoRoutingInitSyphonWithGLContext(glcontext);
-#elif defined(_WIN32)
-		extern void os_VideoRoutingInitSpout();
-		os_VideoRoutingInitSpout();
-#endif
-	}
-#endif
 }
 
 void SDLGLGraphicsContext::swap()

--- a/core/wsi/sdl.h
+++ b/core/wsi/sdl.h
@@ -29,7 +29,6 @@ public:
 	bool init();
 	void term() override;
 	void swap();
-	void initVideoRouting() override;
 
 private:
 	SDL_GLContext glcontext = nullptr;


### PR DESCRIPTION
- Update Spout2 dep
  - fixes [MINIDUMP-20Y](https://flycast.sentry.io/issues/4603889822/) / [MINIDUMP-21B](https://flycast.sentry.io/issues/4610185662/) / [MINIDUMP-21E](https://flycast.sentry.io/issues/4611071861/)
- No more `initVideoRouting()` calls in `GraphicContext` and gui, Spout/Syphon will be initiated on demand in render
- Dedup gui

### Things to verify:
- Windows:
  - [x] x86_64 MSVC
  - [x] x86_64 MinGW
  - [x] OpenGL
  - [x] OpenGL Per Pixel
  - [x] DirectX 11
  - [x] DirectX 11 Per Pixel

- macOS:
  - [x] x86_64
  - [x] arm64
  - [x] OpenGL
  - [x] Vulkan (Metal)
  - [x] Vulkan (Metal) Per Pixel

- Both platforms:
  - [x] Widescreen / Super Widescreen
  - [x] Render to Texture
  - [x] Full Framebuffer Emulation
  - [x] Overlay (e.g. In-game VMU, FPS, GGPO Stats)
  - [x] Resize window / Resize sharing texture / Change renderer without restarting