### PR TITLE
vk: Determine object type enum when setting object name

### DIFF
--- a/core/rend/vulkan/overlay.cpp
+++ b/core/rend/vulkan/overlay.cpp
@@ -89,7 +89,7 @@ void VulkanOverlay::Prepare(vk::CommandBuffer cmdBuffer, bool vmu, bool crosshai
 				texture->deferDeleteResource(VulkanContext::Instance());
 			texture = createTexture(cmdBuffer, 48, 32, (u8*)vmu_lcd_data[i]);
 #ifdef VK_DEBUG
-			VulkanContext::Instance()->setObjectName((VkImageView)texture->GetImageView(), vk::ImageView::objectType, "VMU " + std::to_string(i));
+			VulkanContext::Instance()->setObjectName(texture->GetImageView(), "VMU " + std::to_string(i));
 #endif
 			this->vmuLastChanged[i] = ::vmuLastChanged[i];
 		}

--- a/core/rend/vulkan/texture.cpp
+++ b/core/rend/vulkan/texture.cpp
@@ -251,8 +251,8 @@ void Texture::CreateImage(vk::ImageTiling tiling, vk::ImageUsageFlags usage, vk:
 #ifdef VK_DEBUG
 	char name[128];
 	sprintf(name, "texture @ %x", startAddress);
-	VulkanContext::Instance()->setObjectName((VkImage)image.get(), vk::Image::objectType, name);
-	VulkanContext::Instance()->setObjectName((VkImageView)imageView.get(), vk::ImageView::objectType, name);
+	VulkanContext::Instance()->setObjectName(image.get(), name);
+	VulkanContext::Instance()->setObjectName(imageView.get(), name);
 #endif
 }
 
@@ -444,7 +444,7 @@ void FramebufferAttachment::Init(u32 width, u32 height, vk::Format format, const
 	image = device.createImageUnique(imageCreateInfo);
 #ifdef VK_DEBUG
 	if (!name.empty())
-		VulkanContext::Instance()->setObjectName((VkImage)image.get(), vk::Image::objectType, name);
+		VulkanContext::Instance()->setObjectName(image.get(), name);
 #endif
 
 	VmaAllocationCreateInfo allocCreateInfo = { VmaAllocationCreateFlags(), VmaMemoryUsage::VMA_MEMORY_USAGE_GPU_ONLY };
@@ -459,7 +459,7 @@ void FramebufferAttachment::Init(u32 width, u32 height, vk::Format format, const
 		imageView = device.createImageViewUnique(imageViewCreateInfo);
 #ifdef VK_DEBUG
 		if (!name.empty())
-			VulkanContext::Instance()->setObjectName((VkImageView)imageView.get(), vk::ImageView::objectType, name);
+			VulkanContext::Instance()->setObjectName(imageView.get(), name);
 #endif
 
 		if ((usage & vk::ImageUsageFlagBits::eDepthStencilAttachment) && (usage & vk::ImageUsageFlagBits::eInputAttachment))
@@ -469,7 +469,7 @@ void FramebufferAttachment::Init(u32 width, u32 height, vk::Format format, const
 			stencilView = device.createImageViewUnique(imageViewCreateInfo);
 #ifdef VK_DEBUG
 			if (!name.empty())
-				VulkanContext::Instance()->setObjectName((VkImageView)stencilView.get(), vk::ImageView::objectType, name);
+				VulkanContext::Instance()->setObjectName(stencilView.get(), name);
 #endif
 		}
 	}

--- a/core/rend/vulkan/vk_context_lr.h
+++ b/core/rend/vulkan/vk_context_lr.h
@@ -100,7 +100,10 @@ public:
 		commandPool.addToFlight(object);
 	}
 #ifdef VK_DEBUG
-	void setObjectName(VkHandle object, vk::ObjectType objectType, const std::string& name) {}
+	template<typename HandleType, typename = std::enable_if_t<vk::isVulkanHandleType<HandleType>::value>>
+	void setObjectName(const HandleType& object, const std::string& name)
+	{
+	}
 #endif
 
 	constexpr static int VENDOR_AMD = 0x1022;

--- a/core/rend/vulkan/vulkan_context.h
+++ b/core/rend/vulkan/vulkan_context.h
@@ -121,11 +121,12 @@ public:
 	}
 
 #ifdef VK_DEBUG
-	void setObjectName(VkHandle object, vk::ObjectType objectType, const std::string& name)
+	template<typename HandleType, typename = std::enable_if_t<vk::isVulkanHandleType<HandleType>::value>>
+	void setObjectName(const HandleType& object, const std::string& name)
 	{
 		vk::DebugUtilsObjectNameInfoEXT nameInfo {};
-		nameInfo.objectType = objectType;
-		nameInfo.objectHandle = (uint64_t)object;
+		nameInfo.objectType = HandleType::objectType;
+		nameInfo.objectHandle = reinterpret_cast<uint64_t>(static_cast<typename HandleType::NativeType>(object));
 		nameInfo.pObjectName = name.c_str();
 		if (device) {
 			vk::Result e = device->setDebugUtilsObjectNameEXT(&nameInfo);


### PR DESCRIPTION
Uses compile-time type-information provided by vulkan-hpp to automatically determine a vulkan-object's `objectType` when calling `setObjectName`.