### PR TITLE
vk: Add `VK_EXT_provoking_vertex` optimization

### DIFF
--- a/core/rend/vulkan/drawer.cpp
+++ b/core/rend/vulkan/drawer.cpp
@@ -404,7 +404,15 @@ bool Drawer::Draw(const Texture *fogTexture, const Texture *paletteTexture)
 	static const float scopeColor[4] = { 0.75f, 0.75f, 0.75f, 1.0f };
 	CommandBufferDebugScope _(cmdBuffer, "Draw", scopeColor);
 
-	setFirstProvokingVertex(pvrrc);
+	if (VulkanContext::Instance()->hasProvokingVertex())
+	{
+		// Pipelines are using VK_EXT_provoking_vertex, no need to
+		// re-order vertices
+	}
+	else
+	{
+		setFirstProvokingVertex(pvrrc);
+	}
 
 	// Upload vertex and index buffers
 	VertexShaderUniforms vtxUniforms;

--- a/core/rend/vulkan/oit/oit_drawer.cpp
+++ b/core/rend/vulkan/oit/oit_drawer.cpp
@@ -341,7 +341,15 @@ bool OITDrawer::Draw(const Texture *fogTexture, const Texture *paletteTexture)
 	bool firstFrameAfterInit = oitBuffers->isFirstFrameAfterInit();
 	oitBuffers->OnNewFrame(cmdBuffer);
 
-	setFirstProvokingVertex(pvrrc);
+	if (VulkanContext::Instance()->hasProvokingVertex())
+	{
+		// Pipelines are using VK_EXT_provoking_vertex, no need to
+		// re-order vertices
+	}
+	else
+	{
+		setFirstProvokingVertex(pvrrc);
+	}
 
 	// Upload vertex and index buffers
 	UploadMainBuffer(vtxUniforms, fragUniforms);

--- a/core/rend/vulkan/oit/oit_pipeline.cpp
+++ b/core/rend/vulkan/oit/oit_pipeline.cpp
@@ -222,6 +222,17 @@ void OITPipelineManager::CreateFinalPipeline(bool dithering)
 	  0.0f,                                         // depthBiasSlopeFactor
 	  1.0f                                          // lineWidth
 	);
+
+	// Dreamcast uses the last vertex as the provoking vertex, but Vulkan uses the first.
+	// Utilize VK_EXT_provoking_vertex when available to set the provoking vertex to be the
+	// last vertex
+	vk::PipelineRasterizationProvokingVertexStateCreateInfoEXT provokingVertexInfo{};
+	if (GetContext()->hasProvokingVertex())
+	{
+		provokingVertexInfo.provokingVertexMode = vk::ProvokingVertexModeEXT::eLastVertex;
+		pipelineRasterizationStateCreateInfo.pNext = &provokingVertexInfo;
+	}
+
 	vk::PipelineMultisampleStateCreateInfo pipelineMultisampleStateCreateInfo;
 
 	// Depth and stencil

--- a/core/rend/vulkan/oit/oit_pipeline.cpp
+++ b/core/rend/vulkan/oit/oit_pipeline.cpp
@@ -49,6 +49,17 @@ void OITPipelineManager::CreatePipeline(u32 listType, bool autosort, const PolyP
 	  0.0f,                                         // depthBiasSlopeFactor
 	  1.0f                                          // lineWidth
 	);
+
+	// Dreamcast uses the last vertex as the provoking vertex, but Vulkan uses the first.
+	// Utilize VK_EXT_provoking_vertex when available to set the provoking vertex to be the
+	// last vertex
+	vk::PipelineRasterizationProvokingVertexStateCreateInfoEXT provokingVertexInfo{};
+	if (GetContext()->hasProvokingVertex())
+	{
+		provokingVertexInfo.provokingVertexMode = vk::ProvokingVertexModeEXT::eLastVertex;
+		pipelineRasterizationStateCreateInfo.pNext = &provokingVertexInfo;
+	}
+
 	vk::PipelineMultisampleStateCreateInfo pipelineMultisampleStateCreateInfo;
 
 	// Depth and stencil

--- a/core/rend/vulkan/oit/oit_pipeline.cpp
+++ b/core/rend/vulkan/oit/oit_pipeline.cpp
@@ -317,6 +317,17 @@ void OITPipelineManager::CreateClearPipeline()
 	  0.0f,                                         // depthBiasSlopeFactor
 	  1.0f                                          // lineWidth
 	);
+
+	// Dreamcast uses the last vertex as the provoking vertex, but Vulkan uses the first.
+	// Utilize VK_EXT_provoking_vertex when available to set the provoking vertex to be the
+	// last vertex
+	vk::PipelineRasterizationProvokingVertexStateCreateInfoEXT provokingVertexInfo{};
+	if (GetContext()->hasProvokingVertex())
+	{
+		provokingVertexInfo.provokingVertexMode = vk::ProvokingVertexModeEXT::eLastVertex;
+		pipelineRasterizationStateCreateInfo.pNext = &provokingVertexInfo;
+	}
+
 	vk::PipelineMultisampleStateCreateInfo pipelineMultisampleStateCreateInfo;
 
 	// Depth and stencil
@@ -522,6 +533,17 @@ void OITPipelineManager::CreateTrModVolPipeline(ModVolMode mode, int cullMode, b
 	  0.0f,                                         // depthBiasSlopeFactor
 	  1.0f                                          // lineWidth
 	);
+
+	// Dreamcast uses the last vertex as the provoking vertex, but Vulkan uses the first.
+	// Utilize VK_EXT_provoking_vertex when available to set the provoking vertex to be the
+	// last vertex
+	vk::PipelineRasterizationProvokingVertexStateCreateInfoEXT provokingVertexInfo{};
+	if (GetContext()->hasProvokingVertex())
+	{
+		provokingVertexInfo.provokingVertexMode = vk::ProvokingVertexModeEXT::eLastVertex;
+		pipelineRasterizationStateCreateInfo.pNext = &provokingVertexInfo;
+	}
+
 	vk::PipelineMultisampleStateCreateInfo pipelineMultisampleStateCreateInfo;
 
 	// Depth and stencil

--- a/core/rend/vulkan/oit/oit_pipeline.cpp
+++ b/core/rend/vulkan/oit/oit_pipeline.cpp
@@ -399,6 +399,17 @@ void OITPipelineManager::CreateModVolPipeline(ModVolMode mode, int cullMode, boo
 	  0.0f,                                         // depthBiasSlopeFactor
 	  1.0f                                          // lineWidth
 	);
+
+	// Dreamcast uses the last vertex as the provoking vertex, but Vulkan uses the first.
+	// Utilize VK_EXT_provoking_vertex when available to set the provoking vertex to be the
+	// last vertex
+	vk::PipelineRasterizationProvokingVertexStateCreateInfoEXT provokingVertexInfo{};
+	if (GetContext()->hasProvokingVertex())
+	{
+		provokingVertexInfo.provokingVertexMode = vk::ProvokingVertexModeEXT::eLastVertex;
+		pipelineRasterizationStateCreateInfo.pNext = &provokingVertexInfo;
+	}
+
 	vk::PipelineMultisampleStateCreateInfo pipelineMultisampleStateCreateInfo;
 
 	// Depth and stencil

--- a/core/rend/vulkan/pipeline.cpp
+++ b/core/rend/vulkan/pipeline.cpp
@@ -67,6 +67,17 @@ void PipelineManager::CreateModVolPipeline(ModVolMode mode, int cullMode, bool n
 	  0.0f,                                         // depthBiasSlopeFactor
 	  1.0f                                          // lineWidth
 	);
+
+	// Dreamcast uses the last vertex as the provoking vertex, but Vulkan uses the first.
+	// Utilize VK_EXT_provoking_vertex when available to set the provoking vertex to be the
+	// last vertex
+	vk::PipelineRasterizationProvokingVertexStateCreateInfoEXT provokingVertexInfo{};
+	if (GetContext()->hasProvokingVertex())
+	{
+		provokingVertexInfo.provokingVertexMode = vk::ProvokingVertexModeEXT::eLastVertex;
+		pipelineRasterizationStateCreateInfo.pNext = &provokingVertexInfo;
+	}
+
 	vk::PipelineMultisampleStateCreateInfo pipelineMultisampleStateCreateInfo;
 
 	// Depth and stencil

--- a/core/rend/vulkan/pipeline.cpp
+++ b/core/rend/vulkan/pipeline.cpp
@@ -200,6 +200,17 @@ void PipelineManager::CreateDepthPassPipeline(int cullMode, bool naomi2)
 	  0.0f,                                         // depthBiasSlopeFactor
 	  1.0f                                          // lineWidth
 	);
+
+	// Dreamcast uses the last vertex as the provoking vertex, but Vulkan uses the first.
+	// Utilize VK_EXT_provoking_vertex when available to set the provoking vertex to be the
+	// last vertex
+	vk::PipelineRasterizationProvokingVertexStateCreateInfoEXT provokingVertexInfo{};
+	if (GetContext()->hasProvokingVertex())
+	{
+		provokingVertexInfo.provokingVertexMode = vk::ProvokingVertexModeEXT::eLastVertex;
+		pipelineRasterizationStateCreateInfo.pNext = &provokingVertexInfo;
+	}
+
 	vk::PipelineMultisampleStateCreateInfo pipelineMultisampleStateCreateInfo;
 
 	// Depth and stencil

--- a/core/rend/vulkan/pipeline.cpp
+++ b/core/rend/vulkan/pipeline.cpp
@@ -295,6 +295,17 @@ void PipelineManager::CreatePipeline(u32 listType, bool sortTriangles, const Pol
 	  0.0f,                                         // depthBiasSlopeFactor
 	  1.0f                                          // lineWidth
 	);
+
+	// Dreamcast uses the last vertex as the provoking vertex, but Vulkan uses the first.
+	// Utilize VK_EXT_provoking_vertex when available to set the provoking vertex to be the
+	// last vertex
+	vk::PipelineRasterizationProvokingVertexStateCreateInfoEXT provokingVertexInfo{};
+	if (GetContext()->hasProvokingVertex())
+	{
+		provokingVertexInfo.provokingVertexMode = vk::ProvokingVertexModeEXT::eLastVertex;
+		pipelineRasterizationStateCreateInfo.pNext = &provokingVertexInfo;
+	}
+
 	vk::PipelineMultisampleStateCreateInfo pipelineMultisampleStateCreateInfo;
 
 	// Depth and stencil

--- a/core/rend/vulkan/vk_context_lr.h
+++ b/core/rend/vulkan/vk_context_lr.h
@@ -92,6 +92,7 @@ public:
 	bool SupportsSamplerAnisotropy() const { return samplerAnisotropy; }
 	bool SupportsDedicatedAllocation() const { return dedicatedAllocationSupported; }
 	bool hasPerPixel() override { return fragmentStoresAndAtomics; }
+	bool hasProvokingVertex() { return provokingVertexSupported; }
 	const VMAllocator& GetAllocator() const { return allocator; }
 	vk::DeviceSize GetMaxMemoryAllocationSize() const { return maxMemoryAllocationSize; }
 	f32 GetMaxSamplerAnisotropy() const { return samplerAnisotropy ? maxSamplerAnisotropy : 1.f; }
@@ -129,10 +130,11 @@ private:
 	bool optimalTilingSupported1555 = false;
 	bool optimalTilingSupported4444 = false;
 public:
+	bool fragmentStoresAndAtomics = false;
 	bool samplerAnisotropy = false;
 	f32 maxSamplerAnisotropy = 0.f;
 	bool dedicatedAllocationSupported = false;
-	bool fragmentStoresAndAtomics = false;
+	bool provokingVertexSupported = false;
 private:
 	u32 vendorID = 0;
 

--- a/core/rend/vulkan/vmallocator.cpp
+++ b/core/rend/vulkan/vmallocator.cpp
@@ -55,7 +55,8 @@ void VMAllocator::Init(vk::PhysicalDevice physicalDevice, vk::Device device, vk:
 		allocatorInfo.flags |= VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT;
 
 	allocatorInfo.physicalDevice = (VkPhysicalDevice)physicalDevice;
-	allocatorInfo.vulkanApiVersion = physicalDevice.getProperties().apiVersion;
+	// Top-out at vulkan 1.1
+	allocatorInfo.vulkanApiVersion = (physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_1) ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0;
 	allocatorInfo.device = (VkDevice)device;
 	allocatorInfo.instance = (VkInstance)instance;
 #if !defined(NDEBUG) || defined(DEBUGFAST)

--- a/core/rend/vulkan/vmallocator.cpp
+++ b/core/rend/vulkan/vmallocator.cpp
@@ -55,6 +55,7 @@ void VMAllocator::Init(vk::PhysicalDevice physicalDevice, vk::Device device, vk:
 		allocatorInfo.flags |= VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT;
 
 	allocatorInfo.physicalDevice = (VkPhysicalDevice)physicalDevice;
+	allocatorInfo.vulkanApiVersion = physicalDevice.getProperties().apiVersion;
 	allocatorInfo.device = (VkDevice)device;
 	allocatorInfo.instance = (VkInstance)instance;
 #if !defined(NDEBUG) || defined(DEBUGFAST)

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -290,11 +290,6 @@ bool VulkanContext::InitInstance(const char** extensions, uint32_t extensions_co
 			optimalTilingSupported4444 = true;
 		else
 			NOTICE_LOG(RENDERER, "eR4G4B4A4UnormPack16 not supported for optimal tiling");
-		const auto features = physicalDevice.getFeatures();
-		fragmentStoresAndAtomics = !!features.fragmentStoresAndAtomics;
-		samplerAnisotropy = !!features.samplerAnisotropy;
-		if (!fragmentStoresAndAtomics)
-			NOTICE_LOG(RENDERER, "Fragment stores & atomic not supported: no per-pixel sorting");
 
 		ShaderCompiler::Init();
 
@@ -358,6 +353,8 @@ bool VulkanContext::InitDevice()
 		return false;
 	try
 	{
+		const vk::PhysicalDeviceProperties physicalDeviceProperties = physicalDevice.getProperties();
+
 		std::vector<vk::QueueFamilyProperties> queueFamilyProperties = physicalDevice.getQueueFamilyProperties();
 #ifdef VK_DEBUG
 		std::for_each(queueFamilyProperties.begin(), queueFamilyProperties.end(),
@@ -434,11 +431,6 @@ bool VulkanContext::InitDevice()
 		// Required swapchain extension
 		tryAddDeviceExtension(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
 
-		// Enable VK_KHR_dedicated_allocation if available
-		const bool getMemReq2Supported = tryAddDeviceExtension(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
-		dedicatedAllocationSupported = tryAddDeviceExtension(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
-		dedicatedAllocationSupported &= getMemReq2Supported;
-
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 		tryAddDeviceExtension(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 #endif
@@ -449,16 +441,80 @@ bool VulkanContext::InitDevice()
 		tryAddDeviceExtension(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
 #endif
 
+		// Enable VK_KHR_dedicated_allocation if available
+		if (physicalDeviceProperties.apiVersion >= VK_API_VERSION_1_1)
+		{
+			// Core in Vulkan 1.1
+			dedicatedAllocationSupported = true;
+		}
+		else
+		{
+			const bool getMemReq2Supported = tryAddDeviceExtension(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
+			if (getMemReq2Supported)
+			{
+				dedicatedAllocationSupported = tryAddDeviceExtension(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
+			}
+		}
+
+		// Check for VK_KHR_get_physical_device_properties2
+		// Core as of Vulkan 1.1
+		const bool getPhysicalDeviceProperties2Supported =
+			(physicalDeviceProperties.apiVersion >= VK_API_VERSION_1_1)
+			? true : tryAddDeviceExtension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+
+		if (getPhysicalDeviceProperties2Supported)
+		{
+			// Enable VK_EXT_provoking_vertex if available
+			provokingVertexSupported = tryAddDeviceExtension(VK_EXT_PROVOKING_VERTEX_EXTENSION_NAME);
+		}
+		
+		// Get device features
+
+		vk::PhysicalDeviceFeatures2 featuresChain{};
+		vk::PhysicalDeviceFeatures& features = featuresChain.features;
+
+		vk::PhysicalDeviceProvokingVertexFeaturesEXT provokingVertexFeatures{};
+		if (provokingVertexSupported)
+		{
+			featuresChain.pNext = &provokingVertexFeatures;
+		}
+		
+		// Get the physical device's features
+		if (getPhysicalDeviceProperties2Supported && featuresChain.pNext)
+		{
+			physicalDevice.getFeatures2(&featuresChain);
+		}
+		else
+		{
+			physicalDevice.getFeatures(&features);
+		}
+
+		if (provokingVertexSupported)
+		{
+			provokingVertexSupported &= provokingVertexFeatures.provokingVertexLast;
+		}
+
+		samplerAnisotropy = features.samplerAnisotropy;
+		fragmentStoresAndAtomics = features.fragmentStoresAndAtomics;
+		if (!fragmentStoresAndAtomics)
+			NOTICE_LOG(RENDERER, "Fragment stores & atomic not supported: no per-pixel sorting");
+
 		// create a UniqueDevice
 		float queuePriority = 1.0f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo(vk::DeviceQueueCreateFlags(), graphicsQueueIndex, 1, &queuePriority);
-		vk::PhysicalDeviceFeatures features;
-		if (fragmentStoresAndAtomics)
-			features.fragmentStoresAndAtomics = true;
-		if (samplerAnisotropy)
-			features.samplerAnisotropy = true;
-		device = physicalDevice.createDeviceUnique(vk::DeviceCreateInfo(vk::DeviceCreateFlags(), deviceQueueCreateInfo,
+
+		if (getPhysicalDeviceProperties2Supported)
+		{
+			vk::DeviceCreateInfo deviceCreateInfo(vk::DeviceCreateFlags(), deviceQueueCreateInfo,
+				nullptr, enabledExtensions);
+			deviceCreateInfo.pNext = &featuresChain;
+			device = physicalDevice.createDeviceUnique(deviceCreateInfo);
+		}
+		else
+		{
+			device = physicalDevice.createDeviceUnique(vk::DeviceCreateInfo(vk::DeviceCreateFlags(), deviceQueueCreateInfo,
 				nullptr, enabledExtensions, &features));
+		}
 
 #if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
 		VULKAN_HPP_DEFAULT_DISPATCHER.init(*device);

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -158,10 +158,9 @@ bool VulkanContext::InitInstance(const char** extensions, uint32_t extensions_co
 		bool vulkan11 = false;
 		if (VULKAN_HPP_DEFAULT_DISPATCHER.vkEnumerateInstanceVersion != nullptr)
 		{
-			u32 apiVersion = vk::enumerateInstanceVersion();
+			const u32 apiVersion = vk::enumerateInstanceVersion();
 
-			vulkan11 = VK_API_VERSION_MAJOR(apiVersion) > 1
-					|| (VK_API_VERSION_MAJOR(apiVersion) == 1 && VK_API_VERSION_MINOR(apiVersion) >= 1);
+			vulkan11 = (apiVersion >= VK_API_VERSION_1_1);
 		}
 
 		vk::ApplicationInfo applicationInfo("Flycast", 1, "Flycast", 1, vulkan11 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0);

--- a/core/rend/vulkan/vulkan_context.h
+++ b/core/rend/vulkan/vulkan_context.h
@@ -167,6 +167,7 @@ public:
 				vk::SubmitInfo(nullptr, nullptr, buffers), fence);
 	}
 	bool hasPerPixel() override { return fragmentStoresAndAtomics; }
+	bool hasProvokingVertex() { return provokingVertexSupported; }
 	bool recreateSwapChainIfNeeded();
 	void addToFlight(Deletable *object) override {
 		inFlightObjects[GetCurrentImageIndex()].emplace_back(object);
@@ -229,6 +230,7 @@ private:
 	bool samplerAnisotropy = false;
 	float maxSamplerAnisotropy = 0.f;
 	bool dedicatedAllocationSupported = false;
+	bool provokingVertexSupported = false;
 	u32 vendorID = 0;
 	int swapInterval = 1;
 	vk::UniqueDevice device;


### PR DESCRIPTION
The dreamcast uses the last vertex as the provoking vertex, while vulkan uses the first vertex.
This requires an additional call to `setFirstProvokingVertex` to reorder the vertices for all incoming geometry.
With `VK_EXT_provoking_vertex`, the pipeline can designate that the provoking vertex is to be the last vertex, which removes the need to re-order incoming geometry on the CPU.