### PR TITLE
Recover DreamLink hardware after load state

### DIFF
--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -2500,7 +2500,7 @@ struct DreamLinkPurupuru : public maple_sega_purupuru
 static std::list<std::shared_ptr<DreamLinkVmu>> dreamLinkVmus[2];
 static std::list<std::shared_ptr<DreamLinkPurupuru>> dreamLinkPurupurus;
 
-void createDreamLinkDevices(std::shared_ptr<DreamLink> dreamlink, bool gameStart)
+void createDreamLinkDevices(std::shared_ptr<DreamLink> dreamlink, bool gameStart, bool stateLoaded)
 {
 	const int bus = dreamlink->getBus();
 
@@ -2522,7 +2522,7 @@ void createDreamLinkDevices(std::shared_ptr<DreamLink> dreamlink, bool gameStart
 				}
 			}
 
-			if (gameStart || !vmuFound)
+			if (gameStart || stateLoaded || !vmuFound)
 			{
 				if (!vmu)
 				{
@@ -2530,6 +2530,13 @@ void createDreamLinkDevices(std::shared_ptr<DreamLink> dreamlink, bool gameStart
 				}
 
 				vmu->Setup(bus, i);
+
+				if (stateLoaded && vmu->useRealVmuMemory)
+				{
+					// Disconnect from real VMU memory when a state is loaded
+					vmu->useRealVmuMemory = false;
+					os_notify("WARNING: Disconnected from physical VMU memory due to load state", 6000);
+				}
 
 				if (!vmuFound && dev && dev->get_device_type() == MDT_SegaVMU && !vmu->useRealVmuMemory) {
 					// Only copy data from virtual VMU if Physical VMU Only is disabled

--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -2153,9 +2153,6 @@ struct DreamLinkVmu : public maple_sega_vmu
 
 	void OnSetup() override
 	{
-		// Update useRealVmuMemory in case config changed
-		useRealVmuMemory = config::UsePhysicalVmuMemory;
-
 		// All data must be re-read
 		memset(mirroredBlocks, 0, sizeof(mirroredBlocks));
 
@@ -2529,14 +2526,22 @@ void createDreamLinkDevices(std::shared_ptr<DreamLink> dreamlink, bool gameStart
 					vmu = std::make_shared<DreamLinkVmu>(dreamlink);
 				}
 
-				vmu->Setup(bus, i);
-
-				if (stateLoaded && vmu->useRealVmuMemory)
+				if (gameStart)
 				{
-					// Disconnect from real VMU memory when a state is loaded
-					vmu->useRealVmuMemory = false;
-					os_notify("WARNING: Disconnected from physical VMU memory due to load state", 6000);
+					// Update useRealVmuMemory in case config changed
+					vmu->useRealVmuMemory = config::UsePhysicalVmuMemory;
 				}
+				else if (stateLoaded)
+				{
+					if (vmu->useRealVmuMemory)
+					{
+						// Disconnect from real VMU memory when a state is loaded
+						vmu->useRealVmuMemory = false;
+						os_notify("WARNING: Disconnected from physical VMU memory due to load state", 6000);
+					}
+				}
+
+				vmu->Setup(bus, i);
 
 				if (!vmuFound && dev && dev->get_device_type() == MDT_SegaVMU && !vmu->useRealVmuMemory) {
 					// Only copy data from virtual VMU if Physical VMU Only is disabled

--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -2570,12 +2570,13 @@ void createDreamLinkDevices(std::shared_ptr<DreamLink> dreamlink, bool gameStart
 				}
 			}
 
-			if (gameStart || !rumbleFound)
+			if (gameStart || stateLoaded || !rumbleFound)
 			{
 				if (!rumble)
 				{
 					rumble = std::make_shared<DreamLinkPurupuru>(dreamlink);
 				}
+
 				rumble->Setup(bus, i);
 
 				if (!rumbleFound) dreamLinkPurupurus.push_back(rumble);

--- a/core/sdl/dreamlink.cpp
+++ b/core/sdl/dreamlink.cpp
@@ -46,7 +46,7 @@
 #include <setupapi.h>
 #endif
 
-void createDreamLinkDevices(std::shared_ptr<DreamLink> dreamlink, bool gameStart);
+void createDreamLinkDevices(std::shared_ptr<DreamLink> dreamlink, bool gameStart, bool stateLoaded);
 void tearDownDreamLinkDevices(std::shared_ptr<DreamLink> dreamlink);
 
 bool DreamLinkGamepad::isDreamcastController(int deviceIndex)
@@ -146,21 +146,22 @@ void DreamLinkGamepad::registered()
 		dreamlink->connect();
 
 		// Create DreamLink Maple Devices here just in case game is already running
-		createDreamLinkDevices(dreamlink, false);
+		createDreamLinkDevices(dreamlink, false, false);
 	}
 }
 
 void DreamLinkGamepad::handleEvent(Event event, void *arg)
 {
 	DreamLinkGamepad *gamepad = static_cast<DreamLinkGamepad*>(arg);
-	if (gamepad->dreamlink != nullptr && event != Event::Terminate) {
-		createDreamLinkDevices(gamepad->dreamlink, event == Event::Start);
+	if (gamepad->dreamlink != nullptr)
+	{
+		if (event != Event::Terminate) {
+			createDreamLinkDevices(gamepad->dreamlink, event == Event::Start, event == Event::LoadState);
+		}
+		else {
+			gamepad->dreamlink->gameTermination();
+		}
 	}
-
-    if (gamepad->dreamlink != nullptr && event == Event::Terminate)
-    {
-		gamepad->dreamlink->gameTermination();
-    }
 }
 
 void DreamLinkGamepad::resetMappingToDefault(bool arcade, bool gamepad) {

--- a/core/sdl/dreamlink.h
+++ b/core/sdl/dreamlink.h
@@ -24,8 +24,6 @@
 #define USE_DREAMCASTCONTROLLER 1
 #endif
 
-#ifdef USE_DREAMCASTCONTROLLER
-
 #include "types.h"
 #include "emulator.h"
 #include "sdl_gamepad.h"
@@ -165,5 +163,3 @@ private:
 	bool startPressed = false;
 	std::string device_guid;
 };
-
-#endif

--- a/core/sdl/dreamlink.h
+++ b/core/sdl/dreamlink.h
@@ -20,6 +20,12 @@
 
 // This file contains abstraction layer for access to different kinds of physical controllers
 
+#if (defined(_WIN32) || defined(__linux__) || (defined(__APPLE__) && defined(TARGET_OS_MAC))) && !defined(TARGET_UWP)
+#define USE_DREAMCASTCONTROLLER 1
+#endif
+
+#ifdef USE_DREAMCASTCONTROLLER
+
 #include "types.h"
 #include "emulator.h"
 #include "sdl_gamepad.h"
@@ -27,10 +33,6 @@
 #include <functional>
 #include <memory>
 #include <array>
-
-#if (defined(_WIN32) || defined(__linux__) || (defined(__APPLE__) && defined(TARGET_OS_MAC))) && !defined(TARGET_UWP)
-#define USE_DREAMCASTCONTROLLER 1
-#endif
 
 #include <memory>
 
@@ -163,3 +165,5 @@ private:
 	bool startPressed = false;
 	std::string device_guid;
 };
+
+#endif

--- a/core/sdl/dreamlink.h
+++ b/core/sdl/dreamlink.h
@@ -20,10 +20,6 @@
 
 // This file contains abstraction layer for access to different kinds of physical controllers
 
-#if (defined(_WIN32) || defined(__linux__) || (defined(__APPLE__) && defined(TARGET_OS_MAC))) && !defined(TARGET_UWP)
-#define USE_DREAMCASTCONTROLLER 1
-#endif
-
 #include "types.h"
 #include "emulator.h"
 #include "sdl_gamepad.h"
@@ -31,6 +27,10 @@
 #include <functional>
 #include <memory>
 #include <array>
+
+#if (defined(_WIN32) || defined(__linux__) || (defined(__APPLE__) && defined(TARGET_OS_MAC))) && !defined(TARGET_UWP)
+#define USE_DREAMCASTCONTROLLER 1
+#endif
 
 #include <memory>
 

--- a/core/ui/settings_controls.cpp
+++ b/core/ui/settings_controls.cpp
@@ -938,7 +938,7 @@ void gui_settings_controls(bool& maple_devices_changed)
 		DisabledScope scope(game_started);
 		OptionCheckbox("Use Physical VMU Memory", config::UsePhysicalVmuMemory,
 			"Enables direct read/write access to physical VMU memory via DreamPicoPort/DreamConn. "
-			"This is not compatible with load state.");
+			"This is not compatible with load state events.");
 	}
 #endif
 

--- a/core/ui/settings_controls.cpp
+++ b/core/ui/settings_controls.cpp
@@ -22,6 +22,7 @@
 #include "hw/maple/maple_devs.h"
 #include "vgamepad.h"
 #include "oslib/storage.h"
+#include "sdl/dreamlink.h" // For USE_DREAMCASTCONTROLLER
 
 static float calcComboWidth(const char *biggestLabel) {
 	return ImGui::CalcTextSize(biggestLabel).x + ImGui::GetStyle().FramePadding.x * 2.0f + ImGui::GetFrameHeight();

--- a/core/ui/settings_controls.cpp
+++ b/core/ui/settings_controls.cpp
@@ -22,7 +22,10 @@
 #include "hw/maple/maple_devs.h"
 #include "vgamepad.h"
 #include "oslib/storage.h"
+
+#if defined(USE_SDL)
 #include "sdl/dreamlink.h" // For USE_DREAMCASTCONTROLLER
+#endif
 
 static float calcComboWidth(const char *biggestLabel) {
 	return ImGui::CalcTextSize(biggestLabel).x + ImGui::GetStyle().FramePadding.x * 2.0f + ImGui::GetFrameHeight();

--- a/core/ui/settings_controls.cpp
+++ b/core/ui/settings_controls.cpp
@@ -937,7 +937,8 @@ void gui_settings_controls(bool& maple_devices_changed)
 	{
 		DisabledScope scope(game_started);
 		OptionCheckbox("Use Physical VMU Memory", config::UsePhysicalVmuMemory,
-			"Enables direct read/write access to physical VMU memory via DreamPicoPort/DreamConn.");
+			"Enables direct read/write access to physical VMU memory via DreamPicoPort/DreamConn. "
+			"This is not compatible with load state.");
 	}
 #endif
 


### PR DESCRIPTION
After load state, a DreamLink device would no longer communicate with hardware. This is because the hardware device would not be setup unless there was a game-start event or DreamLink peripheral was never created. Neither of these are the case after load-state, and the previously installed peripheral was removed after load-state. 

Additionally, this exposed an issue that using physical memory should not be maintained after load state. That link will now be detached after load-state. This is not a perfect solution, but at least this is documented.

Also the "Use Physical VMU Memory" checkbox was no longer being displayed, and this will re-enable that.