### PR TITLE
vulkan: Add external-memory-host support

### DIFF
--- a/core/rend/vulkan/utils.h
+++ b/core/rend/vulkan/utils.h
@@ -78,6 +78,23 @@ static inline u32 findMemoryType(vk::PhysicalDeviceMemoryProperties const& memor
 	return typeIndex;
 }
 
+static inline void addPointerToChain(void* head, const void* ptr)
+{
+	vk::BaseInStructure* prevInStructure = static_cast<vk::BaseInStructure*>(head);
+	while (prevInStructure->pNext)
+	{
+		// Structure already in chain
+		if (prevInStructure->pNext == ptr)
+		{
+			return;
+		}
+		prevInStructure = const_cast<vk::BaseInStructure*>(prevInStructure->pNext);
+	}
+
+	// Add structure to end
+	prevInStructure->pNext = static_cast<const vk::BaseInStructure*>(ptr);
+}
+
 static const char GouraudSource[] = R"(
 #if pp_Gouraud == 0
 #define INTERPOLATION flat

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -471,23 +471,6 @@ bool VulkanContext::InitDevice()
 		}
 		
 		// Get device features
-		const auto addPointerToChain = [](void* head, const void* ptr) -> void
-		{
-			vk::BaseInStructure* prevInStructure = static_cast<vk::BaseInStructure*>(head);
-			while (prevInStructure->pNext)
-			{
-				// Structure already in chain
-				if (prevInStructure->pNext == ptr)
-				{
-					return;
-				}
-				prevInStructure = const_cast<vk::BaseInStructure*>(prevInStructure->pNext);
-			}
-
-			// Add structure to end
-			prevInStructure->pNext = static_cast<const vk::BaseInStructure*>(ptr);
-		};
-
 		vk::PhysicalDeviceFeatures2 featuresChain{};
 		vk::PhysicalDeviceFeatures& features = featuresChain.features;
 

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -22,6 +22,7 @@
 #include "vulkan_renderer.h"
 #include "imgui.h"
 #include "imgui_impl_vulkan.h"
+#include "stdclass.h"
 #include "ui/gui.h"
 #ifdef USE_SDL
 #include <sdl/sdl.h>

--- a/core/rend/vulkan/vulkan_context.h
+++ b/core/rend/vulkan/vulkan_context.h
@@ -168,6 +168,7 @@ public:
 	}
 	bool hasPerPixel() override { return fragmentStoresAndAtomics; }
 	bool hasProvokingVertex() { return provokingVertexSupported; }
+	bool hasExternalMemoryHost() { return externalMemoryHostSupported; }
 	bool recreateSwapChainIfNeeded();
 	void addToFlight(Deletable *object) override {
 		inFlightObjects[GetCurrentImageIndex()].emplace_back(object);
@@ -231,6 +232,7 @@ private:
 	float maxSamplerAnisotropy = 0.f;
 	bool dedicatedAllocationSupported = false;
 	bool provokingVertexSupported = false;
+	bool externalMemoryHostSupported = false;
 	u32 vendorID = 0;
 	int swapInterval = 1;
 	vk::UniqueDevice device;


### PR DESCRIPTION
Detects the ability to import host pointers directly into the driver(allows any `void*` to be turned into a `vk::DeviceMemory` without the need of a staging-buffer).

Can avoid the need for staging memory in many cases such as screenshot downloads and memory uploads.