### PR TITLE
Load mapping for sdl_gamepad through loadMapping() and getDefaultMapp…

### DIFF
--- a/core/input/gamepad_device.h
+++ b/core/input/gamepad_device.h
@@ -129,6 +129,8 @@ protected:
 	void loadMapping() {
 		if (!find_mapping())
 			input_mapper = getDefaultMapping();
+		else
+			INFO_LOG(INPUT, "using custom mapping '%s'", input_mapper->name.c_str());
 	}
 	virtual std::shared_ptr<InputMapping> getDefaultMapping() {
 		return std::make_shared<IdentityInputMapping>();

--- a/core/sdl/sdl_gamepad.h
+++ b/core/sdl/sdl_gamepad.h
@@ -196,10 +196,7 @@ public:
 			}
 		}
 
-		if (!find_mapping())
-			input_mapper = std::make_shared<DefaultInputMapping<>>(sdl_controller);
-		else
-			INFO_LOG(INPUT, "using custom mapping '%s'", input_mapper->name.c_str());
+		loadMapping();
 
 		hasAnalogStick = SDL_JoystickNumAxes(sdl_joystick) > 0;
 		set_maple_port(maple_port);
@@ -605,6 +602,11 @@ public:
 		return nullptr;
 	}
 
+	std::shared_ptr<InputMapping> getDefaultMapping() override
+	{
+		return std::make_shared<DefaultInputMapping<>>(sdl_controller);
+	}
+
 	void resetMappingToDefault(bool arcade, bool gamepad) override
 	{
 		NOTICE_LOG(INPUT, "Resetting SDL gamepad to default: %d %d", arcade, gamepad);
@@ -699,4 +701,3 @@ public:
 
 	void setAbsPos(int x, int y);
 };
-


### PR DESCRIPTION
sdl_gamepad was using its own check for `if (!find_mapping())` instead of going through `loadMapping()` which was causing issues for the child, `DreamLinkGamepad`. 