### PR TITLE
input: set InputMapping::INVALID_CODE as constexpr

### DIFF
--- a/core/input/mapping.h
+++ b/core/input/mapping.h
@@ -47,7 +47,7 @@ public:
 		};
 
 		//! Initialized and invalid value for code
-		static const u32 INVALID_CODE = std::numeric_limits<u32>::max();
+		static constexpr u32 INVALID_CODE = std::numeric_limits<u32>::max();
 
 		//! The unique code for the set type
 		u32 code = INVALID_CODE;


### PR DESCRIPTION
Otherwise, gcc will fail to link when build type is "Debug"
```
/usr/bin/ld: CMakeFiles/flycast.dir/core/input/mapping.cpp.o: warning: relocation against `_ZN12InputMapping8InputDef12INVALID_CODEE' in read-only section `.text'
/usr/bin/ld: CMakeFiles/flycast.dir/core/input/mapping.cpp.o: in function `InputMapping::get_axis_code(unsigned int, DreamcastKey)':
/home/scribam/CLionProjects/flycast/core/input/mapping.cpp:617:(.text+0x2e84): undefined reference to `InputMapping::InputDef::INVALID_CODE'
/usr/bin/ld: /home/scribam/CLionProjects/flycast/core/input/mapping.cpp:626:(.text+0x2f30): undefined reference to `InputMapping::InputDef::INVALID_CODE'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```