### PR TITLE
DreamPicoPort fixes/enhancements

### DIFF
--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -203,7 +203,7 @@ Option<bool> PerGameVmu("PerGameVmu", false, "config");
 #ifdef _WIN32
 Option<bool, false> UseRawInput("RawInput", false, "input");
 #endif
-Option<bool> UsePhysicalVmuMemory("UsePhysicalVmuMemory", false);
+Option<bool> UsePhysicalVmuMemory("UsePhysicalVmuMemory", true);
 
 #ifdef USE_LUA
 Option<std::string, false> LuaFileName("LuaFileName", "flycast.lua");

--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -2500,21 +2500,7 @@ struct DreamLinkPurupuru : public maple_sega_purupuru
 static std::list<std::shared_ptr<DreamLinkVmu>> dreamLinkVmus[2];
 static std::list<std::shared_ptr<DreamLinkPurupuru>> dreamLinkPurupurus;
 
-static void disablePhysicalVmuMemoryOption()
-{
-	// Make setting read only
-	config::UsePhysicalVmuMemory.override(config::UsePhysicalVmuMemory);
-}
-
-static void enablePhysicalVmuMemoryOption()
-{
-	// Remove read-only setting and preserve current value
-	bool val = config::UsePhysicalVmuMemory;
-	config::UsePhysicalVmuMemory.reset();
-	config::UsePhysicalVmuMemory.set(val);
-}
-
-void createDreamLinkDevices(std::shared_ptr<DreamLink> dreamlink, bool gameStart, bool gameEnd)
+void createDreamLinkDevices(std::shared_ptr<DreamLink> dreamlink, bool gameStart)
 {
 	const int bus = dreamlink->getBus();
 
@@ -2556,15 +2542,6 @@ void createDreamLinkDevices(std::shared_ptr<DreamLink> dreamlink, bool gameStart
 				if (!vmuFound) {
 					dreamLinkVmus[i].push_back(vmu);
 				}
-			}
-
-			if (gameStart)
-			{
-				disablePhysicalVmuMemoryOption();
-			}
-			else if (gameEnd)
-			{
-				enablePhysicalVmuMemoryOption();
 			}
 		}
 		else if (i == 1 && ((dreamlink->getFunctionCode(i + 1) & MFID_8_Vibration) || (dev != nullptr && dev->get_device_type() == MDT_PurupuruPack)))
@@ -2628,11 +2605,6 @@ void tearDownDreamLinkDevices(std::shared_ptr<DreamLink> dreamlink)
 	for (int i = 0; i < 2; ++i)
 	{
 		dreamLinkVmuCount += dreamLinkVmus[i].size();
-	}
-
-	if (dreamLinkVmuCount == 0)
-	{
-		enablePhysicalVmuMemoryOption();
 	}
 
 	for (std::list<std::shared_ptr<DreamLinkPurupuru>>::const_iterator iter = dreamLinkPurupurus.begin();

--- a/core/sdl/dreamconn.h
+++ b/core/sdl/dreamconn.h
@@ -62,6 +62,18 @@ public:
 		return 0;
 	}
 
+	std::array<u32, 3> getFunctionDefinitions(int forPort) const override {
+		std::array<u32, 3> arr{0, 0, 0};
+		if (forPort == 1 && hasVmu()) {
+			// For clock, LCD, storage
+			return std::array<u32, 3>{0x403f7e7e, 0x00100500, 0x00410f00};
+		}
+		else if (forPort == 2 && hasRumble()) {
+			return std::array<u32, 3>{0x00000101, 0, 0};
+		}
+		return std::array<u32, 3>{0, 0, 0};
+	}
+
 	bool hasVmu() const {
 		return expansionDevs & 1;
 	}

--- a/core/sdl/dreamlink.cpp
+++ b/core/sdl/dreamlink.cpp
@@ -86,13 +86,6 @@ DreamLinkGamepad::DreamLinkGamepad(int maple_port, int joystick_idx, SDL_Joystic
 	else if (memcmp(DreamPicoPort::VID_PID_GUID, guid_str + 8, 16) == 0)
 	{
 		dreamlink = std::make_shared<DreamPicoPort>(maple_port, joystick_idx, sdl_joystick);
-		// Set DreamPort device's default deadzone to 0.0 for new mappings only
-		if (input_mapper != nullptr && !find_mapping())
-		{
-			input_mapper->dead_zone = 0.0f;
-			input_mapper->set_dirty();
-			save_mapping();
-		}
 	}
 
 	if (dreamlink) {
@@ -107,6 +100,8 @@ DreamLinkGamepad::DreamLinkGamepad(int maple_port, int joystick_idx, SDL_Joystic
 	EventManager::listen(Event::Start, handleEvent, this);
 	EventManager::listen(Event::LoadState, handleEvent, this);
     EventManager::listen(Event::Terminate, handleEvent, this);
+
+	loadMapping();
 }
 
 DreamLinkGamepad::~DreamLinkGamepad() {
@@ -205,16 +200,12 @@ void DreamLinkGamepad::checkKeyCombo() {
 		gui_open_settings();
 }
 
-void DreamLinkGamepad::resetMappingToDefault(bool arcade, bool gamepad)
-{
-	SDLGamepad::resetMappingToDefault(arcade, gamepad);
-
-	// Set DreamPort device's deadzone to 0.0 for reset-to-default case
-	if (input_mapper != nullptr && dreamlink &&
-		device_guid.length() >= 24 && memcmp(DreamPicoPort::VID_PID_GUID, device_guid.c_str() + 8, 16) == 0) {
-		input_mapper->dead_zone = 0.0f;
-		input_mapper->set_dirty();
+std::shared_ptr<InputMapping> DreamLinkGamepad::getDefaultMapping() {
+	std::shared_ptr<InputMapping> mapping = SDLGamepad::getDefaultMapping();
+	if (mapping && dreamlink) {
+		dreamlink->setDefaultMapping(mapping);
 	}
+	return mapping;
 }
 
 #else // USE_DREAMCASTCONTROLLER
@@ -238,11 +229,8 @@ bool DreamLinkGamepad::gamepad_btn_input(u32 code, bool pressed) {
 bool DreamLinkGamepad::gamepad_axis_input(u32 code, int value) {
 	return SDLGamepad::gamepad_axis_input(code, value);
 }
-bool DreamLinkGamepad::find_mapping(int system) {
-	return SDLGamepad::find_mapping(system);
-}
-void DreamLinkGamepad::resetMappingToDefault(bool arcade, bool gamepad) {
-	SDLGamepad::resetMappingToDefault(arcade, gamepad);
+std::shared_ptr<InputMapping> DreamLinkGamepad::getDefaultMapping() {
+	return SDLGamepad::getDefaultMapping();
 }
 
 #endif

--- a/core/sdl/dreamlink.cpp
+++ b/core/sdl/dreamlink.cpp
@@ -205,17 +205,12 @@ void DreamLinkGamepad::checkKeyCombo() {
 		gui_open_settings();
 }
 
-bool DreamLinkGamepad::find_mapping(int system)
-{
-	return SDLGamepad::find_mapping(system);
-}
-
 void DreamLinkGamepad::resetMappingToDefault(bool arcade, bool gamepad)
 {
 	SDLGamepad::resetMappingToDefault(arcade, gamepad);
-	
+
 	// Set DreamPort device's deadzone to 0.0 for reset-to-default case
-	if (input_mapper != nullptr && dreamlink && 
+	if (input_mapper != nullptr && dreamlink &&
 		device_guid.length() >= 24 && memcmp(DreamPicoPort::VID_PID_GUID, device_guid.c_str() + 8, 16) == 0) {
 		input_mapper->dead_zone = 0.0f;
 		input_mapper->set_dirty();

--- a/core/sdl/dreamlink.cpp
+++ b/core/sdl/dreamlink.cpp
@@ -199,6 +199,11 @@ bool DreamLinkGamepad::gamepad_axis_input(u32 code, int value)
 	return SDLGamepad::gamepad_axis_input(code, value);
 }
 
+void DreamLinkGamepad::resetMappingToDefault(bool arcade, bool gamepad) {
+	SDLGamepad::resetMappingToDefault(arcade, gamepad);
+	dreamlink->setDefaultMapping(input_mapper);
+}
+
 std::shared_ptr<InputMapping> DreamLinkGamepad::getDefaultMapping() {
 	std::shared_ptr<InputMapping> mapping = SDLGamepad::getDefaultMapping();
 	if (mapping && dreamlink) {
@@ -232,6 +237,9 @@ bool DreamLinkGamepad::gamepad_btn_input(u32 code, bool pressed) {
 }
 bool DreamLinkGamepad::gamepad_axis_input(u32 code, int value) {
 	return SDLGamepad::gamepad_axis_input(code, value);
+}
+void DreamLinkGamepad::resetMappingToDefault(bool arcade, bool gamepad) {
+	SDLGamepad::resetMappingToDefault(arcade, gamepad);
 }
 std::shared_ptr<InputMapping> DreamLinkGamepad::getDefaultMapping() {
 	return SDLGamepad::getDefaultMapping();

--- a/core/sdl/dreamlink.cpp
+++ b/core/sdl/dreamlink.cpp
@@ -46,7 +46,7 @@
 #include <setupapi.h>
 #endif
 
-void createDreamLinkDevices(std::shared_ptr<DreamLink> dreamlink, bool gameStart, bool gameEnd);
+void createDreamLinkDevices(std::shared_ptr<DreamLink> dreamlink, bool gameStart);
 void tearDownDreamLinkDevices(std::shared_ptr<DreamLink> dreamlink);
 
 bool DreamLinkGamepad::isDreamcastController(int deviceIndex)
@@ -142,7 +142,7 @@ void DreamLinkGamepad::registered()
 		dreamlink->connect();
 
 		// Create DreamLink Maple Devices here just in case game is already running
-		createDreamLinkDevices(dreamlink, false, false);
+		createDreamLinkDevices(dreamlink, false);
 	}
 }
 
@@ -150,7 +150,7 @@ void DreamLinkGamepad::handleEvent(Event event, void *arg)
 {
 	DreamLinkGamepad *gamepad = static_cast<DreamLinkGamepad*>(arg);
 	if (gamepad->dreamlink != nullptr && event != Event::Terminate) {
-		createDreamLinkDevices(gamepad->dreamlink, event == Event::Start, event == Event::Terminate);
+		createDreamLinkDevices(gamepad->dreamlink, event == Event::Start);
 	}
 
     if (gamepad->dreamlink != nullptr && event == Event::Terminate)
@@ -195,17 +195,17 @@ bool DreamLinkGamepad::gamepad_axis_input(u32 code, int value)
 	return SDLGamepad::gamepad_axis_input(code, value);
 }
 
-void DreamLinkGamepad::checkKeyCombo() {
-	if (ltrigPressed && rtrigPressed && startPressed)
-		gui_open_settings();
-}
-
 std::shared_ptr<InputMapping> DreamLinkGamepad::getDefaultMapping() {
 	std::shared_ptr<InputMapping> mapping = SDLGamepad::getDefaultMapping();
 	if (mapping && dreamlink) {
 		dreamlink->setDefaultMapping(mapping);
 	}
 	return mapping;
+}
+
+void DreamLinkGamepad::checkKeyCombo() {
+	if (ltrigPressed && rtrigPressed && startPressed)
+		gui_open_settings();
 }
 
 #else // USE_DREAMCASTCONTROLLER

--- a/core/sdl/dreamlink.cpp
+++ b/core/sdl/dreamlink.cpp
@@ -95,6 +95,10 @@ DreamLinkGamepad::DreamLinkGamepad(int maple_port, int joystick_idx, SDL_Joystic
 			set_maple_port(defaultBus);
 		}
 
+		std::string uniqueId = dreamlink->getUniqueId();
+		if (!uniqueId.empty()) {
+			this->_unique_id = uniqueId;
+		}
 	}
 
 	EventManager::listen(Event::Start, handleEvent, this);

--- a/core/sdl/dreamlink.cpp
+++ b/core/sdl/dreamlink.cpp
@@ -201,7 +201,9 @@ bool DreamLinkGamepad::gamepad_axis_input(u32 code, int value)
 
 void DreamLinkGamepad::resetMappingToDefault(bool arcade, bool gamepad) {
 	SDLGamepad::resetMappingToDefault(arcade, gamepad);
-	dreamlink->setDefaultMapping(input_mapper);
+	if (input_mapper && dreamlink) {
+		dreamlink->setDefaultMapping(input_mapper);
+	}
 }
 
 std::shared_ptr<InputMapping> DreamLinkGamepad::getDefaultMapping() {

--- a/core/sdl/dreamlink.h
+++ b/core/sdl/dreamlink.h
@@ -96,6 +96,10 @@ public:
 		return -1;
 	}
 
+	//! Allows a DreamLink device to dictate the default mapping
+	virtual void setDefaultMapping(const std::shared_ptr<InputMapping>& mapping) const {
+	}
+
 	//! @return the selected bus number of the controller
 	virtual int getBus() const = 0;
 
@@ -123,11 +127,11 @@ public:
 	bool gamepad_btn_input(u32 code, bool pressed) override;
 	bool gamepad_axis_input(u32 code, int value) override;
 	static bool isDreamcastController(int deviceIndex);
-	void resetMappingToDefault(bool arcade, bool gamepad) override;
 
 private:
 	static void handleEvent(Event event, void *arg);
 	void checkKeyCombo();
+	std::shared_ptr<InputMapping> getDefaultMapping() override;
 
 	std::shared_ptr<DreamLink> dreamlink;
 	bool ltrigPressed = false;

--- a/core/sdl/dreamlink.h
+++ b/core/sdl/dreamlink.h
@@ -100,6 +100,11 @@ public:
 	virtual void setDefaultMapping(const std::shared_ptr<InputMapping>& mapping) const {
 	}
 
+	//! @return a unique ID for this DreamLink device or empty string to use default
+	virtual std::string getUniqueId() const {
+		return std::string();
+	}
+
 	//! @return the selected bus number of the controller
 	virtual int getBus() const = 0;
 

--- a/core/sdl/dreamlink.h
+++ b/core/sdl/dreamlink.h
@@ -123,7 +123,6 @@ public:
 	bool gamepad_btn_input(u32 code, bool pressed) override;
 	bool gamepad_axis_input(u32 code, int value) override;
 	static bool isDreamcastController(int deviceIndex);
-	bool find_mapping(int system = settings.platform.system) override;
 	void resetMappingToDefault(bool arcade, bool gamepad) override;
 
 private:

--- a/core/sdl/dreamlink.h
+++ b/core/sdl/dreamlink.h
@@ -132,6 +132,7 @@ public:
 	bool gamepad_btn_input(u32 code, bool pressed) override;
 	bool gamepad_axis_input(u32 code, int value) override;
 	static bool isDreamcastController(int deviceIndex);
+	void resetMappingToDefault(bool arcade, bool gamepad) override;
 
 protected:
 	std::shared_ptr<InputMapping> getDefaultMapping() override;

--- a/core/sdl/dreamlink.h
+++ b/core/sdl/dreamlink.h
@@ -123,6 +123,8 @@ public:
 	bool gamepad_btn_input(u32 code, bool pressed) override;
 	bool gamepad_axis_input(u32 code, int value) override;
 	static bool isDreamcastController(int deviceIndex);
+	bool find_mapping(int system = settings.platform.system) override;
+	void resetMappingToDefault(bool arcade, bool gamepad) override;
 
 private:
 	static void handleEvent(Event event, void *arg);
@@ -132,4 +134,5 @@ private:
 	bool ltrigPressed = false;
 	bool rtrigPressed = false;
 	bool startPressed = false;
+	std::string device_guid;
 };

--- a/core/sdl/dreamlink.h
+++ b/core/sdl/dreamlink.h
@@ -128,10 +128,12 @@ public:
 	bool gamepad_axis_input(u32 code, int value) override;
 	static bool isDreamcastController(int deviceIndex);
 
+protected:
+	std::shared_ptr<InputMapping> getDefaultMapping() override;
+
 private:
 	static void handleEvent(Event event, void *arg);
 	void checkKeyCombo();
-	std::shared_ptr<InputMapping> getDefaultMapping() override;
 
 	std::shared_ptr<DreamLink> dreamlink;
 	bool ltrigPressed = false;

--- a/core/sdl/dreamlink.h
+++ b/core/sdl/dreamlink.h
@@ -26,6 +26,7 @@
 
 #include <functional>
 #include <memory>
+#include <array>
 
 #if (defined(_WIN32) || defined(__linux__) || (defined(__APPLE__) && defined(TARGET_OS_MAC))) && !defined(TARGET_UWP)
 #define USE_DREAMCASTCONTROLLER 1
@@ -85,6 +86,10 @@ public:
     //! @param[in] forPort The port number to get the function code of (1 or 2)
     //! @return the device type for the given port
     virtual u32 getFunctionCode(int forPort) const = 0;
+
+    //! @param[in] forPort The port number to get the function definitions of (1 or 2)
+	//! @return the 3 function definitions for the supported function codes
+    virtual std::array<u32, 3> getFunctionDefinitions(int forPort) const = 0;
 
 	//! @return the default bus number to select for this controller or -1 to not select a default
 	virtual int getDefaultBus() const {

--- a/core/sdl/dreampicoport.cpp
+++ b/core/sdl/dreampicoport.cpp
@@ -711,6 +711,11 @@ int DreamPicoPort::getDefaultBus() const {
 	}
 }
 
+void DreamPicoPort::setDefaultMapping(const std::shared_ptr<InputMapping>& mapping) const {
+	// Since this is a real DC controller, no deadzone adjustment is needed
+	mapping->dead_zone = 0.0f;
+}
+
 void DreamPicoPort::changeBus(int newBus) {
 	software_bus = newBus;
 }

--- a/core/sdl/dreampicoport.cpp
+++ b/core/sdl/dreampicoport.cpp
@@ -649,7 +649,7 @@ DreamPicoPort::DreamPicoPort(int bus, int joystick_idx, SDL_Joystick* sdl_joysti
 
 	unique_id.clear();
 	if (!is_hardware_bus_implied && !serial_number.empty()) {
-		// Locking to name which includes A-D plus serial number will ensure correct enumeration every time
+		// Locking to name, which includes A-D, plus serial number will ensure correct enumeration every time
 		unique_id = std::string("sdl_") + getName("") + std::string("_") + serial_number;
 	}
 }
@@ -722,6 +722,10 @@ int DreamPicoPort::getDefaultBus() const {
 void DreamPicoPort::setDefaultMapping(const std::shared_ptr<InputMapping>& mapping) const {
 	// Since this is a real DC controller, no deadzone adjustment is needed
 	mapping->dead_zone = 0.0f;
+	// Map the things not set by SDL
+	mapping->set_button(DC_BTN_C, 2);
+	mapping->set_button(DC_BTN_Z, 5);
+	mapping->set_button(DC_BTN_D, 10);
 }
 
 std::string DreamPicoPort::getUniqueId() const {

--- a/core/sdl/dreampicoport.cpp
+++ b/core/sdl/dreampicoport.cpp
@@ -690,6 +690,18 @@ u32 DreamPicoPort::getFunctionCode(int forPort) const {
 	return SWAP32(mask);
 }
 
+std::array<u32, 3> DreamPicoPort::getFunctionDefinitions(int forPort) const {
+	std::array<u32, 3> arr{0, 0, 0};
+	if (peripherals.size() > forPort) {
+		std::size_t idx = 0;
+		for (const auto& peripheral : peripherals[forPort]) {
+			arr[idx++] = SWAP32(peripheral[1]);
+			if (idx >= 3) break;
+		}
+	}
+	return arr;
+}
+
 int DreamPicoPort::getDefaultBus() const {
 	if (!is_hardware_bus_implied && !is_single_device) {
 		return hardware_bus;

--- a/core/sdl/dreampicoport.h
+++ b/core/sdl/dreampicoport.h
@@ -57,6 +57,10 @@ class DreamPicoPort : public DreamLink
     double interface_version = 0.0;
     //! The queried peripherals; for each function, index 0 is function code and index 1 is the function definition
     std::vector<std::vector<std::array<uint32_t, 2>>> peripherals;
+	//! The located serial number of this device or empty string if could not be found
+	std::string serial_number;
+	//! If set, the determined unique ID of this device. If not set, the serial could not be parsed.
+	std::string unique_id;
 
 public:
     //! Dreamcast Controller USB VID:1209 PID:2f07
@@ -85,6 +89,8 @@ public:
 
 	void setDefaultMapping(const std::shared_ptr<InputMapping>& mapping) const override;
 
+	std::string getUniqueId() const override;
+
 	void changeBus(int newBus);
 
 	std::string getName() const override;
@@ -100,6 +106,9 @@ public:
 	bool isHardwareBusImplied() const;
 
 	bool isSingleDevice() const;
+
+private:
+	std::string getName(std::string separator) const;
 
 private:
     asio::error_code sendCmd(const std::string& cmd);

--- a/core/sdl/dreampicoport.h
+++ b/core/sdl/dreampicoport.h
@@ -83,6 +83,8 @@ public:
 
 	int getDefaultBus() const override;
 
+	void setDefaultMapping(const std::shared_ptr<InputMapping>& mapping) const override;
+
 	void changeBus(int newBus);
 
 	std::string getName() const override;

--- a/core/sdl/dreampicoport.h
+++ b/core/sdl/dreampicoport.h
@@ -79,6 +79,8 @@ public:
 
     u32 getFunctionCode(int forPort) const override;
 
+	std::array<u32, 3> getFunctionDefinitions(int forPort) const override;
+
 	int getDefaultBus() const override;
 
 	void changeBus(int newBus);

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -2034,8 +2034,11 @@ static void gui_settings_controls(bool& maple_devices_changed)
 	OptionCheckbox("Use Raw Input", config::UseRawInput, "Supports multiple pointing devices (mice, light guns) and keyboards");
 #endif
 #ifdef USE_DREAMCASTCONTROLLER
-	OptionCheckbox("Use Physical VMU Memory", config::UsePhysicalVmuMemory,
-		"Enables direct read/write access to physical VMU memory via DreamPicoPort/DreamConn.");
+	{
+		DisabledScope scope(game_started);
+		OptionCheckbox("Use Physical VMU Memory", config::UsePhysicalVmuMemory,
+			"Enables direct read/write access to physical VMU memory via DreamPicoPort/DreamConn.");
+	}
 #endif
 
 	ImGui::Spacing();


### PR DESCRIPTION
Various fixes/enhancements to DreamPicoPort

- Enable `UsePhysicalVmuMemory` by default
- Removed `disablePhysicalVmuMemoryOption` and `enablePhysicalVmuMemoryOption`, instead setting `DisabledScope scope(game_started);` for the option checkbox
- Allow DreamLink device to dictate default mapping values
    - For DreamPicoPort, set deadzone to 0% and map C, Z, and D buttons through this
- Allow DreamLink device to set unique ID
    - For DreamPicoPort, set unique ID to name plus serial ex: `sdl_DreamPicoPortA_E66118604B872C2A`
    - This corrects random enumeration order in Windows
    - Serial retrieval doesn't work on Linux or MacOS, but these systems don't have the wonky enumeration order issue this was implemented to correct