### PR TITLE
Use Windows-2025 Runner

### DIFF
--- a/.github/workflows/uwp.yml
+++ b/.github/workflows/uwp.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: UWP
-    runs-on: windows-latest
+    runs-on: windows-2025
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`windows-latest` uses` windows-2022` by default.

The purpose of this change is to use more recent packages for compilation.