### PR TITLE
cmake: lower minimum requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
-cmake_minimum_required(VERSION 3.25...4.0)
+if(APPLE AND NOT LIBRETRO)
+	# Requirement from SDL
+	# Minimum version for $<LINK_LIBRARY:feature,library-list>
+	cmake_minimum_required(VERSION 3.24)
+else()
+	cmake_minimum_required(VERSION 3.22.1)
+endif()
 
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)

--- a/shell/android-studio/flycast/build.gradle
+++ b/shell/android-studio/flycast/build.gradle
@@ -72,7 +72,7 @@ android {
     externalNativeBuild {
         cmake {
             path file('../../../CMakeLists.txt')
-            version '3.28.3'
+            version '3.22.1'
         }
     }
     packagingOptions {


### PR DESCRIPTION
- On Apple with SDL, `cmake_minimum_required(VERSION 3.24)` is defined here: https://github.com/libsdl-org/SDL/blob/5d249570393f7a37e037abf22cd6012a4cc56a71/CMakeLists.txt#L2308
- For other systems, using `3.22.1` will fix the libretro build, restore the previous cmake version used on Android and looks safe enough