### PR TITLE
Generate Xcode project which can support both iOS and iOS Simulator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ if(APPLE)
 		set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum macOS deployment version")
 		set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "")
 	endif()
+	set(ZLIB_LIBRARY "-lz" CACHE STRING "Use generic linker flag for Xcode to support multiple SDKs")
 endif()
 
 if(LIBRETRO)

--- a/core/build.h
+++ b/core/build.h
@@ -42,9 +42,15 @@
 	#define HOST_CPU CPU_GENERIC
 #endif
 
-#if defined(TARGET_IPHONE) && !defined(__aarch64__)
+#if defined(__APPLE__)
+#include "TargetConditionals.h"
+#if defined(TARGET_OS_SIMULATOR)
 // iOS simulator
 #define TARGET_NO_REC
+#endif
+#if defined(TARGET_MAC) && HOST_CPU == CPU_ARM64
+#define TARGET_ARM_MAC
+#endif
 #endif
 
 #if defined(TARGET_NO_REC)

--- a/core/types.h
+++ b/core/types.h
@@ -51,8 +51,7 @@ int darw_printf(const char* Text,...);
 #endif
 
 #ifndef TARGET_IPHONE
-#if defined(__APPLE__) && defined(__MACH__) && HOST_CPU == CPU_ARM64
-#define TARGET_ARM_MAC
+#if defined(TARGET_ARM_MAC)
 #include <pthread.h>
 inline static void JITWriteProtect(bool enabled) {
 	if (__builtin_available(macOS 11.0, *))

--- a/shell/apple/emulator-ios/emulator/FlycastViewController.mm
+++ b/shell/apple/emulator-ios/emulator/FlycastViewController.mm
@@ -323,6 +323,13 @@ static void updateAudioSession(Event event, void *)
 	}
 	settings.display.dpi = 160.f * scale;
 	initRenderApi();
+#if defined(TARGET_OS_SIMULATOR) && HOST_CPU == CPU_ARM64
+	if (config::RendererType.get() == RenderType::OpenGL)
+	{
+		NSLog(@"🚨🚨🚨 OpenGL renderer is not supported in Apple Silicon Mac 🚨🚨🚨\n");
+		raise(SIGTRAP);
+	}
+#endif
 	mainui_init();
 
 	[self altKitStart];

--- a/shell/apple/generate_xcode_project.command
+++ b/shell/apple/generate_xcode_project.command
@@ -6,7 +6,11 @@ echo "2) iOS"
 read -p "Choose your target platform: " x
 
 if [ $x -eq 2 ]; then
-    option="-DCMAKE_SYSTEM_NAME=iOS"
+    if [ "$(uname -m)" = "arm64" ]; then
+        option="-DCMAKE_SYSTEM_NAME=iOS"
+    else
+        option="-DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64"
+    fi
     lldbinitfolder="emulator-ios"
     echo 'Building iOS xcodeproj for debugging'
     echo 'Remove CODE_SIGNING_ALLOWED=NO in Build Settings if you are using your Apple Developer Certificate for signing'


### PR DESCRIPTION
- Using generic linker flag `-lz` so the same Xcode project can be used for iOS devices and simulators
- Build x86_64 simulator for Intel Macs with project generator helper
- Warn Apple Silicon user when they are playing with iOS Simulator