### PR TITLE
vk: Refactor swapchain format selection

### DIFF
--- a/core/rend/vulkan/vulkan_context.h
+++ b/core/rend/vulkan/vulkan_context.h
@@ -240,7 +240,7 @@ private:
 	vk::UniqueSwapchainKHR swapChain;
 	std::vector<vk::UniqueImageView> imageViews;
 	u32 currentImage = 0;
-	vk::Format colorFormat = vk::Format::eUndefined;
+	vk::Format presentFormat = vk::Format::eUndefined;
 
 	vk::Queue graphicsQueue;
 	vk::Queue presentQueue;


### PR DESCRIPTION
Use a series of stable-partitions to sort the list of available formats to find the best candidate surface-format/color-space that is a non-sRGB format being presented in an sRGB color-space. Vulkan mandates that all surface formats that have SRGB forms must also support a UNORM form.

This is basically just RGBA8/BGRA8 on all platforms still, but in a way that is still capable of falling back to secondary formats in a stable way in the case that the primary choice is not available.  Mobile devices especially have a LOT of secondary HDR surface formats and other weird formats that can be used to present such as RGBA16 or RGBA565. With stable partitions, if we can't get our best option then there is always a "next best thing" to fall back on rather than relying on the driver-order.