### PR TITLE
ci: bump actions/setup-python to v5

### DIFF
--- a/.github/workflows/crowdin_prep.yml
+++ b/.github/workflows/crowdin_prep.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: zulu
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/.github/workflows/crowdin_translate.yml
+++ b/.github/workflows/crowdin_translate.yml
@@ -18,7 +18,7 @@ jobs:
           distribution: zulu
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
Fix the following warning in https://github.com/flyinghead/flycast/actions/runs/10118310701:
> The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/setup-python@v4. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/