### PR TITLE
Allow tweak GDB options

### DIFF
--- a/core/hw/mem/addrspace.cpp
+++ b/core/hw/mem/addrspace.cpp
@@ -543,4 +543,18 @@ u32 getVramOffset(void *addr)
 	}
 }
 
+void getAddress(void** out_ram_base, void** out_ram, void** out_vram, void** out_aica) {
+    if (ram_base != nullptr) {
+        *out_ram_base =	ram_base;
+        *out_ram = &mem_b[0];
+        *out_vram = &vram[0];
+        *out_aica = &aica::aica_ram[0];
+    } else {
+        *out_ram_base =	nullptr;
+        *out_ram = nullptr;
+        *out_vram = nullptr;
+        *out_aica = nullptr;
+    }
+}
+
 } // namespace addrspace

--- a/core/hw/mem/addrspace.h
+++ b/core/hw/mem/addrspace.h
@@ -80,5 +80,6 @@ bool bm_lockedWrite(u8* address); // FIXME rename?
 void protectVram(u32 addr, u32 size);
 void unprotectVram(u32 addr, u32 size);
 u32 getVramOffset(void *addr);
+void getAddress(void** out_ram_base, void** out_ram, void** out_vram, void** out_aica);
 
 } // namespace addrspace


### PR DESCRIPTION
In Advanced Settings tab:
* Display current VM addresses
* Add options to tweak GDB debugging
* move _Serial Console_ option

All these changes honors `ENABLE_GDB_SERVER`.