### PR TITLE
uwp: fix http ContentLength assignment

### DIFF
--- a/shell/uwp/http_client.cpp
+++ b/shell/uwp/http_client.cpp
@@ -18,6 +18,7 @@
 */
 #include "oslib/http_client.h"
 #include "stdclass.h"
+#include <windows.h>
 
 namespace http {
 
@@ -104,7 +105,7 @@ int post(const std::string& url, const char *payload, const char *contentType, s
 	{
 		Uri^ uri = ref new Uri(ref new String(wurl.get()));
 		HttpStringContent^ content = ref new HttpStringContent(ref new String(wpayload.get()));
-		content->Headers->ContentLength = strlen(payload);
+		content->Headers->ContentLength = ref new Box<UINT64>(strlen(payload));
 		if (contentType != nullptr)
 			content->Headers->ContentType = ref new HttpMediaTypeHeaderValue(ref new String(wcontentType.get()));
 


### PR DESCRIPTION
Fix for UWP when building for other architectures (win32, arm, arm64)

> D:\a\flycast\flycast\shell\uwp\http_client.cpp(107,19): error C2664: 'void Windows::Web::Http::Headers::HttpContentHeaderCollection::ContentLength::set(Platform::IBox<unsigned __int64> ^)': cannot convert argument 1 from 'size_t' to 'Platform::IBox<unsigned __int64> ^' [D:\a\flycast\flycast\build\flycast.vcxproj]