### PR TITLE
Mimic 8-bit overflow manually in SCBRR2_write

### DIFF
--- a/core/hw/sh4/modules/serial.cpp
+++ b/core/hw/sh4/modules/serial.cpp
@@ -339,7 +339,12 @@ void SCIFSerialPort::SCFCR2_write(u16 data)
 // SCBRR2 - Bit Rate Register
 void SCIFSerialPort::SCBRR2_write(u32 addr, u8 data)
 {
-	SCIF_SCBRR2 = data;
+	// Mimic 8-bit overflow manually: -94 could become 4294967202 with 32-bit overflow in macOS arm64
+	if (static_cast<s8>(data) < 0)
+		SCIF_SCBRR2 = static_cast<s8>(data) + 256;
+	else
+		SCIF_SCBRR2 = data;
+	
 	Instance().updateBaudRate();
 }
 


### PR DESCRIPTION
Fixes MUSHIKING cannot insert card with macOS arm64. [(Issue reported from Discord)](https://discord.com/channels/627187835945877505/627187836441067533/1303388853339422854)

Details:
In macOS arm64, the `SCIFSerialPort::schedCallback` would stop calling after the `Now Loading...` screen.



```
SCIFSerialPort::schedCallback
SCIFSerialPort::rxSched()
return scif.frameSize * scif.cyclesPerBit (10, 2560)
SH4 SCIF: Frame size 10 cycles/bit 2560 (78125 bauds) pipe 0x600002b78460, SCIF_SCBRR2 = 19, SCIF_SCSMR2.CKS = 0
SCIFSerialPort::SCBRR2_write: 4294967202
SH4 SCIF: Frame size 10 cycles/bit 0 (0 bauds) pipe 0x600002b78460, SCIF_SCBRR2 = 4294967202, SCIF_SCSMR2.CKS = 0
SCIFSerialPort::schedCallback
SCIFSerialPort::rxSched()
return scif.frameSize * scif.cyclesPerBit (10, 0)
```

This happens when `SCIFSerialPort::SCBRR2_write` is trying to write a `-94`, overflowing to become `4294967202`, making cyclesPerBit become `0`.
(But on the debug build, it is writing `162`, the 8-bit overflow value for `-94`)

Since `static_cast<signed char>(data)` or `static_cast<u8>(static_cast<signed char>(data)>`  does not work, so I just add 256 directly to mimic the 8-bit overflow

Question:
- Should I add ifdef directive so the new code only runs on macOS arm64?
- Is there a better 8-bit overflow handling?