### PR TITLE
cheats: fix parsing cheat codes on some platforms (like Windows)

### DIFF
--- a/core/cheats.cpp
+++ b/core/cheats.cpp
@@ -677,7 +677,7 @@ static std::vector<u32> parseCodes(const std::string& s)
 			curCode += c;
 			if (curCode.length() == 8)
 			{
-				codes.push_back(strtol(curCode.c_str(), nullptr, 16));
+				codes.push_back(strtoul(curCode.c_str(), nullptr, 16));
 				curCode.clear();
 			}
 		}
@@ -688,7 +688,7 @@ static std::vector<u32> parseCodes(const std::string& s)
 	{
 		if (curCode.length() != 8)
 			throw FlycastException("Invalid cheat code");
-		codes.push_back(strtol(curCode.c_str(), nullptr, 16));
+		codes.push_back(strtoul(curCode.c_str(), nullptr, 16));
 	}
 
 	return codes;


### PR DESCRIPTION
using strtol here instead of strtoul when cheat code values are expected to be unsigned and are above 7fffffff breaks on platforms like Windows where long is 32-bit even on 64-bit platforms, capping out at 2147483647 and causing some (possibly quite a lot) of cheat codes to break.