### PR TITLE
vk: Add `CommandBufferDebugScope` utility-type

### DIFF
--- a/core/rend/vulkan/drawer.cpp
+++ b/core/rend/vulkan/drawer.cpp
@@ -82,6 +82,9 @@ void BaseDrawer::SetBaseScissor(const vk::Extent2D& viewport)
 
 void BaseDrawer::scaleAndWriteFramebuffer(vk::CommandBuffer commandBuffer, FramebufferAttachment *finalFB)
 {
+	static const float scopeColor[4] = { 0.25f, 0.25f, 0.25f, 0.25f };
+	CommandBufferDebugScope _(commandBuffer, "scaleAndWriteFramebuffer", scopeColor);
+
 	u32 width = (pvrrc.ta_GLOB_TILE_CLIP.tile_x_num + 1) * 32;
 	u32 height = (pvrrc.ta_GLOB_TILE_CLIP.tile_y_num + 1) * 32;
 
@@ -162,6 +165,9 @@ void BaseDrawer::scaleAndWriteFramebuffer(vk::CommandBuffer commandBuffer, Frame
 
 void Drawer::DrawPoly(const vk::CommandBuffer& cmdBuffer, u32 listType, bool sortTriangles, const PolyParam& poly, u32 first, u32 count)
 {
+	static const float scopeColor[4] = { 0.25f, 0.50f, 0.25f, 1.0f };
+	CommandBufferDebugScope _(cmdBuffer, "DrawPoly", scopeColor);
+
 	vk::Rect2D scissorRect;
 	TileClipping tileClip = SetTileClip(poly.tileclip, scissorRect);
 	if (tileClip == TileClipping::Outside)
@@ -239,6 +245,10 @@ void Drawer::DrawSorted(const vk::CommandBuffer& cmdBuffer, const std::vector<So
 {
 	if (first == last)
 		return;
+
+	static const float scopeColor[4] = { 0.25f, 0.50f, 0.50f, 1.0f };
+	CommandBufferDebugScope _(cmdBuffer, "DrawSorted", scopeColor);
+
 	for (u32 idx = first; idx < last; idx++)
 		DrawPoly(cmdBuffer, ListType_Translucent, true, pvrrc.global_param_tr[polys[idx].polyIndex], polys[idx].first, polys[idx].count);
 	if (multipass && config::TranslucentPolygonDepthMask)
@@ -267,6 +277,10 @@ void Drawer::DrawList(const vk::CommandBuffer& cmdBuffer, u32 listType, bool sor
 {
 	if (first == last)
 		return;
+
+	static const float scopeColor[4] = { 0.50f, 0.25f, 0.50f, 1.0f };
+	CommandBufferDebugScope _(cmdBuffer, "DrawList", scopeColor);
+
 	const PolyParam *pp_end = polys.data() + last;
 	for (const PolyParam *pp = &polys[first]; pp != pp_end; pp++)
 		if (pp->count > 2)
@@ -277,6 +291,9 @@ void Drawer::DrawModVols(const vk::CommandBuffer& cmdBuffer, int first, int coun
 {
 	if (count == 0 || pvrrc.modtrig.empty() || !config::ModifierVolumes)
 		return;
+
+	static const float scopeColor[4] = { 0.75f, 0.25f, 0.25f, 1.0f };
+	CommandBufferDebugScope _(cmdBuffer, "DrawModVols", scopeColor);
 
 	cmdBuffer.bindVertexBuffers(0, curMainBuffer, offsets.modVolOffset);
 	SetScissor(cmdBuffer, baseScissor);
@@ -383,6 +400,9 @@ bool Drawer::Draw(const Texture *fogTexture, const Texture *paletteTexture)
 	currentScissor = vk::Rect2D();
 
 	vk::CommandBuffer cmdBuffer = BeginRenderPass();
+
+	static const float scopeColor[4] = { 0.75f, 0.75f, 0.75f, 1.0f };
+	CommandBufferDebugScope _(cmdBuffer, "Draw", scopeColor);
 
 	setFirstProvokingVertex(pvrrc);
 

--- a/core/rend/vulkan/oit/oit_drawer.cpp
+++ b/core/rend/vulkan/oit/oit_drawer.cpp
@@ -28,6 +28,9 @@
 void OITDrawer::DrawPoly(const vk::CommandBuffer& cmdBuffer, u32 listType, bool autosort, Pass pass,
 		const PolyParam& poly, u32 first, u32 count)
 {
+	static const float scopeColor[4] = { 0.25f, 0.50f, 0.25f, 1.0f };
+	CommandBufferDebugScope _(cmdBuffer, "DrawPoly(OIT)", scopeColor);
+
 	vk::Rect2D scissorRect;
 	TileClipping tileClip = SetTileClip(poly.tileclip, scissorRect);
 	if (tileClip == TileClipping::Outside)
@@ -133,6 +136,10 @@ void OITDrawer::DrawList(const vk::CommandBuffer& cmdBuffer, u32 listType, bool 
 {
 	if (first == last)
 		return;
+
+	static const float scopeColor[4] = { 0.50f, 0.25f, 0.50f, 1.0f };
+	CommandBufferDebugScope _(cmdBuffer, "DrawList(OIT)", scopeColor);
+
 	const PolyParam *pp_end = polys.data() + last;
 	for (const PolyParam *pp = &polys[first]; pp != pp_end; pp++)
 		if (pp->count > 2)
@@ -144,6 +151,9 @@ void OITDrawer::DrawModifierVolumes(const vk::CommandBuffer& cmdBuffer, int firs
 {
 	if (count == 0 || pvrrc.modtrig.empty() || !config::ModifierVolumes)
 		return;
+
+	static const float scopeColor[4] = { 0.75f, 0.25f, 0.25f, 1.0f };
+	CommandBufferDebugScope _(cmdBuffer, "DrawModVols(OIT)", scopeColor);
 
 	cmdBuffer.bindVertexBuffers(0, curMainBuffer, offsets.modVolOffset);
 	SetScissor(cmdBuffer, baseScissor);
@@ -277,6 +287,9 @@ vk::Framebuffer OITTextureDrawer::getFramebuffer(int renderPass, int renderPassC
 bool OITDrawer::Draw(const Texture *fogTexture, const Texture *paletteTexture)
 {
 	vk::CommandBuffer cmdBuffer = NewFrame();
+
+	static const float scopeColor[4] = { 0.75f, 0.75f, 0.75f, 1.0f };
+	CommandBufferDebugScope _(cmdBuffer, "Draw(OIT)", scopeColor);
 
 	if (needAttachmentTransition)
 	{

--- a/core/rend/vulkan/texture.cpp
+++ b/core/rend/vulkan/texture.cpp
@@ -25,6 +25,9 @@
 
 void setImageLayout(vk::CommandBuffer const& commandBuffer, vk::Image image, vk::Format format, u32 mipmapLevels, vk::ImageLayout oldImageLayout, vk::ImageLayout newImageLayout)
 {
+	static const float scopeColor[4] = { 0.75f, 0.75f, 0.0f, 1.0f };
+	CommandBufferDebugScope _(commandBuffer, "setImageLayout", scopeColor);
+
 	vk::AccessFlags sourceAccessMask;
 	switch (oldImageLayout)
 	{
@@ -260,6 +263,9 @@ void Texture::SetImage(u32 srcSize, const void *srcData, bool isNew, bool genMip
 {
 	verify((bool)commandBuffer);
 
+	static const float scopeColor[4] = { 1.0f, 1.0f, 0.0f, 1.0f };
+	CommandBufferDebugScope _(commandBuffer, "SetImage", scopeColor);
+
 	if (!isNew && !needsStaging)
 		setImageLayout(commandBuffer, image.get(), format, mipmapLevels, vk::ImageLayout::eShaderReadOnlyOptimal, vk::ImageLayout::eGeneral);
 
@@ -354,6 +360,9 @@ void Texture::SetImage(u32 srcSize, const void *srcData, bool isNew, bool genMip
 
 void Texture::GenerateMipmaps()
 {
+	static const float scopeColor[4] = { 0.75f, 0.75f, 0.0f, 1.0f };
+	CommandBufferDebugScope _(commandBuffer, "GenerateMipmaps", scopeColor);
+
 	u32 mipWidth = extent.width;
 	u32 mipHeight = extent.height;
 	vk::ImageMemoryBarrier barrier(vk::AccessFlagBits::eTransferWrite, vk::AccessFlagBits::eTransferRead,

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -938,6 +938,10 @@ void VulkanContext::DrawFrame(vk::ImageView imageView, const vk::Extent2D& exten
 	vtx[2].y = vtx[3].y = vtx[0].y + 2;
 
 	vk::CommandBuffer commandBuffer = GetCurrentCommandBuffer();
+
+	static const float scopeColor[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
+	CommandBufferDebugScope _(commandBuffer, "DrawFrame", scopeColor);
+
 	if (config::Rotate90)
 		quadRotatePipeline->BindPipeline(commandBuffer);
 	else
@@ -1291,6 +1295,10 @@ bool VulkanContext::GetLastFrame(std::vector<u8>& data, int& width, int& height)
 	vk::UniqueCommandBuffer commandBuffer = std::move(device->allocateCommandBuffersUnique(
 			vk::CommandBufferAllocateInfo(*commandPools.back(), vk::CommandBufferLevel::ePrimary, 1)).front());
 	commandBuffer->begin(vk::CommandBufferBeginInfo(vk::CommandBufferUsageFlagBits::eOneTimeSubmit));
+
+	static const float scopeColor[4] = { 1.0f, 1.0f, 0.0f, 1.0f };
+	CommandBufferDebugScope _(commandBuffer.get(), "GetLastFrame", scopeColor);
+
 	// render pass
 	vk::AttachmentDescription attachmentDescription = vk::AttachmentDescription(vk::AttachmentDescriptionFlags(), vk::Format::eR8G8B8A8Unorm, vk::SampleCountFlagBits::e1,
 			vk::AttachmentLoadOp::eClear, vk::AttachmentStoreOp::eStore, vk::AttachmentLoadOp::eDontCare, vk::AttachmentStoreOp::eDontCare,

--- a/core/rend/vulkan/vulkan_driver.h
+++ b/core/rend/vulkan/vulkan_driver.h
@@ -59,8 +59,13 @@ public:
 				context->PresentLastFrame();
 			}
 			if (!justStarted)
+			{
+				const vk::CommandBuffer targetCommandBuffer = getCommandBuffer();
+				static const float scopeColor[4] = {0.26f, 0.59f, 0.98f, 0.31f};
+				CommandBufferDebugScope _(targetCommandBuffer, "ImGui", scopeColor);
 				// Record Imgui Draw Data and draw funcs into command buffer
 				ImGui_ImplVulkan_RenderDrawData(drawData, (VkCommandBuffer)getCommandBuffer());
+			}
 			justStarted = false;
 			if (!rendering || newFrameStarted)
 				context->EndFrame();


### PR DESCRIPTION
Adds a new RAII-based utility type for adding diagnostic information to command buffers. Enabled only when `VK_DEBUG` is set to `1`.

[This allows GPU tooling such as RenderDoc and NSight to have additional diagnostic information attached to each command buffer](https://wunkolo.github.io/post/2024/09/gpu-debug-scopes/) to help with diagnosing rendering issues.

Before:
![qrenderdoc_SG85ylMU10](https://github.com/user-attachments/assets/58c74d7a-a54f-4d2b-824a-0c793055abdb)

After:
![qrenderdoc_SKqsThRJNb](https://github.com/user-attachments/assets/f657fa70-d5a7-484c-bf74-86df80d585d3)
