### PR TITLE
vk: Use `VK_FORMAT_R8G8B8A8_UNORM` for vertex colors

### DIFF
--- a/core/rend/vulkan/oit/oit_pipeline.h
+++ b/core/rend/vulkan/oit/oit_pipeline.h
@@ -427,11 +427,11 @@ private:
 		static const vk::VertexInputAttributeDescription vertexInputAttributeDescriptions[] =
 		{
 				vk::VertexInputAttributeDescription(0, 0, vk::Format::eR32G32B32Sfloat, offsetof(Vertex, x)),	// pos
-				vk::VertexInputAttributeDescription(1, 0, vk::Format::eR8G8B8A8Uint, offsetof(Vertex, col)),	// base color
-				vk::VertexInputAttributeDescription(2, 0, vk::Format::eR8G8B8A8Uint, offsetof(Vertex, spc)),	// offset color
+				vk::VertexInputAttributeDescription(1, 0, vk::Format::eR8G8B8A8Unorm, offsetof(Vertex, col)),	// base color
+				vk::VertexInputAttributeDescription(2, 0, vk::Format::eR8G8B8A8Unorm, offsetof(Vertex, spc)),	// offset color
 				vk::VertexInputAttributeDescription(3, 0, vk::Format::eR32G32Sfloat, offsetof(Vertex, u)),		// tex coord
-				vk::VertexInputAttributeDescription(4, 0, vk::Format::eR8G8B8A8Uint, offsetof(Vertex, col1)),	// base1 color
-				vk::VertexInputAttributeDescription(5, 0, vk::Format::eR8G8B8A8Uint, offsetof(Vertex, spc1)),	// offset1 color
+				vk::VertexInputAttributeDescription(4, 0, vk::Format::eR8G8B8A8Unorm, offsetof(Vertex, col1)),	// base1 color
+				vk::VertexInputAttributeDescription(5, 0, vk::Format::eR8G8B8A8Unorm, offsetof(Vertex, spc1)),	// offset1 color
 				vk::VertexInputAttributeDescription(6, 0, vk::Format::eR32G32Sfloat, offsetof(Vertex, u1)),		// tex1 coord
 				vk::VertexInputAttributeDescription(7, 0, vk::Format::eR32G32B32Sfloat, offsetof(Vertex, nx)),	// naomi2 normal
 		};

--- a/core/rend/vulkan/oit/oit_shaders.cpp
+++ b/core/rend/vulkan/oit/oit_shaders.cpp
@@ -37,11 +37,11 @@ layout (push_constant) uniform constants
 } pushConstants;
 
 layout (location = 0) in vec4         in_pos;
-layout (location = 1) in uvec4        in_base;
-layout (location = 2) in uvec4        in_offs;
+layout (location = 1) in vec4        in_base;
+layout (location = 2) in vec4        in_offs;
 layout (location = 3) in mediump vec2 in_uv;
-layout (location = 4) in uvec4        in_base1;						// New for OIT, only for OP/PT with 2-volume
-layout (location = 5) in uvec4        in_offs1;
+layout (location = 4) in vec4        in_base1;						// New for OIT, only for OP/PT with 2-volume
+layout (location = 5) in vec4        in_offs1;
 layout (location = 6) in mediump vec2 in_uv1;
 
 layout (location = 0) INTERPOLATION out highp vec4 vtx_base;
@@ -59,11 +59,11 @@ void main()
 	vpos /= vpos.z;
 	vpos.z = vpos.w;
 #endif
-	vtx_base = vec4(in_base) / 255.0;
-	vtx_offs = vec4(in_offs) / 255.0;
+	vtx_base = in_base;
+	vtx_offs = in_offs;
 	vtx_uv = vec3(in_uv, vpos.z);
-	vtx_base1 = vec4(in_base1) / 255.0;
-	vtx_offs1 = vec4(in_offs1) / 255.0;
+	vtx_base1 = in_base1;
+	vtx_offs1 = in_offs1;
 	vtx_uv1 = in_uv1;
 #if pp_Gouraud == 1 && DIV_POS_Z != 1
 	vtx_base *= vpos.z;
@@ -638,11 +638,11 @@ layout (push_constant) uniform constants
 } pushConstants;
 
 layout (location = 0) in vec4         in_pos;
-layout (location = 1) in uvec4        in_base;
-layout (location = 2) in uvec4        in_offs;
+layout (location = 1) in vec4        in_base;
+layout (location = 2) in vec4        in_offs;
 layout (location = 3) in mediump vec2 in_uv;
-layout (location = 4) in uvec4        in_base1;
-layout (location = 5) in uvec4        in_offs1;
+layout (location = 4) in vec4        in_base1;
+layout (location = 5) in vec4        in_offs1;
 layout (location = 6) in mediump vec2 in_uv1;
 layout (location = 7) in vec3         in_normal;
 
@@ -677,16 +677,16 @@ void wDivide(inout vec4 vpos)
 void main()
 {
 	vec4 vpos = n2Uniform.mvMat * in_pos;
-	vtx_base = vec4(in_base) / 255.0;
-	vtx_offs = vec4(in_offs) / 255.0;
+	vtx_base = in_base;
+	vtx_offs = in_offs;
 
 	#if LIGHT_ON == 1
 	vec3 vnorm = normalize(mat3(n2Uniform.normalMat) * in_normal);
 	#endif
 
 	#if pp_TwoVolumes == 1
-		vtx_base1 = vec4(in_base1) / 255.0;
-		vtx_offs1 = vec4(in_offs1) / 255.0;
+		vtx_base1 = in_base1;
+		vtx_offs1 = in_offs1;
 		vtx_uv1 = in_uv1;
 		#if LIGHT_ON == 1
 			// FIXME need offset0 and offset1 for bump maps

--- a/core/rend/vulkan/pipeline.cpp
+++ b/core/rend/vulkan/pipeline.cpp
@@ -454,7 +454,7 @@ void OSDPipeline::CreatePipeline()
 	static const vk::VertexInputBindingDescription vertexInputBindingDescription(0, sizeof(OSDVertex));
 	static const std::array<vk::VertexInputAttributeDescription, 3> vertexInputAttributeDescriptions = {
 			vk::VertexInputAttributeDescription(0, 0, vk::Format::eR32G32Sfloat, offsetof(OSDVertex, x)),	// pos
-			vk::VertexInputAttributeDescription(1, 0, vk::Format::eR8G8B8A8Uint, offsetof(OSDVertex, r)),	// color
+			vk::VertexInputAttributeDescription(1, 0, vk::Format::eR8G8B8A8Unorm, offsetof(OSDVertex, r)),	// color
 			vk::VertexInputAttributeDescription(2, 0, vk::Format::eR32G32Sfloat, offsetof(OSDVertex, u)),	// tex coord
 	};
 	vk::PipelineVertexInputStateCreateInfo vertexInputStateCreateInfo(

--- a/core/rend/vulkan/pipeline.h
+++ b/core/rend/vulkan/pipeline.h
@@ -296,8 +296,8 @@ private:
 		static const vk::VertexInputAttributeDescription vertexInputAttributeDescriptions[] =
 		{
 				vk::VertexInputAttributeDescription(0, 0, vk::Format::eR32G32B32Sfloat, offsetof(Vertex, x)),	// pos
-				vk::VertexInputAttributeDescription(1, 0, vk::Format::eR8G8B8A8Uint, offsetof(Vertex, col)),	// base color
-				vk::VertexInputAttributeDescription(2, 0, vk::Format::eR8G8B8A8Uint, offsetof(Vertex, spc)),	// offset color
+				vk::VertexInputAttributeDescription(1, 0, vk::Format::eR8G8B8A8Unorm, offsetof(Vertex, col)),	// base color
+				vk::VertexInputAttributeDescription(2, 0, vk::Format::eR8G8B8A8Unorm, offsetof(Vertex, spc)),	// offset color
 				vk::VertexInputAttributeDescription(3, 0, vk::Format::eR32G32Sfloat, offsetof(Vertex, u)),		// tex coord
 				vk::VertexInputAttributeDescription(4, 0, vk::Format::eR32G32B32Sfloat, offsetof(Vertex, nx)),	// naomi2 normal
 		};

--- a/core/rend/vulkan/shaders.cpp
+++ b/core/rend/vulkan/shaders.cpp
@@ -30,8 +30,8 @@ layout (std140, set = 0, binding = 0) uniform VertexShaderUniforms
 } uniformBuffer;
 
 layout (location = 0) in vec4         in_pos;
-layout (location = 1) in uvec4        in_base;
-layout (location = 2) in uvec4        in_offs;
+layout (location = 1) in vec4        in_base;
+layout (location = 2) in vec4        in_offs;
 layout (location = 3) in mediump vec2 in_uv;
 
 layout (location = 0) INTERPOLATION out highp vec4 vtx_base;
@@ -45,8 +45,8 @@ void main()
 	vpos /= vpos.z;
 	vpos.z = vpos.w;
 #endif
-	vtx_base = vec4(in_base) / 255.0;
-	vtx_offs = vec4(in_offs) / 255.0;
+	vtx_base = in_base;
+	vtx_offs = in_offs;
 	vtx_uv = vec3(in_uv, vpos.z);
 #if pp_Gouraud == 1 && DIV_POS_Z != 1
 	vtx_base *= vpos.z;
@@ -403,7 +403,7 @@ layout (location = 1) out mediump vec2 outUV;
 
 void main() 
 {
-	outColor = inColor / 255.0;
+	outColor = inColor;
 	outUV = inUV;
 	gl_Position = inPos;
 }
@@ -684,8 +684,8 @@ void wDivide(inout vec4 vpos)
 void main()
 {
 	vec4 vpos = n2Uniform.mvMat * in_pos;
-	vtx_base = vec4(in_base) / 255.0;
-	vtx_offs = vec4(in_offs) / 255.0;
+	vtx_base = in_base;
+	vtx_offs = in_offs;
 
 	vec3 vnorm = normalize(mat3(n2Uniform.normalMat) * in_normal);
 


### PR DESCRIPTION
Rather than using `VK_FORMAT_R8G8B8A8_UINT` for these vertex attributes and then dividing by `255.0` in each of the shaders, the `VK_FORMAT_R8G8B8A8_UNORM` format will automatically remap byte components into the `0.0-1.0` range and removes the need to do the extra divisions or castings within the shader.