### PR TITLE
Adds option to enable/disable "Fix Upscale Bleeding Edge" - Standalone/Libretro

### DIFF
--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -108,6 +108,7 @@ Option<bool> DupeFrames("rend.DupeFrames", false);
 Option<int> PerPixelLayers("rend.PerPixelLayers", 32);
 Option<bool> NativeDepthInterpolation("rend.NativeDepthInterpolation", false);
 Option<bool> EmulateFramebuffer("rend.EmulateFramebuffer", false);
+Option<bool> FixUpscaleBleedingEdge("rend.FixUpscaleBleedingEdge", true);
 #ifdef VIDEO_ROUTING
 Option<bool, false> VideoRouting("rend.VideoRouting", false);
 Option<bool, false> VideoRoutingScale("rend.VideoRoutingScale", false);

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -474,6 +474,7 @@ extern Option<bool> ThreadedRendering;
 extern Option<bool> DupeFrames;
 extern Option<bool> NativeDepthInterpolation;
 extern Option<bool> EmulateFramebuffer;
+extern Option<bool> FixUpscaleBleedingEdge;
 #ifdef VIDEO_ROUTING
 extern Option<bool, false> VideoRouting;
 extern Option<bool, false> VideoRoutingScale;

--- a/core/hw/pvr/ta_vtx.cpp
+++ b/core/hw/pvr/ta_vtx.cpp
@@ -1160,7 +1160,7 @@ static void parseRenderPass(RenderPass& pass, const RenderPass& previousPass, re
 			|| config::RendererType == RenderType::Vulkan_OIT;
 	const bool mergeTranslucent = config::PerStripSorting || perPixel;
 
-	if (config::RenderResolution > 480 && !config::EmulateFramebuffer)
+	if (config::RenderResolution > 480 && !config::EmulateFramebuffer && config::FixUpscaleBleedingEdge)
 	{
 		fix_texture_bleeding(ctx.global_param_op, previousPass.op_count, pass.op_count, ctx);
 		fix_texture_bleeding(ctx.global_param_pt, previousPass.pt_count, pass.pt_count, ctx);

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -2064,6 +2064,8 @@ static void gui_display_settings()
 		    	OptionCheckbox("Rotate Screen 90°", config::Rotate90, "Rotate the screen 90° counterclockwise");
 		    	OptionCheckbox("Delay Frame Swapping", config::DelayFrameSwapping,
 		    			"Useful to avoid flashing screen or glitchy videos. Not recommended on slow platforms");
+		    	OptionCheckbox("Fix Upscale Bleeding Edge", config::FixUpscaleBleedingEdge,
+		    			"Helps with texture bleeding case when upscaling. Disabling it can help if pixels are warping when upscaling in 2D games (MVC2, CVS, KOF, etc.)");
 		    	OptionCheckbox("Native Depth Interpolation", config::NativeDepthInterpolation,
 		    			"Helps with texture corruption and depth issues on AMD GPUs. Can also help Intel GPUs in some cases.");
 		    	OptionCheckbox("Full Framebuffer Emulation", config::EmulateFramebuffer,

--- a/shell/libretro/libretro_core_options.h
+++ b/shell/libretro/libretro_core_options.h
@@ -597,6 +597,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled",
    },
    {
+      CORE_OPTION_NAME "_fix_upscale_bleeding_edge",
+	  "Fix Upscale Bleeding Edge",
+	  NULL,
+	  "Helps with texture bleeding case when upscaling. Disabling it can help if pixels are warping when upscaling in 2D games (MVC2, CVS, KOF, etc.)",
+	  NULL,
+	  "video",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled",
+   },
+   {
       CORE_OPTION_NAME "_threaded_rendering",
       "Threaded Rendering",
       NULL,

--- a/shell/libretro/option.cpp
+++ b/shell/libretro/option.cpp
@@ -92,6 +92,7 @@ Option<int64_t> PixelBufferSize("", 512_MB);
 IntOption PerPixelLayers(CORE_OPTION_NAME "_oit_layers");
 Option<bool> NativeDepthInterpolation(CORE_OPTION_NAME "_native_depth_interpolation");
 Option<bool> EmulateFramebuffer(CORE_OPTION_NAME "_emulate_framebuffer", false);
+Option<bool> FixUpscaleBleedingEdge(CORE_OPTION_NAME "_fix_upscale_bleeding_edge", true);
 
 // Misc
 


### PR DESCRIPTION
Helps with texture bleeding case when upscaling. Disabling it can help if pixels are warping when upscaling in 2D games (MVC2, CVS, KOF, etc.).

The fix is enabled by default as to keep the current behaviour.

I tested in standalone + libretro and it works perfectly on the fly.

Thanks to @blueminder for the instructions :)

Closes https://github.com/flyinghead/flycast/issues/1223