### PR TITLE
Improve 2D Rendering on CRTs by Forcing 640x240 Output

### DIFF
--- a/shell/libretro/libretro_core_options.h
+++ b/shell/libretro/libretro_core_options.h
@@ -269,6 +269,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "video",
       {
          { "320x240",    "320x240 (Half)" },
+	 { "640x240",    "640x240 (Native 240p)" },
          { "640x480",    "640x480 (Native)" },
          { "800x600",    "800x600 (x1.25)" },
          { "960x720",    "960x720 (x1.5)" },


### PR DESCRIPTION
Many 2D games (e.g. Metal Slug 6) output at 480i or 480p despite using assets designed with 240p-style presentation. On 15khz CRTs, these games often look clearer and more stable when forced into a 640x240 (super) resolution. This improves scanline visibility and eliminates flicker, more closely replicating a native 240p arcade output.

When using Calamity CRT timings, switching to 320x240 only downscales the textures; the output resolution remains 480i/p, resulting in degraded image quality and persistent interlacing artifacts.

This core addition instead could added as a toggle under Emulation Hacks for forced 240 height output. This would give users better per-game control, improve compatibility with larger super resolutions, and help retain visual fidelity for 2D games with high-res textures.

Some arcade cabinets used hardware converters to transform 480i output into 240p for progressive scan CRTs. This feature brings that same capability to users running emulators on real CRT setups.

https://www.arcade-projects.com/threads/naomi-video-on-15khz-looks-pretty-terrible.22081/