### PR TITLE
[Android] Fix aptX Adaptive's Dynamic Low Latency mode

### DIFF
--- a/core/audio/audiobackend_oboe.cpp
+++ b/core/audio/audiobackend_oboe.cpp
@@ -91,6 +91,7 @@ public:
 				->setFormat(oboe::AudioFormat::I16)
 				->setChannelCount(oboe::ChannelCount::Stereo)
 				->setSampleRate(44100)
+				->setSampleRateConversionQuality(oboe::SampleRateConversionQuality::High)
 				->setFramesPerCallback(SAMPLE_COUNT)
 				->setDataCallback(&audioCallback)
 				->setErrorCallback(&errorCallback)


### PR DESCRIPTION
Convert sampling rate by using Oboe since converting by underlying APIs prevent us from getting a low latency stream