### PR TITLE
Reset static device state on core unload to ensure input descriptors …

### DIFF
--- a/shell/libretro/libretro.cpp
+++ b/shell/libretro/libretro.cpp
@@ -311,6 +311,9 @@ static void retro_keyboard_event(bool down, unsigned keycode, uint32_t character
 // Now comes the interesting stuff
 void retro_init()
 {
+	first_run = true;
+	memset(device_type, -1, sizeof(device_type));
+	
 	static bool emuInited;
 
 	// Logging
@@ -371,6 +374,7 @@ void retro_deinit()
 {
 	INFO_LOG(COMMON, "retro_deinit");
 	first_run = true;
+	memset(device_type, -1, sizeof(device_type));
 
 	//When auto-save states are enabled this is needed to prevent the core from shutting down before
 	//any save state actions are still running - which results in partial saves


### PR DESCRIPTION
Explicitly reset static variables `device_type` and `first_run` in  
`retro_deinit()` and `retro_init()` to guarantee a clean state when  
the core is reloaded. This fixes input descriptors not refreshing  
after core reloads due to retained static values.  

- Reset `device_type` to `{-1, -1, -1, -1` in `retro_deinit()`  
- Ensure `first_run` is reinitialized to `true` in `retro_init()`  
- Addresses platform-specific behavior where dynamic libraries may retain  
  static variables even after unload (e.g., incomplete OS-level cleanup) 