### PR TITLE
build: drop unsupported architectures

### DIFF
--- a/core/build.h
+++ b/core/build.h
@@ -15,12 +15,8 @@
 //HOST_CPU
 #define CPU_X86      0x20000001
 #define CPU_ARM      0x20000002
-#define CPU_MIPS     0x20000003
+#define CPU_ARM64    0x20000003
 #define CPU_X64      0x20000004
-#define CPU_GENERIC  0x20000005 //used for pnacl, emscripten, etc
-#define CPU_PPC      0x20000006
-#define CPU_PPC64    0x20000007
-#define CPU_ARM64    0x20000008
 
 //FEAT_SHREC, FEAT_AREC, FEAT_DSPREC
 #define DYNAREC_NONE	0x40000001
@@ -36,10 +32,8 @@
 	#define HOST_CPU CPU_ARM
 #elif defined(__aarch64__) || defined(_M_ARM64)
 	#define HOST_CPU CPU_ARM64
-#elif defined(__mips__)
-	#define HOST_CPU CPU_MIPS
 #else
-	#define HOST_CPU CPU_GENERIC
+	#error Unsupported architecture
 #endif
 
 #if defined(TARGET_IPHONE) && !defined(__aarch64__)

--- a/core/linux/context.cpp
+++ b/core/linux/context.cpp
@@ -125,10 +125,6 @@ static void context_segfault(host_context_t* hostctx, void* segfault_ctx)
     #else
         #error "Unsupported OS"
 	#endif
-#elif HOST_CPU == CPU_MIPS
-	bicopy<ToSegfault>(hostctx->pc, MCTX(.pc));
-#elif HOST_CPU == CPU_GENERIC
-    //nothing!
 #else
 	#error Unsupported HOST_CPU
 #endif

--- a/core/oslib/host_context.h
+++ b/core/oslib/host_context.h
@@ -2,9 +2,7 @@
 #include "types.h"
 
 struct host_context_t {
-#if HOST_CPU != CPU_GENERIC
 	uintptr_t pc;
-#endif
 
 #if HOST_CPU == CPU_X86
 	u32 eax;

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -2899,12 +2899,8 @@ static void gui_settings_about()
 			"x86"
 #elif HOST_CPU == CPU_ARM
 			"ARM"
-#elif HOST_CPU == CPU_MIPS
-			"MIPS"
 #elif HOST_CPU == CPU_X64
 			"x86/64"
-#elif HOST_CPU == CPU_GENERIC
-			"Generic"
 #elif HOST_CPU == CPU_ARM64
 			"ARM64"
 #else


### PR DESCRIPTION
CMake already triggers a fatal error if the architecture is not supported so it is unlikely that the deleted code in this PR has any use