### PR TITLE
[Libretro] Add game dir as fall back for arcade BIOSes

### DIFF
--- a/shell/libretro/libretro.cpp
+++ b/shell/libretro/libretro.cpp
@@ -205,7 +205,7 @@ static char game_dir[1024];
 char game_dir_no_slash[1024];
 char vmu_dir_no_slash[PATH_MAX];
 char content_name[PATH_MAX];
-static char g_roms_dir[PATH_MAX];
+char g_roms_dir[PATH_MAX];
 static std::mutex mtx_serialization;
 static bool gl_ctx_resetting = false;
 static bool is_dupe;

--- a/shell/libretro/oslib.cpp
+++ b/shell/libretro/oslib.cpp
@@ -28,6 +28,7 @@ const char *retro_get_system_directory();
 extern char game_dir_no_slash[1024];
 extern char vmu_dir_no_slash[PATH_MAX];
 extern char content_name[PATH_MAX];
+extern char g_roms_dir[PATH_MAX];
 extern unsigned per_content_vmus;
 extern std::string arcadeFlashPath;
 
@@ -102,10 +103,14 @@ std::string findNaomiBios(const std::string& name)
 {
 	std::string basepath(game_dir_no_slash);
 	basepath += path_default_slash() + name;
-	if (file_exists(basepath))
-		return basepath;
-	else
-		return "";
+	if (!file_exists(basepath))
+	{
+		// File not found in system dir, try game dir instead
+		basepath = g_roms_dir + name;
+		if (!file_exists(basepath))
+			return "";
+	}
+	return basepath;
 }
 
 std::string getSavestatePath(int index, bool writable)


### PR DESCRIPTION
If the BIOS doesn't exist in system/dc/ the core will now check in the game directory as a fall back.

Using `g_roms_dir` which is initialized in `retro_load_game()`: https://github.com/flyinghead/flycast/blob/da3cfd9d587d892aa7a3abefe919faa1078f4766/shell/libretro/libretro.cpp#L2045