### PR TITLE
Android gradle plugin, SDL 2.30.0, devkitpro build image

### DIFF
--- a/.github/workflows/switch.yml
+++ b/.github/workflows/switch.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     name: ${{ matrix.config.name }}
     runs-on: ubuntu-latest
-    container: devkitpro/devkita64:latest
+    container: devkitpro/devkita64:20240120
 
     strategy:
       matrix:

--- a/.github/workflows/uwp.yml
+++ b/.github/workflows/uwp.yml
@@ -6,30 +6,15 @@ jobs:
   build:
     runs-on: windows-latest
 
-    env:
-      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
-      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
-
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
 
-      - name: bootstrap vcpkg
-        run: |
-          git clone https://github.com/microsoft/vcpkg
-          mkdir vcpkg\bincache
-          vcpkg\bootstrap-vcpkg.bat
-
-      - uses: actions/cache@v4
-        with:
-          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-          key: vcpkg-${{ hashFiles( 'vcpkg.json' ) }}
-
       - name: CMake
         run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 17 2022" -A x64 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.22000.0 -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake
+          cmake -B build -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 17 2022" -A x64 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.22000.0
           cmake --build build --config Release --parallel 2
         shell: cmd
 

--- a/shell/android-studio/build.gradle
+++ b/shell/android-studio/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.2.1' apply false
-    id 'com.android.library' version '8.2.1' apply false
+    id 'com.android.application' version '8.2.2' apply false
+    id 'com.android.library' version '8.2.2' apply false
 }
 
 task clean(type: Delete) {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,0 @@
-{
-  "name": "flycast",
-  "version-string": "1.2.0-dev",
-  "dependencies": [
-    "sdl2"
-  ]
-}


### PR DESCRIPTION
There is an issue with the latest devkitpro docker image that's why I locked the version.
- https://devkitpro.org/viewtopic.php?f=42&t=9532&sid=edf39fafcceeba2fa54876ae27f4b6af
- Logs: https://github.com/scribam/flycast/actions/runs/7766044323/job/21181417489