### PR TITLE
cmake: disable link option --execute-only on openbsd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,10 @@ if(NINTENDO_SWITCH)
 	target_include_directories(${PROJECT_NAME} PRIVATE shell/switch)
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+	target_link_options(${PROJECT_NAME} PRIVATE "-Wl,--no-execute-only")
+endif()
+
 if(USE_BREAKPAD AND NOT LIBRETRO)
 	find_program(SH_EXECUTABLE sh)
 	if((ANDROID AND NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows") OR (MINGW AND SH_EXECUTABLE) OR (CMAKE_SYSTEM_NAME STREQUAL "Linux"))


### PR DESCRIPTION
`--execute-only` is enabled by default on openbsd.

This PR fixes the following error on openbsd/arm64:
```
ld: error: cannot place CMakeFiles/flycast.dir/core/hw/aica/dsp_arm64.cpp.o:(.text) into .text: --execute-only does not support intermingling data and code
```
https://github.com/scribam/flycast/actions/runs/15235573297/job/42848889115#step:4:1443