### PR TITLE
VMUs and Rumble Packs with Original Dreamcast Controllers

### DIFF
--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -2106,7 +2106,7 @@ maple_device* maple_Create(MapleDeviceType type)
 	return nullptr;
 }
 
-#if defined(_WIN32) && !defined(TARGET_UWP) && defined(USE_SDL) && !defined(LIBRETRO)
+#if (defined(_WIN32) || defined(__linux__) || (defined(__APPLE__) && defined(TARGET_OS_MAC))) && !defined(TARGET_UWP) && defined(USE_SDL) && !defined(LIBRETRO)
 #include "sdl/dreamconn.h"
 
 struct DreamConnVmu : public maple_sega_vmu

--- a/core/sdl/dreamconn.cpp
+++ b/core/sdl/dreamconn.cpp
@@ -41,6 +41,12 @@ static asio::error_code sendMsg(const MapleMsg& msg, asio::ip::tcp::iostream& st
 {
 	std::ostringstream s;
 	s.fill('0');
+	if (dreamcastControllerType == TYPE_DREAMCASTCONTROLLERUSB)
+	{
+		// Messages to Dreamcast Controller USB need to be prefixed to trigger the correct parser
+		s << "X ";
+	}
+		
 	s << std::hex << std::uppercase
 		<< std::setw(2) << (u32)msg.command << " "
 		<< std::setw(2) << (u32)msg.destAP << " "

--- a/core/sdl/dreamconn.cpp
+++ b/core/sdl/dreamconn.cpp
@@ -359,8 +359,6 @@ DreamConnGamepad::DreamConnGamepad(int maple_port, int joystick_idx, SDL_Joystic
 	{
 		dreamcastControllerType = TYPE_DREAMCASTCONTROLLERUSB;
 		_name = "Dreamcast Controller USB";
-		leftTrigger = 2;
-		rightTrigger = 5;
 	}
 	
 	EventManager::listen(Event::Start, handleEvent, this);

--- a/core/sdl/dreamconn.cpp
+++ b/core/sdl/dreamconn.cpp
@@ -322,6 +322,8 @@ DreamConnGamepad::DreamConnGamepad(int maple_port, int joystick_idx, SDL_Joystic
 	{
 		dreamcastControllerType = TYPE_DREAMCASTCONTROLLERUSB;
 		_name = "Dreamcast Controller USB";
+		leftTrigger = 2;
+		rightTrigger = 5;
 	}
 	
 	EventManager::listen(Event::Start, handleEvent, this);
@@ -372,27 +374,14 @@ bool DreamConnGamepad::gamepad_axis_input(u32 code, int value)
 {
 	if (!is_detecting_input())
 	{
-	// For DreamcastControllerUsb, we need to diff between Linux which exposes the UDB HID event codes as expected, and MacOS/Windows which require a dedicated mapping
-	// Change is temporary for testing - will be superseded by an extension of SDL providing default mappings for DreamcastControllerUsb
-#if defined(_WIN32) || (defined(__APPLE__) && defined(TARGET_OS_MAC))
-		if ((code == leftTrigger && dreamcastControllerType == TYPE_DREAMCONN) || (code == 2 && dreamcastControllerType == TYPE_DREAMCASTCONTROLLERUSB)) {
-			ltrigPressed = value > 0;
-			checkKeyCombo();
-		}
-		if ((code == rightTrigger && dreamcastControllerType == TYPE_DREAMCONN) || (code == 5 && dreamcastControllerType == TYPE_DREAMCASTCONTROLLERUSB)) {
-			rtrigPressed = value > 0;
-			checkKeyCombo();
-		}
-#elif defined(__linux__)
 		if (code == leftTrigger) {
 			ltrigPressed = value > 0;
 			checkKeyCombo();
 		}
-		if (code == rightTrigger) {
+		else if (code == rightTrigger) {
 			rtrigPressed = value > 0;
 			checkKeyCombo();
 		}
-#endif
 	}
 	else {
 		ltrigPressed = false;

--- a/core/sdl/dreamconn.h
+++ b/core/sdl/dreamconn.h
@@ -72,9 +72,6 @@ public:
 	int getBus() const {
 		return bus;
 	}
-	int getDreamcastControllerType() const {
-		return dreamcastControllerType;
-	}
 	bool hasVmu() {
 		return expansionDevs & 1;
 	}

--- a/core/sdl/dreamconn.h
+++ b/core/sdl/dreamconn.h
@@ -51,10 +51,12 @@ class DreamConn
 {
 	const int bus;
 	const int dreamcastControllerType;
+#ifdef USE_DREAMCASTCONTROLLER
 	asio::ip::tcp::iostream iostream;
 	asio::io_context io_context;
 	asio::io_service io_service;
 	asio::serial_port serial_handler{io_context};
+#endif
 	bool maple_io_connected;
 	u8 expansionDevs = 0;
 	static constexpr u16 BASE_PORT = 37393;

--- a/core/sdl/dreamconn.h
+++ b/core/sdl/dreamconn.h
@@ -54,7 +54,6 @@ class DreamConn
 #ifdef USE_DREAMCASTCONTROLLER
 	asio::ip::tcp::iostream iostream;
 	asio::io_context io_context;
-	asio::io_service io_service;
 	asio::serial_port serial_handler{io_context};
 #endif
 	bool maple_io_connected;

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -83,7 +83,7 @@ static void sdl_open_joystick(int index)
 		std::shared_ptr<SDLGamepad> gamepad = std::make_shared<SwitchGamepad>(index < MAPLE_PORTS ? index : -1, index, pJoystick);
 #else
 		std::shared_ptr<SDLGamepad> gamepad;
-		if (DreamConnGamepad::isDreamConn(index))
+		if (DreamConnGamepad::isDreamcastController(index))
 			gamepad = std::make_shared<DreamConnGamepad>(index < MAPLE_PORTS ? index : -1, index, pJoystick);
 		else
 			gamepad = std::make_shared<SDLGamepad>(index < MAPLE_PORTS ? index : -1, index, pJoystick);

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -266,6 +266,15 @@ void input_sdl_init()
 	if (settings.input.keyboardLangId == KeyboardLayout::US)
 		settings.input.keyboardLangId = detectKeyboardLayout();
 	barcode.clear();
+
+	// Add MacOS and Windows mappings for Dreamcast Controller USB
+	// Linux mappings are OK by default
+	// Can be removed once mapping is merged into SDL, see https://github.com/libsdl-org/SDL/pull/12039
+#if (defined(__APPLE__) && defined(TARGET_OS_MAC))
+	SDL_GameControllerAddMapping("0300000009120000072f000000010000,OrangeFox86 Dreamcast Controller USB,crc:3cef,a:b0,b:b1,x:b3,y:b4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,dpdown:h0.4,leftx:a0,lefty:a1,lefttrigger:a2,righttrigger:a5,start:b11");
+#elif defined(_WIN32)
+	SDL_GameControllerAddMapping("0300000009120000072f000000000000,OrangeFox86 Dreamcast Controller USB,crc:baa5,a:b0,b:b1,x:b3,y:b4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,dpdown:h0.4,leftx:a0,lefty:a1,lefttrigger:-a2,righttrigger:-a5,start:b11");
+#endif
 }
 
 void input_sdl_quit()

--- a/core/sdl/sdl_gamepad.h
+++ b/core/sdl/sdl_gamepad.h
@@ -4,73 +4,28 @@
 #include "stdclass.h"
 #include "sdl.h"
 
-template<bool Arcade = false, bool Gamepad = false, bool DreamcastControllerUsb = false>
+template<bool Arcade = false, bool Gamepad = false>
 class DefaultInputMapping : public InputMapping
 {
 public:
 	DefaultInputMapping()
 	{
-		if (!DreamcastControllerUsb)
-		{
-			name = "Default";
-			set_button(DC_BTN_Y, 0);
-			set_button(DC_BTN_B, 1);
-			set_button(DC_BTN_A, 2);
-			set_button(DC_BTN_X, 3);
-			set_button(DC_BTN_START, 9);
+		name = "Default";
+		set_button(DC_BTN_Y, 0);
+		set_button(DC_BTN_B, 1);
+		set_button(DC_BTN_A, 2);
+		set_button(DC_BTN_X, 3);
+		set_button(DC_BTN_START, 9);
 
-			set_axis(0, DC_AXIS_LEFT, 0, false);
-			set_axis(0, DC_AXIS_RIGHT, 0, true);
-			set_axis(0, DC_AXIS_UP, 1, false);
-			set_axis(0, DC_AXIS_DOWN, 1, true);
-			set_axis(0, DC_AXIS2_LEFT, 2, false);
-			set_axis(0, DC_AXIS2_RIGHT, 2, true);
-			set_axis(0, DC_AXIS2_UP, 3, false);
-			set_axis(0, DC_AXIS2_DOWN, 3, true);
-			dirty = false;
-		}
-		else
-		{
-			// For DreamcastControllerUsb, we need to diff between Linux which exposes the UDB HID event codes as expected, and MacOS/Windows which require a dedicated mapping
-			// Change is temporary for testing - will be superseded by an extension of SDL providing default mappings for DreamcastControllerUsb
-			name = "Dreamcast Controller USB";
-#if defined(__linux__)
-			set_button(DC_BTN_Y, 0);
-			set_button(DC_BTN_B, 1);
-			set_button(DC_BTN_A, 2);
-			set_button(DC_BTN_X, 3);
-			set_button(DC_BTN_START, 9);
-
-			set_axis(0, DC_AXIS_LEFT, 0, false);
-			set_axis(0, DC_AXIS_RIGHT, 0, true);
-			set_axis(0, DC_AXIS_UP, 1, false);
-			set_axis(0, DC_AXIS_DOWN, 1, true);
-			set_axis(0, DC_AXIS2_LEFT, 2, false);
-			set_axis(0, DC_AXIS2_RIGHT, 2, true);
-			set_axis(0, DC_AXIS2_UP, 3, false);
-			set_axis(0, DC_AXIS2_DOWN, 3, true);
-			dirty = false;
-#elif defined(_WIN32) || (defined(__APPLE__) && defined(TARGET_OS_MAC))
-			set_button(DC_DPAD_UP, 256);
-			set_button(DC_DPAD_DOWN, 257);
-			set_button(DC_DPAD_LEFT, 258);
-			set_button(DC_DPAD_RIGHT, 259);
-			
-			set_button(DC_BTN_Y, 4);
-			set_button(DC_BTN_B, 1);
-			set_button(DC_BTN_A, 0);
-			set_button(DC_BTN_X, 3);
-			set_button(DC_BTN_START, 11);
-
-			set_axis(0, DC_AXIS_LEFT, 0, false);
-			set_axis(0, DC_AXIS_RIGHT, 0, true);
-			set_axis(0, DC_AXIS_UP, 1, false);
-			set_axis(0, DC_AXIS_DOWN, 1, true);
-			set_axis(0, DC_AXIS_LT, 2, true);
-			set_axis(0, DC_AXIS_RT, 5, true);
-			dirty = false;
-#endif
-		}
+		set_axis(0, DC_AXIS_LEFT, 0, false);
+		set_axis(0, DC_AXIS_RIGHT, 0, true);
+		set_axis(0, DC_AXIS_UP, 1, false);
+		set_axis(0, DC_AXIS_DOWN, 1, true);
+		set_axis(0, DC_AXIS2_LEFT, 2, false);
+		set_axis(0, DC_AXIS2_RIGHT, 2, true);
+		set_axis(0, DC_AXIS2_UP, 3, false);
+		set_axis(0, DC_AXIS2_DOWN, 3, true);
+		dirty = false;
 	}
 
 	DefaultInputMapping(SDL_GameController *sdlController) : DefaultInputMapping()
@@ -202,10 +157,7 @@ public:
 			dirty = false;
 		}
 		else
-			if (DreamcastControllerUsb)
-				INFO_LOG(INPUT, "using default mapping for Dreamcast Controller USB");
-			else
-				INFO_LOG(INPUT, "using default mapping");
+			INFO_LOG(INPUT, "using default mapping");
 	}
 };
 
@@ -245,18 +197,7 @@ public:
 		}
 
 		if (!find_mapping())
-		{
-			// We explicitely check for Dreamcast Controller USB with VID:1209 PID:2f07 to override the default button mapping
-			// Change is temporary for testing - will be superseded by an extension of SDL providing default mappings for DreamcastControllerUsb
-			char guid_str[33] {};
-			SDL_JoystickGetGUIDString(SDL_JoystickGetDeviceGUID(joystick_idx), guid_str, sizeof(guid_str));
-			if (memcmp("09120000072f0000", guid_str + 8, 16) == 0)
-			{
-				input_mapper = std::make_shared<DefaultInputMapping<false, true, true>>(sdl_controller);
-			}
-			else
-				input_mapper = std::make_shared<DefaultInputMapping<>>(sdl_controller);
-		}
+			input_mapper = std::make_shared<DefaultInputMapping<>>(sdl_controller);
 		else
 			INFO_LOG(INPUT, "using custom mapping '%s'", input_mapper->name.c_str());
 
@@ -666,28 +607,16 @@ public:
 
 	void resetMappingToDefault(bool arcade, bool gamepad) override
 	{
-		// We explicitely check for Dreamcast Controller USB with VID:1209 PID:2f07 to override the default button mapping
-		// Change is temporary for testing - will be superseded by an extension of SDL providing default mappings for DreamcastControllerUsb
-		char guid_str[33] {};
-		SDL_JoystickGetGUIDString(SDL_JoystickGetGUID(this->sdl_joystick), guid_str, sizeof(guid_str));
-		if (memcmp("09120000072f0000", guid_str + 8, 16) == 0)
+		NOTICE_LOG(INPUT, "Resetting SDL gamepad to default: %d %d", arcade, gamepad);
+		if (arcade)
 		{
-			NOTICE_LOG(INPUT, "Resetting SDL gamepad to default for Dreamcast Controller USB");
-			input_mapper = std::make_shared<DefaultInputMapping<false, true, true>>(sdl_controller);
+			if (gamepad)
+				input_mapper = std::make_shared<DefaultInputMapping<true, true>>(sdl_controller);
+			else
+				input_mapper = std::make_shared<DefaultInputMapping<true, false>>(sdl_controller);
 		}
 		else
-		{
-			NOTICE_LOG(INPUT, "Resetting SDL gamepad to default: %d %d", arcade, gamepad);
-			if (arcade)
-			{
-				if (gamepad)
-					input_mapper = std::make_shared<DefaultInputMapping<true, true, false>>(sdl_controller);
-				else
-					input_mapper = std::make_shared<DefaultInputMapping<true, false, false>>(sdl_controller);
-			}
-			else
-				input_mapper = std::make_shared<DefaultInputMapping<false, false, false>>(sdl_controller);
-		}
+			input_mapper = std::make_shared<DefaultInputMapping<false, false>>(sdl_controller);
 	}
 
 


### PR DESCRIPTION
This PR enables the usage of VMUs and Rumble Packs with original Dreamcast Controllers connected to MacOS/Linux/Windows using the [DreamcastControllerUsbPico](https://github.com/OrangeFox86/DreamcastControllerUsbPico) Raspberry Pi Pico-based USB-Adapter.

By default, the USB-Adapter provides the following devices:
- USB HID with support for analog triggers (e.g., to be used by any emulator/game)
- USB MSC exposing the VMU contents as a removable media (e.g., to copy savegames between emulators and actual hardware)
- USB CDC serial device for communication with the Maple Bus (i.e., enabling arbitrary MapleIO)

Using the USB CDC serial device, this PR piggybacks on the handler for DreamConn+ Controllers as discussed [here](https://github.com/flyinghead/flycast/issues/1305). It currently provides a working implementation of VMUs and Rumble Packs using MapleIO with support for MacOS/Linux/Windows.

Demo: https://youtu.be/Nj4dRMZ_jB0

Usage:
- Wire up DreamcastControllerUsbPico for [Host Mode 1 Player](https://github.com/OrangeFox86/DreamcastControllerUsbPico?tab=readme-ov-file#quick-installation-guide)
- Deploy the [precompiled binary](https://github.com/OrangeFox86/DreamcastControllerUsbPico/releases/tag/v0.14) on the microcontroller
- Plugin the microcontroller
- Linux: there might be some permission issues since the USB serial device (most likely `/dev/ttyACM*`) is owned by root. Change permission of the device to your user, or startup Flycast with superuser permissions
- Startup Flycast
- MacOS and Windows: the button mappings need to be manually configured in Flycasts' Controls Tab (see also todos). Make sure that Left Trigger is assigned to 2+, and Right Trigger to 5+ (sometimes they register as 2-/5- for some reason)

Notes:
- Controller needs to be reconnected if devices (e.g., VMU/Rumble pack) are added to the controller
- Games need to be restarted if a Controller is reconnected to re-initialize MapleIO communication. Not sure if this is identical for DreamConn+
- When MapleIO disconnects (e.g., a game is closed), VMU LCD shows the last state until new LCD data is received
- VMUs can not be used for actual savegames during emulation. Yet, VMU binary files can be copied over to/from the VMU using the USB Mass Storage device
- Supports 1 Controller only, primarily because I only have 1 Controller to test this with

Todos:
- I probably broke some DreamConn+ stuff which I cannot test as I do not own that device. Maybe @chrisvcpp can pitch in and verify DreamConn+ support
- MapleIO on the serial port is performed asynchronously to optimize performance. For some reason, the completion handler is not called when the `async_write()` finishes. As such, the disconnection of a serial device can currently not be detected reliably since the device will report being open despite being disconnected. As a consequence, the `DreamConn` instance is not deconstructed correctly until a new game is started
- Depending on OS, USB port, and other serial devices connected, the serial device handler (e.g., `/dev/ttyACM0`, `COM1`) changes. Currently, the first serial device found is used. This should probably be exposed to a config file or the UI for proper handling
- On MacOS and Windows, the default button mapping of the USB HID does not match the buttons a, y, start, the dpad, and the analog triggers. Even if manually configured, the `checkKeyCombo()` is not working since leftTrigger and rightTrigger seem to be not correctly wired within the `SDLGamepad` handler - I couldn't figure out why. This can probably be hardcoded? The mapping is: 

```
[analog]
bind0 = 0-:btn_analog_left
bind1 = 0+:btn_analog_right
bind2 = 1-:btn_analog_up
bind3 = 1+:btn_analog_down
bind4 = 2+:btn_trigger_left
bind5 = 5+:btn_trigger_right

[digital]
bind0 = 0:btn_a
bind1 = 1:btn_b
bind2 = 3:btn_x
bind3 = 4:btn_y
bind4 = 11:btn_start
bind5 = 256:btn_dpad1_up
bind6 = 257:btn_dpad1_down
bind7 = 258:btn_dpad1_left
bind8 = 259:btn_dpad1_right
```

Credits go to @Tails86 for DreamcastControllerUsbPico, @flyinghead for Flycast, and @chrisvcpp for DreamConn+. Thanks to @Marcel43367 for helping on serial device debugging!
