### PR TITLE
fix: added missing addrspace inclusion in settings.cpp for GDB_SERVER

### DIFF
--- a/core/ui/settings.cpp
+++ b/core/ui/settings.cpp
@@ -24,6 +24,10 @@
 #include "hw/maple/maple_if.h"
 #include "imgui_stdlib.h"
 
+#ifdef GDB_SERVER
+#include "hw/mem/addrspace.h"
+#endif
+
 static void gui_settings_advanced()
 {
 #if FEAT_SHREC != DYNAREC_NONE


### PR DESCRIPTION
I tried to compile with GDB support but it gave an error in settings.cpp, just a small fix.
Sorry my english.

![image](https://github.com/user-attachments/assets/fa10f999-7caf-4c7b-aee6-29cbe87c2ee8)
