### PR TITLE
[macOS] Fix booting game stuck with Video Routing

### DIFF
--- a/core/rend/gles/gldraw.cpp
+++ b/core/rend/gles/gldraw.cpp
@@ -644,9 +644,9 @@ void DrawStrips()
 
 void OpenGLRenderer::RenderFramebuffer(const FramebufferInfo& info)
 {
-	initVideoRoutingFrameBuffer();
 	glReadFramebuffer(info);
 	saveCurrentFramebuffer();
+	initVideoRoutingFrameBuffer();
 	getVideoShift(gl.ofbo.shiftX, gl.ofbo.shiftY);
 #ifdef LIBRETRO
 	glBindFramebuffer(GL_FRAMEBUFFER, postProcessor.getFramebuffer(gl.dcfb.width, gl.dcfb.height));


### PR DESCRIPTION
![Jan-09-2025 01-49-48](https://github.com/user-attachments/assets/b18772a2-2289-41f0-bfa6-c12872484071)

```cpp
gl.videorouting.framebuffer = std::make_unique<GlFramebuffer>(targetWidth, targetHeight, true, true);
```
cannot be called before
```cpp
saveCurrentFramebuffer();
```