### PR TITLE
Fix `{Push,Pop}StyleVar` assert

### DIFF
--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1486,13 +1486,15 @@ void error_popup()
 		{
 			ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + uiScaled(400.f));
 			ImGui::TextWrapped("%s", error_msg.c_str());
-			ImguiStyleVar _(ImGuiStyleVar_FramePadding, ScaledVec2(16, 3));
-			float currentwidth = ImGui::GetContentRegionAvail().x;
-			ImGui::SetCursorPosX((currentwidth - uiScaled(80.f)) / 2.f + ImGui::GetStyle().WindowPadding.x);
-			if (ImGui::Button("OK", ScaledVec2(80.f, 0)))
 			{
-				error_msg.clear();
-				ImGui::CloseCurrentPopup();
+				ImguiStyleVar _(ImGuiStyleVar_FramePadding, ScaledVec2(16, 3));
+				float currentwidth = ImGui::GetContentRegionAvail().x;
+				ImGui::SetCursorPosX((currentwidth - uiScaled(80.f)) / 2.f + ImGui::GetStyle().WindowPadding.x);
+				if (ImGui::Button("OK", ScaledVec2(80.f, 0)))
+				{
+					error_msg.clear();
+					ImGui::CloseCurrentPopup();
+				}
 			}
 			ImGui::SetItemDefaultFocus();
 			ImGui::PopTextWrapPos();
@@ -1513,25 +1515,27 @@ static void contentpath_warning_popup()
         {
             ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + uiScaled(400.f));
             ImGui::TextWrapped("  Scanned %d folders but no game can be found!  ", scanner.empty_folders_scanned);
-            ImguiStyleVar _(ImGuiStyleVar_FramePadding, ScaledVec2(16, 3));
-            float currentwidth = ImGui::GetContentRegionAvail().x;
-            ImGui::SetCursorPosX((currentwidth - uiScaled(100.f)) / 2.f + ImGui::GetStyle().WindowPadding.x - uiScaled(55.f));
-            if (ImGui::Button("Reselect", ScaledVec2(100.f, 0)))
-            {
-            	scanner.content_path_looks_incorrect = false;
-                ImGui::CloseCurrentPopup();
-                show_contentpath_selection = true;
-            }
+			{
+				ImguiStyleVar _(ImGuiStyleVar_FramePadding, ScaledVec2(16, 3));
+				float currentwidth = ImGui::GetContentRegionAvail().x;
+				ImGui::SetCursorPosX((currentwidth - uiScaled(100.f)) / 2.f + ImGui::GetStyle().WindowPadding.x - uiScaled(55.f));
+				if (ImGui::Button("Reselect", ScaledVec2(100.f, 0)))
+				{
+					scanner.content_path_looks_incorrect = false;
+					ImGui::CloseCurrentPopup();
+					show_contentpath_selection = true;
+				}
 
-            ImGui::SameLine();
-            ImGui::SetCursorPosX((currentwidth - uiScaled(100.f)) / 2.f + ImGui::GetStyle().WindowPadding.x + uiScaled(55.f));
-            if (ImGui::Button("Cancel", ScaledVec2(100.f, 0)))
-            {
-            	scanner.content_path_looks_incorrect = false;
-                ImGui::CloseCurrentPopup();
-                scanner.stop();
-                config::ContentPath.get().clear();
-            }
+				ImGui::SameLine();
+				ImGui::SetCursorPosX((currentwidth - uiScaled(100.f)) / 2.f + ImGui::GetStyle().WindowPadding.x + uiScaled(55.f));
+				if (ImGui::Button("Cancel", ScaledVec2(100.f, 0)))
+				{
+					scanner.content_path_looks_incorrect = false;
+					ImGui::CloseCurrentPopup();
+					scanner.stop();
+					config::ContentPath.get().clear();
+				}
+			}
             ImGui::SetItemDefaultFocus();
             ImGui::EndPopup();
         }


### PR DESCRIPTION
When entering an error or contentpath warning popup, there are two `ImguiStyleVar` on the stack. Within the pop-up frame, an additional `ImguiStyleVar` is added. When the popup ends, there is technically one more ImguiStyleVar on the internal stack than when we entered the popup, causing an assert to hit:

```
Program: G:\flycast\out\build\x64-Debug\flycast.exe
File: G:\flycast\core\deps\imgui\imgui.cpp
Line: 10104

Expression: SizeOfStyleVarStack >= g.StyleVarStack.Size && "PushStyleVar/PopStyleVar Mismatch!"
```

These nested imgui RAII objects need to be scoped such that the stack is preserved both upon entry and exit of these popups to avoid these asserts.