### PR TITLE
Some ifdefs to improve builds

### DIFF
--- a/core/hw/sh4/modules/mmu.cpp
+++ b/core/hw/sh4/modules/mmu.cpp
@@ -459,7 +459,9 @@ void mmu_set_state()
 	setSqwHandler();
 }
 
+#ifdef FAST_MMU
 u32 mmuAddressLUT[0x100000];
+#endif
 
 void MMU_init()
 {

--- a/core/hw/sh4/modules/mmu.h
+++ b/core/hw/sh4/modules/mmu.h
@@ -117,6 +117,7 @@ template<typename T> void DYNACALL mmu_WriteMem(u32 adr, T data);
 
 void mmu_TranslateSQW(u32 adr, u32* out);
 
+#ifdef FAST_MMU
 // maps 4K virtual page number to physical address
 extern u32 mmuAddressLUT[0x100000];
 
@@ -130,7 +131,9 @@ static inline void mmuAddressLUTFlush(bool full)
 		memset(mmuAddressLUT, 0, slotPages * sizeof(u32));		// flush slot 0
 	}
 }
+#endif
 
+#if FEAT_SHREC == DYNAREC_JIT
 static inline u32 DYNACALL mmuDynarecLookup(u32 vaddr, u32 write, u32 pc)
 {
 	u32 paddr;
@@ -157,6 +160,7 @@ static inline u32 DYNACALL mmuDynarecLookup(u32 vaddr, u32 write, u32 pc)
 
 	return paddr;
 }
+#endif
 
 void MMU_init();
 void MMU_reset();

--- a/core/linux/common.cpp
+++ b/core/linux/common.cpp
@@ -65,8 +65,10 @@ void fault_handler(int sn, siginfo_t * si, void *segfault_ctx)
 		context_to_segfault(&ctx, segfault_ctx);
 		return;
 	}
-#endif
+
 	ERROR_LOG(COMMON, "SIGSEGV @ %p invalid access to %p", (void *)ctx.pc, si->si_addr);
+#endif
+
 #ifdef __SWITCH__
 	MemoryInfo meminfo;
 	u32 pageinfo;


### PR DESCRIPTION
- mmuAddressLUT / mmuAddressLUTFlush are only used when FAST_MMU is defined
- mmuDynarecLookup is a function only used by dynarecs (arm, arm64, x86, x86_64)
- I moved the ERROR_LOG because `ctx.pc` requires `host_context_t ctx;` defined only when FEAT_SHREC == DYNAREC_JIT

It fixes some compilation errors when `HOST_CPU == CPU_GENERIC`