### PR TITLE
Fix macOS debug build UI crash

### DIFF
--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -3073,7 +3073,7 @@ static void gameTooltip(const std::string& tip)
 
 static bool gameImageButton(ImguiTexture& texture, const std::string& tooltip, ImVec2 size, const std::string& gameName)
 {
-	bool pressed = texture.button("", size, gameName);
+	bool pressed = texture.button("##imagebutton", size, gameName);
 	gameTooltip(tooltip);
 
     return pressed;

--- a/shell/apple/emulator-osx/emulator-osx/osx-main.mm
+++ b/shell/apple/emulator-osx/emulator-osx/osx-main.mm
@@ -34,7 +34,9 @@ int darw_printf(const char* text, ...)
     va_end(args);
     
     NSString* log = [NSString stringWithCString:temp encoding: NSUTF8StringEncoding];
-    static bool isXcode = [[[NSProcessInfo processInfo] environment][@"OS_ACTIVITY_DT_MODE"] boolValue];
+    NSDictionary<NSString *, NSString *>* env = [[NSProcessInfo processInfo] environment];
+    static bool isXcode = [env[@"OS_ACTIVITY_DT_MODE"] boolValue] || [env[@"COMMAND_MODE"] isEqualToString:@"unix2003"];
+	
     if (isXcode) // Xcode console does not support colors
     {
         log = [log stringByReplacingOccurrencesOfString:@"\x1b[0m" withString:@""];


### PR DESCRIPTION
> [DEBUG] People keep stumbling on this problem and using "" as identifier in the root of a window instead of "##something".

- The crash only happens in Debug build
- Fix Xcode 15 console pretty print as well