### PR TITLE
DreamPicoPort Mapping Updates (for maraca support)

### DIFF
--- a/core/sdl/dreamlink.cpp
+++ b/core/sdl/dreamlink.cpp
@@ -205,6 +205,25 @@ void DreamLinkGamepad::resetMappingToDefault(bool arcade, bool gamepad) {
 		dreamlink->setDefaultMapping(input_mapper);
 	}
 }
+const char *DreamLinkGamepad::get_button_name(u32 code) {
+	if (dreamlink) {
+		const char* name = dreamlink->getButtonName(code);
+		if (name) {
+			return name;
+		}
+	}
+	return SDLGamepad::get_button_name(code);
+}
+
+const char *DreamLinkGamepad::get_axis_name(u32 code) {
+	if (dreamlink) {
+		const char* name = dreamlink->getAxisName(code);
+		if (name) {
+			return name;
+		}
+	}
+	return SDLGamepad::get_axis_name(code);
+}
 
 std::shared_ptr<InputMapping> DreamLinkGamepad::getDefaultMapping() {
 	std::shared_ptr<InputMapping> mapping = SDLGamepad::getDefaultMapping();
@@ -242,6 +261,12 @@ bool DreamLinkGamepad::gamepad_axis_input(u32 code, int value) {
 }
 void DreamLinkGamepad::resetMappingToDefault(bool arcade, bool gamepad) {
 	SDLGamepad::resetMappingToDefault(arcade, gamepad);
+}
+const char *DreamLinkGamepad::get_button_name(u32 code) {
+	return SDLGamepad::get_button_name(code);
+}
+const char *DreamLinkGamepad::get_axis_name(u32 code) {
+	return SDLGamepad::get_axis_name(code);
 }
 std::shared_ptr<InputMapping> DreamLinkGamepad::getDefaultMapping() {
 	return SDLGamepad::getDefaultMapping();

--- a/core/sdl/dreamlink.h
+++ b/core/sdl/dreamlink.h
@@ -100,6 +100,22 @@ public:
 	virtual void setDefaultMapping(const std::shared_ptr<InputMapping>& mapping) const {
 	}
 
+	//! Allows button names to be defined by a DreamLink device
+	//! @param[in] code The button code to retrieve name of
+	//! @return the button name for the given code to override what is defined by the gamepad
+	//! @return nullptr to fall back to gamepad definitions
+	virtual const char *getButtonName(u32 code) const {
+		return nullptr;
+	}
+
+	//! Allows axis names to be defined by a DreamLink device
+	//! @param[in] code The axis code to retrieve name of
+	//! @return the axis name for the given code to override what is defined by the gamepad
+	//! @return nullptr to fall back to gamepad definitions
+	virtual const char *getAxisName(u32 code) const {
+		return nullptr;
+	}
+
 	//! @return a unique ID for this DreamLink device or empty string to use default
 	virtual std::string getUniqueId() const {
 		return std::string();
@@ -133,6 +149,8 @@ public:
 	bool gamepad_axis_input(u32 code, int value) override;
 	static bool isDreamcastController(int deviceIndex);
 	void resetMappingToDefault(bool arcade, bool gamepad) override;
+	const char *get_button_name(u32 code) override;
+	const char *get_axis_name(u32 code) override;
 
 protected:
 	std::shared_ptr<InputMapping> getDefaultMapping() override;

--- a/core/sdl/dreampicoport.cpp
+++ b/core/sdl/dreampicoport.cpp
@@ -726,6 +726,10 @@ void DreamPicoPort::setDefaultMapping(const std::shared_ptr<InputMapping>& mappi
 	mapping->set_button(DC_BTN_C, 2);
 	mapping->set_button(DC_BTN_Z, 5);
 	mapping->set_button(DC_BTN_D, 10);
+	mapping->set_button(DC_DPAD2_UP, 9);
+	mapping->set_button(DC_DPAD2_DOWN, 8);
+	mapping->set_button(DC_DPAD2_LEFT, 7);
+	mapping->set_button(DC_DPAD2_RIGHT, 6);
 }
 
 std::string DreamPicoPort::getUniqueId() const {

--- a/core/sdl/dreampicoport.cpp
+++ b/core/sdl/dreampicoport.cpp
@@ -732,6 +732,29 @@ void DreamPicoPort::setDefaultMapping(const std::shared_ptr<InputMapping>& mappi
 	mapping->set_button(DC_DPAD2_RIGHT, 6);
 }
 
+const char *DreamPicoPort::getButtonName(u32 code) const {
+	switch (code) {
+		// Coincides with buttons setup in setDefaultMapping
+		case 2: return "C";
+		case 5: return "Z";
+		case 10: return "D";
+		case 9: return "DPad2 Up";
+		case 8: return "DPad2 Down";
+		case 7: return "DPad2 Left";
+		case 6: return "DPad2 Right";
+
+		// These buttons are normally not physically accessible, but are mapped on DreamPicoPort
+		case 12: return "VMU1 A";
+		case 15: return "VMU1 B";
+		case 16: return "VMU1 Up";
+		case 17: return "VMU1 Down";
+		case 18: return "VMU1 Left";
+		case 19: return "VMU1 Right";
+
+		default: return nullptr; // no override
+	}
+}
+
 std::string DreamPicoPort::getUniqueId() const {
 	return unique_id;
 }

--- a/core/sdl/dreampicoport.h
+++ b/core/sdl/dreampicoport.h
@@ -89,6 +89,8 @@ public:
 
 	void setDefaultMapping(const std::shared_ptr<InputMapping>& mapping) const override;
 
+	const char *getButtonName(u32 code) const override;
+
 	std::string getUniqueId() const override;
 
 	void changeBus(int newBus);

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -270,9 +270,9 @@ void input_sdl_init()
 	// Linux mappings are OK by default
 	// Can be removed once mapping is merged into SDL, see https://github.com/libsdl-org/SDL/pull/12039
 #if (defined(__APPLE__) && defined(TARGET_OS_MAC))
-	SDL_GameControllerAddMapping("0300000009120000072f000000010000,OrangeFox86 DreamPicoPort,a:b0,b:b1,x:b3,y:b4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,dpdown:h0.4,leftx:a0,lefty:a1,lefttrigger:a2,righttrigger:a5,start:b11");
+	SDL_GameControllerAddMapping("0300000009120000072f000000010000,OrangeFox86 DreamPicoPort,a:b0,b:b1,x:b3,y:b4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,dpdown:h0.4,leftx:a0,lefty:a1,lefttrigger:a2,rightx:a3,righty:a4,righttrigger:a5,start:b11");
 #elif defined(_WIN32)
-	SDL_GameControllerAddMapping("0300000009120000072f000000000000,OrangeFox86 DreamPicoPort,a:b0,b:b1,x:b3,y:b4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,dpdown:h0.4,leftx:a0,lefty:a1,lefttrigger:-a2,righttrigger:-a5,start:b11");
+	SDL_GameControllerAddMapping("0300000009120000072f000000000000,OrangeFox86 DreamPicoPort,a:b0,b:b1,x:b3,y:b4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,dpdown:h0.4,leftx:a0,lefty:a1,lefttrigger:-a2,rightx:a3,righty:a4,righttrigger:-a5,start:b11");
 #endif
 }
 


### PR DESCRIPTION
- Added rightx and righty for maracas
- Added secondary D-Pad mapping
- Allow DreamLink device to dictate button/axis naming; set naming for known DreamPicoPort button codes not mapped in SDL
(going into dev because master doesn't currently have the automatic C, D, Z mapping that is also needed for maracas)