### PR TITLE
Fix Xcode 15 linker error

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -29,6 +29,7 @@ jobs:
     steps:
       - name: Set up build environment (macOS)
         run: |
+          sudo xcode-select -switch /Applications/Xcode_15.3.app
           # Unlink and re-link to prevent errors when github mac runner images install python outside of brew. See https://github.com/actions/setup-python/issues/577
           brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
           brew update || :


### PR DESCRIPTION
Fix the `ImageLoaderMachO::doModInitFunctions(ImageLoader::LinkContext const&)` error introduced by Xcode 15.
Bumping to use Xcode 15.3 since the problem seems to be gone without adding any workaround flags

May have to use other workarounds as stated from the Apple docs:
https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Linking

e.g. adding `-ld64` / `-Wl,-ld_classic`