### PR TITLE
Connect to DreamConn only once registered

### DIFF
--- a/core/input/gamepad_device.cpp
+++ b/core/input/gamepad_device.cpp
@@ -329,7 +329,7 @@ bool GamepadDevice::gamepad_axis_input(u32 code, int value)
 			int threshold = 16384;
 			if (code == leftTrigger || code == rightTrigger )
 				threshold = 100;
-
+				
 			if (std::abs(v) < threshold)
 				kcode[port] |=  key; // button released
 			else
@@ -540,9 +540,9 @@ static FILE *get_record_input(bool write)
 void GamepadDevice::Register(const std::shared_ptr<GamepadDevice>& gamepad)
 {
 	int maple_port = cfgLoadInt("input",
-			MAPLE_PORT_CFG_PREFIX + gamepad->unique_id(), gamepad->maple_port());
-	// set_maple_port will perform connection to real maple bus here
-	gamepad->set_maple_port(maple_port);
+			MAPLE_PORT_CFG_PREFIX + gamepad->unique_id(), 12345);
+	if (maple_port != 12345)
+		gamepad->set_maple_port(maple_port);
 #ifdef TEST_AUTOMATION
 	if (record_input == NULL)
 	{

--- a/core/input/gamepad_device.cpp
+++ b/core/input/gamepad_device.cpp
@@ -329,7 +329,7 @@ bool GamepadDevice::gamepad_axis_input(u32 code, int value)
 			int threshold = 16384;
 			if (code == leftTrigger || code == rightTrigger )
 				threshold = 100;
-				
+
 			if (std::abs(v) < threshold)
 				kcode[port] |=  key; // button released
 			else
@@ -554,6 +554,9 @@ void GamepadDevice::Register(const std::shared_ptr<GamepadDevice>& gamepad)
 	Lock _(_gamepads_mutex);
 	_gamepads.push_back(gamepad);
 	MapleConfigMap::UpdateVibration = updateVibration;
+
+	gamepad->_is_registered = true;
+	gamepad->registered();
 }
 
 void GamepadDevice::Unregister(const std::shared_ptr<GamepadDevice>& gamepad)

--- a/core/input/gamepad_device.cpp
+++ b/core/input/gamepad_device.cpp
@@ -329,7 +329,7 @@ bool GamepadDevice::gamepad_axis_input(u32 code, int value)
 			int threshold = 16384;
 			if (code == leftTrigger || code == rightTrigger )
 				threshold = 100;
-				
+
 			if (std::abs(v) < threshold)
 				kcode[port] |=  key; // button released
 			else
@@ -540,9 +540,9 @@ static FILE *get_record_input(bool write)
 void GamepadDevice::Register(const std::shared_ptr<GamepadDevice>& gamepad)
 {
 	int maple_port = cfgLoadInt("input",
-			MAPLE_PORT_CFG_PREFIX + gamepad->unique_id(), 12345);
-	if (maple_port != 12345)
-		gamepad->set_maple_port(maple_port);
+			MAPLE_PORT_CFG_PREFIX + gamepad->unique_id(), gamepad->maple_port());
+	// set_maple_port will perform connection to real maple bus here
+	gamepad->set_maple_port(maple_port);
 #ifdef TEST_AUTOMATION
 	if (record_input == NULL)
 	{

--- a/core/input/gamepad_device.h
+++ b/core/input/gamepad_device.h
@@ -40,7 +40,7 @@ public:
 	virtual bool gamepad_btn_input(u32 code, bool pressed);
 	virtual bool gamepad_axis_input(u32 code, int value);
 	virtual ~GamepadDevice() = default;
-	
+
 	void detect_btn_input(input_detected_cb button_pressed);
 	void detect_axis_input(input_detected_cb axis_moved);
 	void detectButtonOrAxisInput(input_detected_cb input_changed);
@@ -91,6 +91,7 @@ public:
 			save_mapping();
 		}
 	}
+	bool is_registered() const { return _is_registered; }
 
 	static void Register(const std::shared_ptr<GamepadDevice>& gamepad);
 	static void Unregister(const std::shared_ptr<GamepadDevice>& gamepad);
@@ -145,6 +146,7 @@ protected:
 	u32 rightTrigger = ~0;
 
 private:
+	virtual void registered() {}
 	bool handleButtonInput(int port, DreamcastKey key, bool pressed);
 	std::string make_mapping_filename(bool instance, int system, bool perGame = false);
 
@@ -189,6 +191,7 @@ private:
 	u64 _detection_start_time = 0;
 	input_detected_cb _input_detected;
 	bool _remappable;
+	bool _is_registered = false;
 	u32 digitalToAnalogState[4];
 	std::map<DreamcastKey, int> lastAxisValue[4];
 	bool perGameMapping = false;

--- a/core/sdl/dreamconn.cpp
+++ b/core/sdl/dreamconn.cpp
@@ -800,6 +800,8 @@ DreamConnGamepad::~DreamConnGamepad() {
 void DreamConnGamepad::set_maple_port(int port) {
 	SDLGamepad::set_maple_port(port);
 }
+void DreamConnGamepad::registered() {
+}
 bool DreamConnGamepad::gamepad_btn_input(u32 code, bool pressed) {
 	return SDLGamepad::gamepad_btn_input(code, pressed);
 }

--- a/core/sdl/dreamconn.cpp
+++ b/core/sdl/dreamconn.cpp
@@ -566,7 +566,19 @@ private:
 	}
 };
 
-DreamConn::DreamConn(int bus, int dreamcastControllerType) : bus(bus), dreamcastControllerType(dreamcastControllerType) {
+DreamConn::DreamConn(int bus, int dreamcastControllerType, const std::string& name) :
+	bus(bus), dreamcastControllerType(dreamcastControllerType), name(name)
+{
+	change_bus(bus);
+}
+
+DreamConn::~DreamConn() {
+	disconnect();
+}
+
+void DreamConn::change_bus(int bus) {
+	disconnect();
+	dcConnection.reset();
 	switch (dreamcastControllerType)
 	{
 		case TYPE_DREAMCONN:
@@ -577,16 +589,14 @@ DreamConn::DreamConn(int bus, int dreamcastControllerType) : bus(bus), dreamcast
 			dcConnection = std::make_unique<DreamcastControllerUsbPicoConnection>(bus);
 			break;
 	}
-
-	connect();
-}
-
-DreamConn::~DreamConn() {
-	disconnect();
 }
 
 void DreamConn::connect()
 {
+	if (maple_io_connected) {
+		disconnect();
+	}
+
 	maple_io_connected = false;
 	expansionDevs = 0;
 
@@ -607,7 +617,7 @@ void DreamConn::connect()
 
 	if (hasVmu() || hasRumble())
 	{
-		NOTICE_LOG(INPUT, "Connected to DreamcastController[%d]: Type:%s, VMU:%d, Rumble Pack:%d", bus, dreamcastControllerType == 1 ? "DreamConn+ / DreamcConn S Controller" : "Dreamcast Controller USB", hasVmu(), hasRumble());
+		NOTICE_LOG(INPUT, "Connected to DreamcastController[%d]: Type:%s, VMU:%d, Rumble Pack:%d", bus, name.c_str(), hasVmu(), hasRumble());
 		maple_io_connected = true;
 	}
 	else
@@ -682,13 +692,13 @@ DreamConnGamepad::DreamConnGamepad(int maple_port, int joystick_idx, SDL_Joystic
 	// Dreamcast Controller USB VID:1209 PID:2f07
 	if (memcmp(DreamConnConnection::VID_PID_GUID, guid_str + 8, 16) == 0)
 	{
-		dreamcastControllerType = TYPE_DREAMCONN;
 		_name = "DreamConn+ / DreamConn S Controller";
+		dreamconn = std::make_shared<DreamConn>(maple_port, TYPE_DREAMCONN, _name);
 	}
 	else if (memcmp(DreamcastControllerUsbPicoConnection::VID_PID_GUID, guid_str + 8, 16) == 0)
 	{
-		dreamcastControllerType = TYPE_DREAMCASTCONTROLLERUSB;
 		_name = "Dreamcast Controller USB";
+		dreamconn = std::make_shared<DreamConn>(maple_port, TYPE_DREAMCASTCONTROLLERUSB, _name);
 	}
 
 	EventManager::listen(Event::Start, handleEvent, this);
@@ -702,14 +712,26 @@ DreamConnGamepad::~DreamConnGamepad() {
 
 void DreamConnGamepad::set_maple_port(int port)
 {
-	if (port < 0 || port >= 4) {
-		dreamconn.reset();
-	}
-	else if (dreamconn == nullptr || dreamconn->getBus() != port) {
-		dreamconn.reset();
-		dreamconn = std::make_shared<DreamConn>(port, dreamcastControllerType);
+	if (dreamconn) {
+		if (port < 0 || port >= 4) {
+			dreamconn->disconnect();
+		}
+		else if (dreamconn->getBus() != port) {
+			dreamconn->change_bus(port);
+			if (is_registered()) {
+				dreamconn->connect();
+			}
+		}
 	}
 	SDLGamepad::set_maple_port(port);
+}
+
+void DreamConnGamepad::registered()
+{
+	if (dreamconn)
+	{
+		dreamconn->connect();
+	}
 }
 
 void DreamConnGamepad::handleEvent(Event event, void *arg)

--- a/core/sdl/dreamconn.h
+++ b/core/sdl/dreamconn.h
@@ -50,16 +50,17 @@ static_assert(sizeof(MapleMsg) == 1028);
 
 class DreamConn
 {
-	const int bus;
+	int bus = -1;
 	const int dreamcastControllerType;
+	const std::string name;
 #ifdef USE_DREAMCASTCONTROLLER
 	std::unique_ptr<class DreamcastControllerConnection> dcConnection;
 #endif
-	bool maple_io_connected;
+	bool maple_io_connected = false;
 	u8 expansionDevs = 0;
 
 public:
-	DreamConn(int bus, int dreamcastControllerType);
+	DreamConn(int bus, int dreamcastControllerType, const std::string& name);
 
 	~DreamConn();
 
@@ -75,7 +76,8 @@ public:
 		return expansionDevs & 2;
 	}
 
-private:
+	void change_bus(int bus);
+
 	void connect();
 	void disconnect();
 };
@@ -87,6 +89,7 @@ public:
 	~DreamConnGamepad();
 
 	void set_maple_port(int port) override;
+	void registered() override;
 	bool gamepad_btn_input(u32 code, bool pressed) override;
 	bool gamepad_axis_input(u32 code, int value) override;
 	static bool isDreamcastController(int deviceIndex);
@@ -99,5 +102,4 @@ private:
 	bool ltrigPressed = false;
 	bool rtrigPressed = false;
 	bool startPressed = false;
-	int dreamcastControllerType;
 };


### PR DESCRIPTION
This is regarding discussion https://github.com/flyinghead/flycast/discussions/1825

Problem: When no config is present, then a DreamConn connection isn't being made.

[DreamConnGamepad::set_maple_port()](https://github.com/flyinghead/flycast/blob/dev/core/sdl/dreamconn.cpp#L703) needs to be called in order to establish connection to the device. It should always be called in `GamepadDevice::Register()`, even when `cfgLoadInt()` returns the default result. This is essentially just setting it to the same defaulted index it was already set to if it isn't in the config.