### PR TITLE
Make 18 Wheeler button config the same as the arcade.

### DIFF
--- a/core/hw/naomi/naomi_roms_input.h
+++ b/core/hw/naomi/naomi_roms_input.h
@@ -100,7 +100,8 @@ static InputDescriptors _18wheelr_inputs = {
 	  {
 			{ NAOMI_BTN0_KEY, "HORN" },
 			{ NAOMI_DOWN_KEY, "VIEW" },
-			{ NAOMI_BTN1_KEY, "SHIFT L/H" },
+			{ NAOMI_BTN1_KEY, "SHIFT L" },
+			{ NAOMI_BTN3_KEY, "SHIFT H" },
 			{ NAOMI_BTN2_KEY, "SHIFT R" },
 			NAO_START_DESC
 			NAO_BASE_BTN_DESC


### PR DESCRIPTION
18 Wheeler in the arcade has 3 shifter positions: Low, High, and Reverse.

In the current flycast implementation there are only 2. 