### PR TITLE
Cheats: Tokyo Xtreme Racer 2 fix

### DIFF
--- a/core/cheats.cpp
+++ b/core/cheats.cpp
@@ -278,7 +278,7 @@ const WidescreenCheat CheatManager::widescreen_cheats[] =
 		{ "T35402M",    nullptr,    { 0x315370, 0x3153A0 }, { 0x43F00000, 0x3F400000 } },	// Tokyo Bus Guide (JP) doesn't work?
 		{ "T40201D 50", nullptr,    { 0x1D9F10 }, { 0x3F400000 } },		// Tokyo Highway Challenge (PAL)
 		{ "T40210D 50", nullptr,    { 0x21E4F8 }, { 0x43700000 } },		// Tokyo Highway Challenge 2 (PAL)
-		{ "xxxxxxxxxx", nullptr,    { 0x21DEF8 }, { 0x3F400000 } },		// Tokyo Street Racer 2 (USA)
+		{ "T40211N", nullptr,    { 0x21DEF8 }, { 0x43700000 } },		// Tokyo Xtreme Racer 2 (USA)
 //		{ "T36804D05",  nullptr,    { 0xB75E28 }, { 0x3EC00000 } },		// Tomb Raider: The Last Revelation (UK) (PAL) clipping, use hex patch instead
 //		{ "T40205N",    nullptr,    { 0x160D80, 0x160D7C }, { 0xA, 0xA } },	// Tony Hawk's Pro Skater (USA) -> missing character on selection screen
 		{ "T13008D 05", nullptr,    { 0x1D7C20 }, { 0x3FA66666 } },		// Tony Hawk's Pro Skater 2 (PAL)


### PR DESCRIPTION
For some reason every occurence of this cheat you can find online is broken and it's because the value is incorrect. It's actually supposed to be same as PAL version of the game! (hence why the viewport gets shrunk instead of expanded)

Sidenote: While the game has native widescreen option, it works really poorly

Before
![image](https://github.com/flyinghead/flycast/assets/4414625/2fdf3cd8-1bc3-4e53-ba49-6a58919b43da)
After
![image](https://github.com/flyinghead/flycast/assets/4414625/6a5d32ee-57e5-4325-bce7-15abe2369374)
