### PR TITLE
ci: remove ninja installation for macos runner

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -32,7 +32,7 @@ jobs:
           # Unlink and re-link to prevent errors when github mac runner images install python outside of brew. See https://github.com/actions/setup-python/issues/577
           brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
           brew update || :
-          brew install libao ldid ninja pulseaudio
+          brew install libao ldid pulseaudio
           brew uninstall --ignore-dependencies zstd
           VULKAN_VER=1.3.261.1 && aria2c https://sdk.lunarg.com/sdk/download/$VULKAN_VER/mac/vulkansdk-macos-$VULKAN_VER.dmg
           hdiutil attach ./vulkansdk-macos-*.dmg -mountpoint /Volumes/VulkanSDK


### PR DESCRIPTION
This will remove the following warning in GitHub Actions:

> ninja 1.12.1 is already installed and up-to-date. To reinstall 1.12.1, run: brew reinstall ninja

As ninja is already installed in `macos-latest` runners