### PR TITLE
network: fix build with miniupnpc 2.2.8

### DIFF
--- a/core/network/miniupnp.cpp
+++ b/core/network/miniupnp.cpp
@@ -43,7 +43,11 @@ bool MiniUPnP::Init()
 		WARN_LOG(NETWORK, "UPnP discover failed: error %d", error);
 		return false;
 	}
+#if MINIUPNPC_API_VERSION >= 18
+	error = UPNP_GetValidIGD(devlist, &urls, &data, lanAddress, sizeof(lanAddress), nullptr, 0);
+#else
 	error = UPNP_GetValidIGD(devlist, &urls, &data, lanAddress, sizeof(lanAddress));
+#endif
 	freeUPNPDevlist(devlist);
 	if (error != 1)
 	{


### PR DESCRIPTION
See https://github.com/miniupnp/miniupnp/blob/miniupnpc_2_2_8/miniupnpc/Changelog.txt.

I didn’t bump the vendored dependency since I’m not sure what your policy on that is, but this helps Linux distributions that use their own `miniupnpc` package.