### PR TITLE
DreamConn: do not lock mutex multiple times

### DIFF
--- a/core/sdl/dreamconn.cpp
+++ b/core/sdl/dreamconn.cpp
@@ -82,7 +82,10 @@ DreamConn::~DreamConn() {
 
 bool DreamConn::send(const MapleMsg& msg) {
 	std::lock_guard<std::mutex> lock(send_mutex); // Ensure thread safety for send operations
+	return send_no_lock(msg);
+}
 
+bool DreamConn::send_no_lock(const MapleMsg& msg) {
 	asio::error_code ec;
 
 	if (maple_io_connected)
@@ -101,7 +104,7 @@ bool DreamConn::send(const MapleMsg& msg) {
 bool DreamConn::send(const MapleMsg& txMsg, MapleMsg& rxMsg) {
 	std::lock_guard<std::mutex> lock(send_mutex); // Ensure thread safety for send operations
 
-	if (!send(txMsg)) {
+	if (!send_no_lock(txMsg)) {
 		return false;
 	}
 	return receiveMsg(rxMsg, iostream);

--- a/core/sdl/dreamconn.h
+++ b/core/sdl/dreamconn.h
@@ -48,6 +48,10 @@ public:
 
     bool send(const MapleMsg& txMsg, MapleMsg& rxMsg) override;
 
+private:
+	bool send_no_lock(const MapleMsg& msg);
+
+public:
 	int getBus() const override {
 		return bus;
 	}


### PR DESCRIPTION
Extracted from #1989 

This fixes a bug where send operations which expect a response would crash Flycast, because it would lock the non-reentrant mutex once in `send(txMsg, rxMsg)`, then call `send(msg)` which locks the mutex again.

So, for example, VMU graphics/buzzer stuff would work, since no response is expected, but as soon as the game tried to read VMU save data, the emulator would crash.
 