### PR TITLE
vk: Use matching u/v/w sampler address-mode when possible

### DIFF
--- a/core/rend/vulkan/texture.h
+++ b/core/rend/vulkan/texture.h
@@ -125,6 +125,11 @@ public:
 		const vk::SamplerAddressMode vRepeat = tsp.ClampV ? vk::SamplerAddressMode::eClampToEdge
 				: tsp.FlipV ? vk::SamplerAddressMode::eMirroredRepeat : vk::SamplerAddressMode::eRepeat;
 
+		// The W-axis is unused for 2D textures
+		// Try to keep all three of the wrapping-modes the same by just repeating vRepeat for wRepeat
+		// BestPractices-Arm-vkCreateSampler-different-wrapping-modes
+		const vk::SamplerAddressMode wRepeat = vRepeat;
+
 		const bool anisotropicFiltering = config::AnisotropicFiltering > 1 && VulkanContext::Instance()->SupportsSamplerAnisotropy()
 				&& filter == vk::Filter::eLinear && !punchThrough;
 #ifndef __APPLE__
@@ -137,7 +142,7 @@ public:
 		return samplers.emplace(
 					std::make_pair(samplerHash, VulkanContext::Instance()->GetDevice().createSamplerUnique(
 						vk::SamplerCreateInfo(vk::SamplerCreateFlags(), filter, filter,
-							mipmapMode, uRepeat, vRepeat, vk::SamplerAddressMode::eClampToEdge, mipLodBias,
+							mipmapMode, uRepeat, vRepeat, wRepeat, mipLodBias,
 							anisotropicFiltering, std::min((float)config::AnisotropicFiltering, VulkanContext::Instance()->GetMaxSamplerAnisotropy()),
 							false, vk::CompareOp::eNever,
 							0.0f, vk::LodClampNone, vk::BorderColor::eFloatOpaqueBlack)))).first->second.get();

--- a/core/rend/vulkan/vulkan_driver.h
+++ b/core/rend/vulkan/vulkan_driver.h
@@ -99,7 +99,7 @@ public:
 								vk::SamplerMipmapMode::eNearest,
 								vk::SamplerAddressMode::eClampToBorder,
 								vk::SamplerAddressMode::eClampToBorder,
-								vk::SamplerAddressMode::eClampToEdge, 0.0f, false,
+								vk::SamplerAddressMode::eClampToBorder, 0.0f, false,
 								0.f, false, vk::CompareOp::eNever, 0.0f, VK_LOD_CLAMP_NONE,
 								vk::BorderColor::eFloatTransparentBlack));
 			}
@@ -115,7 +115,7 @@ public:
 								vk::SamplerMipmapMode::eLinear,
 								vk::SamplerAddressMode::eClampToBorder,
 								vk::SamplerAddressMode::eClampToBorder,
-								vk::SamplerAddressMode::eClampToEdge, 0.0f, false,
+								vk::SamplerAddressMode::eClampToBorder, 0.0f, false,
 								0.f, false, vk::CompareOp::eNever, 0.0f, VK_LOD_CLAMP_NONE,
 								vk::BorderColor::eFloatTransparentBlack));
 			}


### PR DESCRIPTION
This addresses the `BestPractices-Arm-vkCreateSampler-different-wrapping-modes` message from ARM: https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/65b79bac615ec1c47ab61a02d55a3bba871b56b9/layers/best_practices/bp_descriptor.cpp#L95-L100

The `W`-axis for these samplers is always unused, it's never the case that these samplers are going to be used for 3D textures. ARM suggests trying to keep all of the wrapping-modes the same if possible for performance.

`wRepeat` will be set to the same value as `vRepeat` to try and encourage all three wrapping-modes to be the same.