### PR TITLE
Expose MAX_LOGLEVEL to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(SENTRY_UPLOAD_URL "" CACHE STRING "Sentry upload URL")
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/shell/cmake")
 
-# See available log levels under enum LOG_LEVELS in core\log\Log.h
+# See available log levels under enum LOG_LEVELS in core/log/Log.h
 if(DEFINED MAX_LOGLEVEL)
 	add_compile_definitions("MAX_LOGLEVEL=${MAX_LOGLEVEL}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ set(SENTRY_UPLOAD_URL "" CACHE STRING "Sentry upload URL")
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/shell/cmake")
 
+# See available log levels under enum LOG_LEVELS in core\log\Log.h
+if(DEFINED MAX_LOGLEVEL)
+	add_compile_definitions("MAX_LOGLEVEL=${MAX_LOGLEVEL}")
+endif()
+
 if(APPLE)
 	if(CMAKE_SYSTEM_NAME STREQUAL iOS)
 		set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0" CACHE STRING "Minimum iOS deployment version")

--- a/core/log/Log.h
+++ b/core/log/Log.h
@@ -56,13 +56,15 @@ __attribute__((format(printf, 5, 6)))
 #endif
 ;
 
+#ifndef MAX_LOGLEVEL
+
 #if !defined(NDEBUG) || defined(DEBUGFAST)
 #define MAX_LOGLEVEL LogTypes::LOG_LEVELS::LDEBUG
 #else
-#ifndef MAX_LOGLEVEL
 #define MAX_LOGLEVEL LogTypes::LOG_LEVELS::LWARNING
-#endif  // loglevel
-#endif  // logging
+#endif  // #if !defined(NDEBUG) || defined(DEBUGFAST)
+
+#endif  // #ifndef MAX_LOGLEVEL
 
 // Let the compiler optimize this out
 #define GENERIC_LOG(t, v, ...)                                                                     \


### PR DESCRIPTION
Allow `MAX_LOGLEVEL` to optionally be defined externally and pass `MAX_LOGLEVEL` from cmake variable to compiler definition.

This change helps me run in debug mode as I often want to keep logging at warning while debugging since flycast runs way too slow with debug log level enabled. The default compile behavior is as it was previously.