### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/core/deps/picotcp/modules/pico_ipv4.c
+++ b/core/deps/picotcp/modules/pico_ipv4.c
@@ -403,6 +403,11 @@ static int pico_ipv4_process_in(struct pico_protocol *self, struct pico_frame *f
     f->transport_hdr = ((uint8_t *)f->net_hdr) + PICO_SIZE_IP4HDR + option_len;
     f->transport_len = (uint16_t)(short_be(hdr->len) - PICO_SIZE_IP4HDR - option_len);
     f->net_len = (uint16_t)(PICO_SIZE_IP4HDR + option_len);
+
+    if ((f->net_hdr + f->net_len) > (f->buffer + f->buffer_len)) {
+        pico_frame_discard(f);
+        return 0;
+    }
 #if defined(PICO_SUPPORT_IPV4FRAG) || defined(PICO_SUPPORT_IPV6FRAG)
     f->frag = short_be(hdr->frag);
 #endif

--- a/core/deps/picotcp/modules/pico_tcp.c
+++ b/core/deps/picotcp/modules/pico_tcp.c
@@ -860,6 +860,9 @@ static inline void tcp_parse_option_mss(struct pico_socket_tcp *t, uint8_t len, 
     if (tcpopt_len_check(idx, len, PICO_TCPOPTLEN_MSS) < 0)
         return;
 
+    if ((*idx + PICO_TCPOPTLEN_MSS) > len)
+        return;
+
     t->mss_ok = 1;
     mss = short_from(opt + *idx);
     *idx += (uint32_t)sizeof(uint16_t);
@@ -888,6 +891,10 @@ static int tcp_parse_options(struct pico_frame *f)
     uint8_t *opt = f->transport_hdr + PICO_SIZE_TCPHDR;
     uint32_t i = 0;
     f->timestamp = 0;
+
+    if (f->buffer + f->buffer_len > f->transport_hdr + f->transport_len)
+        return -1;
+
     while (i < (f->transport_len - PICO_SIZE_TCPHDR)) {
         uint8_t type =  opt[i++];
         uint8_t len;


### PR DESCRIPTION
Hi Development Team,

I identified potential vulnerabilities in clone functions in `core/deps/picotcp/modules/pico_tcp.c` and `core/deps/picotcp/modules/pico_ipv4.c` sourced from [virtualsquare/picotcp](https://github.com/virtualsquare/picotcp). This issue, originally reported in [CVE-2023-35849](https://nvd.nist.gov/vuln/detail/CVE-2023-35849), was resolved in the repository via this commit https://github.com/virtualsquare/picotcp/commit/4b9a16764f2b12b611de9c34a50b4713d10ca401.

This PR applies the corresponding patch to handle potential null pointer dereference in this codebase.

Please review at your convenience. Thank you!