### PR TITLE
[Libretro] Fix VMU scaling for dynamic res games

### DIFF
--- a/core/rend/dx11/dx11_overlay.cpp
+++ b/core/rend/dx11/dx11_overlay.cpp
@@ -36,9 +36,15 @@ void DX11Overlay::draw(u32 width, u32 height, bool vmu, bool crosshair)
 		const float blend_factor[4] = { 0.75f, 0.75f, 0.75f, 0.75f };
 		deviceContext->OMSetBlendState(blendStates.getState(true, 8, 8), blend_factor, 0xffffffff);
 #else
-		float vmu_padding = 8.f * config::RenderResolution / 480.f;
-		float vmu_height = 32.f * config::RenderResolution / 480.f;
-		float vmu_width = 48.f * config::RenderResolution / 480.f;
+		float vmu_padding_x = 8.f * width / 640.f;
+		float vmu_padding_y = 8.f * height / 480.f;
+		float vmu_width = 48.f * width / 640.f;
+		float vmu_height = 32.f * height / 480.f;
+		if (config::Widescreen)
+		{
+			vmu_padding_x = vmu_padding_x / 4.f * 3.f;
+			vmu_width = vmu_width / 4.f * 3.f;
+		}
 		deviceContext->OMSetBlendState(blendStates.getState(true, 4, 5), nullptr, 0xffffffff);
 #endif
 
@@ -91,20 +97,20 @@ void DX11Overlay::draw(u32 width, u32 height, bool vmu, bool crosshair)
 			{
 			case UPPER_LEFT:
 			default:
-				x = vmu_padding;
-				y = vmu_padding;
+				x = vmu_padding_x;
+				y = vmu_padding_y;
 				break;
 			case UPPER_RIGHT:
-				x = width - vmu_padding - w;
-				y = vmu_padding;
+				x = width - vmu_padding_x - w;
+				y = vmu_padding_y;
 				break;
 			case LOWER_LEFT:
-				x = vmu_padding;
-				y = height - vmu_padding - h;
+				x = vmu_padding_x;
+				y = height - vmu_padding_y - h;
 				break;
 			case LOWER_RIGHT:
-				x = width - vmu_padding - w;
-				y = height - vmu_padding - h;
+				x = width - vmu_padding_x - w;
+				y = height - vmu_padding_y - h;
 				break;
 			}
 #else

--- a/core/rend/gles/gldraw.cpp
+++ b/core/rend/gles/gldraw.cpp
@@ -828,11 +828,10 @@ static void updateVmuTexture(int vmu_screen_number)
 
 void DrawVmuTexture(u8 vmu_screen_number, int width, int height)
 {
-	float vmu_padding = 8.f * config::RenderResolution / 480.f;
-	float x = vmu_padding;
-	float y = vmu_padding;
-	float w = (float)VMU_SCREEN_WIDTH * vmu_screen_params[vmu_screen_number].vmu_screen_size_mult * 4.f / 3.f / gl.ofbo.aspectRatio * config::RenderResolution / 480.f;
-	float h = (float)VMU_SCREEN_HEIGHT * vmu_screen_params[vmu_screen_number].vmu_screen_size_mult * config::RenderResolution / 480.f;
+	float x = 8.f * width / 640.f;
+	float y = 8.f * height / 480.f;
+	float w = (float)VMU_SCREEN_WIDTH * vmu_screen_params[vmu_screen_number].vmu_screen_size_mult * 4.f / 3.f / gl.ofbo.aspectRatio * width / 640.f;
+	float h = (float)VMU_SCREEN_HEIGHT * vmu_screen_params[vmu_screen_number].vmu_screen_size_mult * height / 480.f;
 
 	if (vmu_lcd_changed[vmu_screen_number * 2] || vmuTextureId[vmu_screen_number] == 0)
 		updateVmuTexture(vmu_screen_number);

--- a/core/rend/vulkan/overlay.cpp
+++ b/core/rend/vulkan/overlay.cpp
@@ -126,9 +126,21 @@ void VulkanOverlay::Draw(vk::CommandBuffer commandBuffer, vk::Extent2D viewport,
 
 	if (vmu)
 	{
+#ifndef LIBRETRO
 		f32 vmu_padding = 8.f * scaling;
 		f32 vmu_height = 32.f * scaling;
 		f32 vmu_width = 48.f * scaling;
+#else
+		f32 vmu_padding_x = 8.f * viewport.width / 640.f;
+		f32 vmu_padding_y = 8.f * viewport.height / 480.f;
+		f32 vmu_width = 48.f * viewport.width / 640.f;
+		f32 vmu_height = 32.f * viewport.height / 480.f;
+		if (config::Widescreen)
+		{
+			vmu_padding_x = vmu_padding_x / 4.f * 3.f;
+			vmu_width = vmu_width / 4.f * 3.f;
+		}
+#endif
 
 		pipeline->BindPipeline(commandBuffer);
 		const float *color = nullptr;
@@ -158,20 +170,20 @@ void VulkanOverlay::Draw(vk::CommandBuffer commandBuffer, vk::Extent2D viewport,
 			{
 			case UPPER_LEFT:
 			default:
-				x = vmu_padding;
-				y = vmu_padding;
+				x = vmu_padding_x;
+				y = vmu_padding_y;
 				break;
 			case UPPER_RIGHT:
-				x = viewport.width - vmu_padding - w;
-				y = vmu_padding;
+				x = viewport.width - vmu_padding_x - w;
+				y = vmu_padding_y;
 				break;
 			case LOWER_LEFT:
-				x = vmu_padding;
-				y = viewport.height - vmu_padding - h;
+				x = vmu_padding_x;
+				y = viewport.height - vmu_padding_y - h;
 				break;
 			case LOWER_RIGHT:
-				x = viewport.width - vmu_padding - w;
-				y = viewport.height - vmu_padding - h;
+				x = viewport.width - vmu_padding_x - w;
+				y = viewport.height - vmu_padding_y - h;
 				break;
 			}
 #else


### PR DESCRIPTION
Noticed while testing #1339, the on-screen VMU can get squished if the game decides to change its resolution.

Before:
![image](https://github.com/flyinghead/flycast/assets/33353403/92984281-842a-495c-a12e-ad4fed020ac3)

After:
![image](https://github.com/flyinghead/flycast/assets/33353403/60bcf839-0cad-455e-9315-a4e5d75cabd4)
