### PR TITLE
Remove `-DCMAKE_BUILD_TYPE=Release` from `.gitlab-ci.yml`.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,38 +9,38 @@
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
     CORENAME: flycast
-    CORE_ARGS: -DLIBRETRO=ON -DUSE_LIBCDIO=ON -DCMAKE_BUILD_TYPE=Release
+    CORE_ARGS: -DLIBRETRO=ON -DUSE_LIBCDIO=ON
 
 .core-defs-linux:
   extends: .core-defs
   variables:
-    CORE_ARGS: -DLIBRETRO=ON -DUSE_LIBCDIO=ON -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DCMAKE_BUILD_TYPE=Release
+    CORE_ARGS: -DLIBRETRO=ON -DUSE_LIBCDIO=ON -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE
     CC: /usr/bin/gcc-12
     CXX: /usr/bin/g++-12
 
 .core-defs-osx-x64:
   extends: .core-defs
   variables:
-    CORE_ARGS: -DLIBRETRO=ON -G Xcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=x86_64
+    CORE_ARGS: -DLIBRETRO=ON -G Xcode -DCMAKE_OSX_ARCHITECTURES=x86_64
     EXTRA_PATH: Release
 
 .core-defs-osx-arm64:
   extends: .core-defs
   variables:
-    CORE_ARGS: -DLIBRETRO=ON -G Xcode -DCMAKE_BUILD_TYPE=Release
+    CORE_ARGS: -DLIBRETRO=ON -G Xcode
     EXTRA_PATH: Release
 
 .core-defs-ios-arm64:
   extends: .core-defs
   variables:
-    CORE_ARGS: -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0
+    CORE_ARGS: -DLIBRETRO=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0
     IOS_MINVER: 13.0
     MINVER: 13.0
 
 .core-defs-android:
   extends: .core-defs
   script:
-    - cmake -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release -DANDROID_PLATFORM=android-$API_LEVEL -DCMAKE_TOOLCHAIN_FILE=$NDK_ROOT/build/cmake/android.toolchain.cmake -DANDROID_STL=c++_static -DANDROID_ABI=$ANDROID_ABI -DANDROID_ARM_MODE=arm "$CMAKE_SOURCE_ROOT" -B$BUILD_DIR
+    - cmake -DLIBRETRO=ON -DANDROID_PLATFORM=android-$API_LEVEL -DCMAKE_TOOLCHAIN_FILE=$NDK_ROOT/build/cmake/android.toolchain.cmake -DANDROID_STL=c++_static -DANDROID_ABI=$ANDROID_ABI -DANDROID_ARM_MODE=arm "$CMAKE_SOURCE_ROOT" -B$BUILD_DIR
     - cmake --build $BUILD_DIR --target ${CORENAME}_libretro --config Release -- -j $NUMPROC
     - mv $BUILD_DIR/${CORENAME}_libretro.so $LIBNAME
     - if [ $STRIP_CORE_LIB -eq 1 ]; then $NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip $LIBNAME; fi
@@ -177,3 +177,4 @@ libretro-build-tvos-arm64:
   extends:
     - .libretro-tvos-cmake-arm64
     - .core-defs-ios-arm64
+


### PR DESCRIPTION
There is no longer a need to set this explicitly, as [libretro's CI templates have been corrected](https://git.libretro.com/libretro-infrastructure/ci-templates/-/commit/0241726e188a7c077dcff6cd7c1739039a79a7fb) to not leave it undefined.