### PR TITLE
Screen position bug fix

### DIFF
--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -669,7 +669,7 @@ bool sdl_recreate_window(u32 flags)
 	if (window != nullptr)
 		get_window_state();
 	
-	// Check if the saved window position is on a valid display
+	// Check if the saved window position is on a valid display, preventing Flycast from opening on a screen no longer pluged in
 	bool validPosition = false;
 	int numDisplays = SDL_GetNumVideoDisplays();
 	if (numDisplays > 0) {
@@ -685,7 +685,7 @@ bool sdl_recreate_window(u32 flags)
 			}
 		}
 		
-		// If position is invalid, reset to primary display
+		// If position is invalid, reset to primary display, avoiding Flycast from opening in a missing window and not being seen when windowed
 		if (!validPosition) {
 			NOTICE_LOG(COMMON, "Saved window position is not on any connected display, resetting to primary display");
 			windowPos.x = SDL_WINDOWPOS_UNDEFINED;

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -1,4 +1,3 @@
-
 #if defined(USE_SDL)
 #include "types.h"
 #include "cfg/cfg.h"
@@ -669,6 +668,30 @@ bool sdl_recreate_window(u32 flags)
 	window_maximized = cfgLoadBool("window", "maximized", window_maximized);
 	if (window != nullptr)
 		get_window_state();
+	
+	// Check if the saved window position is on a valid display
+	bool validPosition = false;
+	int numDisplays = SDL_GetNumVideoDisplays();
+	if (numDisplays > 0) {
+		for (int i = 0; i < numDisplays; i++) {
+			SDL_Rect bounds;
+			if (SDL_GetDisplayBounds(i, &bounds) == 0) {
+				// Check if the window position is inside this display
+				if (windowPos.x >= bounds.x && windowPos.x < bounds.x + bounds.w &&
+					windowPos.y >= bounds.y && windowPos.y < bounds.y + bounds.h) {
+					validPosition = true;
+					break;
+				}
+			}
+		}
+		
+		// If position is invalid, reset to primary display
+		if (!validPosition) {
+			NOTICE_LOG(COMMON, "Saved window position is not on any connected display, resetting to primary display");
+			windowPos.x = SDL_WINDOWPOS_UNDEFINED;
+			windowPos.y = SDL_WINDOWPOS_UNDEFINED;
+		}
+	}
 #endif
 	if (window != nullptr)
 	{


### PR DESCRIPTION
Flycast has a bug that happens when you have multiple monitors.

 If I have 2 monitors running, and move Flycast to monitor 2, then exit, it saves so the next time you load up Flycast it will start on that screen. This is nice until you unplug the 2nd monitor before changing it back. When this happens, you can start Flycast but cannot see it, unless you press F11 to make it fullscreen, but then when you hit it again, it goes back to the screen not plugged in and cannot be seen.
 
  I decided to add a check that verifies if the saved window position is on a currently connected display. If not, it resets the window position to the primary display, preventing Flycast from opening on a monitor that is no longer connected and becoming invisible to the user.