### PR TITLE
Always use BSD sed in generate_xcode_project helper

### DIFF
--- a/shell/apple/generate_xcode_project.command
+++ b/shell/apple/generate_xcode_project.command
@@ -34,5 +34,5 @@ fi
 cmake -B build -DCMAKE_BUILD_TYPE=Release $option -DCMAKE_XCODE_GENERATE_SCHEME=YES -G "Xcode"
 
 nl=$'\n'
-sed -i '' -E "s/launchStyle/customLLDBInitFile = \"\$(SRCROOT)\/shell\/apple\/\\${lldbinitfolder}\/LLDBInitFile\"\\${nl}launchStyle/g" build/flycast.xcodeproj/xcshareddata/xcschemes/flycast.xcscheme
+/usr/bin/sed -i '' -E "s/launchStyle/customLLDBInitFile = \"\$(SRCROOT)\/shell\/apple\/\\${lldbinitfolder}\/LLDBInitFile\"\\${nl}launchStyle/g" build/flycast.xcodeproj/xcshareddata/xcschemes/flycast.xcscheme
 open build/flycast.xcodeproj


### PR DESCRIPTION
User with `gnu-sed` installed would break the BSD style sed command