### PR TITLE
Cheats: Tokyo Xtreme Racer 1 (USA) - Widescreen cheat

### DIFF
--- a/core/cheats.cpp
+++ b/core/cheats.cpp
@@ -278,6 +278,7 @@ const WidescreenCheat CheatManager::widescreen_cheats[] =
 		{ "T35402M",    nullptr,    { 0x315370, 0x3153A0 }, { 0x43F00000, 0x3F400000 } },	// Tokyo Bus Guide (JP) doesn't work?
 		{ "T40201D 50", nullptr,    { 0x1D9F10 }, { 0x3F400000 } },		// Tokyo Highway Challenge (PAL)
 		{ "T40210D 50", nullptr,    { 0x21E4F8 }, { 0x43700000 } },		// Tokyo Highway Challenge 2 (PAL)
+		{ "T40202N", nullptr,    { 0x1D9EB0 }, { 0x3F400000 } },		// Tokyo Xtreme Racer (USA)		
 		{ "T40211N", nullptr,    { 0x21DEF8 }, { 0x43700000 } },		// Tokyo Xtreme Racer 2 (USA)
 //		{ "T36804D05",  nullptr,    { 0xB75E28 }, { 0x3EC00000 } },		// Tomb Raider: The Last Revelation (UK) (PAL) clipping, use hex patch instead
 //		{ "T40205N",    nullptr,    { 0x160D80, 0x160D7C }, { 0xA, 0xA } },	// Tony Hawk's Pro Skater (USA) -> missing character on selection screen


### PR DESCRIPTION
Adds widescreen cheat for NTSC version of Tokyo Xtreme Racer 1. It's a port of the PAL version (Tokyo Highway Challenge)

Before:
![image](https://github.com/flyinghead/flycast/assets/4414625/099f777b-7b76-427d-9bb0-824b7de12007)

After:
![image](https://github.com/flyinghead/flycast/assets/4414625/bbd8f7dc-4127-42e4-ac23-66afaced9f66)
