### PR TITLE
[Libretro] Check for per-pixel compatibility and hide the option if not supported

### DIFF
--- a/core/rend/vulkan/vk_context_lr.cpp
+++ b/core/rend/vulkan/vk_context_lr.cpp
@@ -126,7 +126,7 @@ bool VkCreateDevice(retro_vulkan_context* context, VkInstance instance, VkPhysic
 
 	vk::PhysicalDeviceFeatures supportedFeatures;
 	physicalDevice.getFeatures(&supportedFeatures);
-	bool fragmentStoresAndAtomics = supportedFeatures.fragmentStoresAndAtomics;
+	VulkanContext::Instance()->fragmentStoresAndAtomics = supportedFeatures.fragmentStoresAndAtomics;
 	VulkanContext::Instance()->samplerAnisotropy = supportedFeatures.samplerAnisotropy;
 
 	// Enable VK_KHR_dedicated_allocation if available
@@ -157,7 +157,7 @@ bool VkCreateDevice(retro_vulkan_context* context, VkInstance instance, VkPhysic
 			vk::DeviceQueueCreateInfo(vk::DeviceQueueCreateFlags(), context->presentation_queue_family_index, 1, &queuePriority),
 	};
 	vk::PhysicalDeviceFeatures features(*required_features);
-	if (fragmentStoresAndAtomics)
+	if (VulkanContext::Instance()->fragmentStoresAndAtomics)
 		features.fragmentStoresAndAtomics = true;
 	if (VulkanContext::Instance()->samplerAnisotropy)
 		features.samplerAnisotropy = true;

--- a/core/rend/vulkan/vk_context_lr.h
+++ b/core/rend/vulkan/vk_context_lr.h
@@ -89,6 +89,7 @@ public:
 	static VulkanContext *Instance() { return contextInstance; }
 	bool SupportsSamplerAnisotropy() const { return samplerAnisotropy; }
 	bool SupportsDedicatedAllocation() const { return dedicatedAllocationSupported; }
+	bool hasPerPixel() override { return fragmentStoresAndAtomics; }
 	const VMAllocator& GetAllocator() const { return allocator; }
 	vk::DeviceSize GetMaxMemoryAllocationSize() const { return maxMemoryAllocationSize; }
 	f32 GetMaxSamplerAnisotropy() const { return samplerAnisotropy ? maxSamplerAnisotropy : 1.f; }
@@ -126,6 +127,7 @@ public:
 	bool samplerAnisotropy = false;
 	f32 maxSamplerAnisotropy = 0.f;
 	bool dedicatedAllocationSupported = false;
+	bool fragmentStoresAndAtomics = false;
 private:
 	u32 vendorID = 0;
 


### PR DESCRIPTION
Currently if the Libretro core is built with per-pixel support then the option will always be available to the user, even when using a renderer that doesn't support it (e.g. GLES). It's not rare to see people confused because they have glitchy eyes in Sonic or Shenmue for example while they properly have "Per-Pixel" selected in the core options, because it silently falls back to per-triangle without any indication.

This PR will check if the current renderer supports per-pixel by using the hasPerPixel() function (I had to add it for VK since it didn't exist for the Libretro core), if it's not supported then the 2 values here will be nulled out: https://github.com/flyinghead/flycast/blob/056a02357d46886f42249407e83bf598b599ee4d/shell/libretro/libretro_core_options.h#L349 so it doesn't appear, and a "Current renderer does not support 'Per-Pixel' Alpha Sorting." message will be printed in logs.

As we discuss on Discord, the VK changes might be undeed because it's pretty rare that it's not compatible, I'll remove these changes if you want, please let me know.
Other than that, does it look OK? I'm pretty limited with the devices I can test this, I only have a Windows PC and an old Android 32bit phone but AFAICT it works fine, the option is properly hidden on my phone that only supports GLES for example.
I'd just like to make sure there's no way the option ends up being hidden when it's supported.