### PR TITLE
vk: Disable LOD clamping in samplers

### DIFF
--- a/core/rend/vulkan/pipeline.h
+++ b/core/rend/vulkan/pipeline.h
@@ -398,7 +398,7 @@ public:
 					vk::SamplerCreateInfo(vk::SamplerCreateFlags(), vk::Filter::eLinear, vk::Filter::eLinear,
 										vk::SamplerMipmapMode::eLinear, vk::SamplerAddressMode::eClampToEdge, vk::SamplerAddressMode::eClampToEdge,
 										vk::SamplerAddressMode::eClampToEdge, 0.0f, false, 16.0f, false,
-										vk::CompareOp::eNever, 0.0f, 0.0f, vk::BorderColor::eFloatOpaqueBlack));
+										vk::CompareOp::eNever, 0.0f, vk::LodClampNone, vk::BorderColor::eFloatOpaqueBlack));
 		}
 		if (this->renderPass != renderPass)
 		{

--- a/core/rend/vulkan/quad.cpp
+++ b/core/rend/vulkan/quad.cpp
@@ -137,7 +137,7 @@ void QuadPipeline::Init(ShaderManager *shaderManager, vk::RenderPass renderPass,
 						vk::SamplerAddressMode::eClampToEdge,
 						vk::SamplerAddressMode::eClampToEdge,
 						vk::SamplerAddressMode::eClampToEdge, 0.0f, false,
-						16.0f, false, vk::CompareOp::eNever, 0.0f, 0.0f,
+						16.0f, false, vk::CompareOp::eNever, 0.0f, vk::LodClampNone,
 						vk::BorderColor::eFloatOpaqueBlack));
 	}
 	if (!nearestSampler)
@@ -149,7 +149,7 @@ void QuadPipeline::Init(ShaderManager *shaderManager, vk::RenderPass renderPass,
 						vk::SamplerAddressMode::eClampToEdge,
 						vk::SamplerAddressMode::eClampToEdge,
 						vk::SamplerAddressMode::eClampToEdge, 0.0f, false,
-						16.0f, false, vk::CompareOp::eNever, 0.0f, 0.0f,
+						16.0f, false, vk::CompareOp::eNever, 0.0f, vk::LodClampNone,
 						vk::BorderColor::eFloatOpaqueBlack));
 	}
 	if (this->renderPass != renderPass)

--- a/core/rend/vulkan/vulkan_driver.h
+++ b/core/rend/vulkan/vulkan_driver.h
@@ -100,7 +100,7 @@ public:
 								vk::SamplerAddressMode::eClampToBorder,
 								vk::SamplerAddressMode::eClampToBorder,
 								vk::SamplerAddressMode::eClampToEdge, 0.0f, false,
-								0.f, false, vk::CompareOp::eNever, 0.0f, VK_LOD_CLAMP_NONE,
+								0.f, false, vk::CompareOp::eNever, 0.0f, vk::LodClampNone,
 								vk::BorderColor::eFloatTransparentBlack));
 			}
 			sampler = (VkSampler)*pointSampler;
@@ -116,7 +116,7 @@ public:
 								vk::SamplerAddressMode::eClampToBorder,
 								vk::SamplerAddressMode::eClampToBorder,
 								vk::SamplerAddressMode::eClampToEdge, 0.0f, false,
-								0.f, false, vk::CompareOp::eNever, 0.0f, VK_LOD_CLAMP_NONE,
+								0.f, false, vk::CompareOp::eNever, 0.0f, vk::LodClampNone,
 								vk::BorderColor::eFloatTransparentBlack));
 			}
 			sampler = (VkSampler)*linearSampler;


### PR DESCRIPTION
This addresses the `BestPractices-Arm-vkCreateSampler-lod-clamping` message from ARM: https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/65b79bac615ec1c47ab61a02d55a3bba871b56b9/layers/best_practices/bp_descriptor.cpp#L103-L110

Rather than clamping the LOD in the samplers, instead rely on the Image-View's `vk::ImageSubresourceRange` to limit the number of sampled LODs.

Currently, only game-textures actually have MipMaps, so this does not introduce any additional mip-map sampling or filtering anywhere. If any code want's to actually limit the number of LODs sampled, then they would allocate an additional ImageView for the range of MipMaps to be sampled.