### PR TITLE
Cheats: Sega GT (USA) - Widescreen cheat

### DIFF
--- a/core/cheats.cpp
+++ b/core/cheats.cpp
@@ -225,6 +225,7 @@ const WidescreenCheat CheatManager::widescreen_cheats[] =
 		{ "T8104D  58", nullptr,    { 0x2C03F8 }, { 0x44558000 } },		// Shadow Man (PAL)
 		{ "T-8106N",    nullptr,    { 0x2C03F4 }, { 0x3F400000 } },		// Shadow Man (USA)
 		{ "MK-51048",   nullptr,    { 0x4AA4DC, 0x2B4E30 }, { 0x3F400000, 0x3F400000 } },	// Seaman (USA)
+		{ "MK-51053",   nullptr,    { 0x5630CC }, { 0x3F400000 } },		// Sega GT (USA)	
 		{ "MK-5105350", nullptr,    { 0x5D613C }, { 0x3F400000 } },		// Sega GT (PAL)
 		{ "MK-51096",   nullptr,    { 0x495050 }, { 0x43700000 } },		// Sega Marine Fishing (USA)
 //		{ "MK-51019",   nullptr,    { 0xB83A48 }, { 0x3F400000 } },		// Sega Rally 2 (USA) not working?


### PR DESCRIPTION
Adds widescreen cheat for NTSC version of Sega GT. It's a port of the PAL version.
![43](https://github.com/flyinghead/flycast/assets/4414625/cfe4723d-25e2-4e62-aaf2-f1c92314685c)
![169](https://github.com/flyinghead/flycast/assets/4414625/286e2cb0-d5aa-4742-a4ba-935fff270429)
