### PR TITLE
Rename DreamPort to DreamPicoPort

### DIFF
--- a/core/sdl/dreamconn.cpp
+++ b/core/sdl/dreamconn.cpp
@@ -228,18 +228,6 @@ public:
 
 		// use user-configured serial device if available, fallback to first available
 		serial_device = cfgLoadStr("input", "DreamPicoPortSerialDevice", "");
-		if (serial_device.empty()) {
-            serial_device = cfgLoadStr("input", "DreamPortSerialDevice", "");
-            if (!serial_device.empty()) {
-                WARN_LOG(INPUT, "DreamPortSerialDevice config is deprecated; use DreamPicoPortSerialDevice instead");
-            } else {
-                serial_device = cfgLoadStr("input", "DreamcastControllerUsbSerialDevice", "");
-                if (!serial_device.empty()) {
-                    WARN_LOG(INPUT, "DreamcastControllerUsbSerialDevice config is deprecated; use DreamPicoPortSerialDevice instead");
-                }
-            }
-		}
-
 		if (!serial_device.empty())
 		{
 			NOTICE_LOG(INPUT, "DreamPicoPort connecting to user-configured serial device: %s", serial_device.c_str());

--- a/core/sdl/dreamconn.h
+++ b/core/sdl/dreamconn.h
@@ -23,7 +23,7 @@
 #if (defined(_WIN32) || defined(__linux__) || (defined(__APPLE__) && defined(TARGET_OS_MAC))) && !defined(TARGET_UWP)
 #define USE_DREAMCASTCONTROLLER 1
 #define TYPE_DREAMCONN 1
-#define TYPE_DREAMPORT 2
+#define TYPE_DREAMPICOPORT 2
 #include <asio.hpp>
 #endif
 #include <memory>

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -271,9 +271,9 @@ void input_sdl_init()
 	// Linux mappings are OK by default
 	// Can be removed once mapping is merged into SDL, see https://github.com/libsdl-org/SDL/pull/12039
 #if (defined(__APPLE__) && defined(TARGET_OS_MAC))
-	SDL_GameControllerAddMapping("0300000009120000072f000000010000,OrangeFox86 DreamPort,a:b0,b:b1,x:b3,y:b4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,dpdown:h0.4,leftx:a0,lefty:a1,lefttrigger:a2,righttrigger:a5,start:b11");
+	SDL_GameControllerAddMapping("0300000009120000072f000000010000,OrangeFox86 DreamPicoPort,a:b0,b:b1,x:b3,y:b4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,dpdown:h0.4,leftx:a0,lefty:a1,lefttrigger:a2,righttrigger:a5,start:b11");
 #elif defined(_WIN32)
-	SDL_GameControllerAddMapping("0300000009120000072f000000000000,OrangeFox86 DreamPort,a:b0,b:b1,x:b3,y:b4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,dpdown:h0.4,leftx:a0,lefty:a1,lefttrigger:-a2,righttrigger:-a5,start:b11");
+	SDL_GameControllerAddMapping("0300000009120000072f000000000000,OrangeFox86 DreamPicoPort,a:b0,b:b1,x:b3,y:b4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,dpdown:h0.4,leftx:a0,lefty:a1,lefttrigger:-a2,righttrigger:-a5,start:b11");
 #endif
 }
 


### PR DESCRIPTION
PR renames `DreamPort` to `DreamPicoPort` to differentiate from another Dreamcast peripheral using the same name. Renaming has already been done in the [project](https://github.com/OrangeFox86/DreamPicoPort) and in [SDL](https://github.com/libsdl-org/SDL/pull/12325).