### PR TITLE
Fix: DreamPicoPort locks up and causes flycast to hang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -460,7 +460,7 @@ if(NOT LIBRETRO)
 			target_compile_definitions(${PROJECT_NAME} PRIVATE USE_DREAMLINK_DEVICES=1)
 			set(USE_DREAMLINK_DEVICES ON) # Must be set before adding core/sdl
 
-			if ((WIN32 OR WINDOWS_STORE) AND NOT MINGW)
+			if (WINDOWS_STORE)
 				# Use winrt implementation of the DreamPicoPort-API
 				option(DREAMPICOPORT_WITH_LIBUSB "Use libusb to access DreamPicoPort-API" OFF)
 			elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")

--- a/core/sdl/dreampicoport.cpp
+++ b/core/sdl/dreampicoport.cpp
@@ -974,23 +974,6 @@ public:
 
 		std::vector<std::vector<std::array<uint32_t, 2>>> peripherals;
 
-		MapleMsg msg;
-		msg.command = MDCF_GetCondition;
-		msg.destAP = (hardware_bus << 6) | 0x20;
-		msg.originAP = hardware_bus << 6;
-		msg.setData(MFID_0_Input);
-
-		bool success = send(msg, msg, timeout_ms);
-		if (!success) {
-			WARN_LOG(
-				INPUT,
-				"DreamPicoPort[%d] send(condition) failed (%s)",
-				software_bus,
-				dpp_api_device->getLastErrorStr().c_str()
-			);
-			return peripherals; // assume simply controller not connected yet
-		}
-
 		dpp_api::msg::rx::GetDcSummary summary =
 			dpp_api_device->sendSync(dpp_api::msg::tx::GetDcSummary{static_cast<uint8_t>(hardware_bus)});
 		peripherals = summary.summary;


### PR DESCRIPTION
Bug fixes related to [this bug](https://github.com/OrangeFox86/DreamPicoPort/issues/190):
- Updated DreamPicoPort-API which attempts to use `AutoClearStall` on endpoints when WinRT is used
- Use libusb for DreamPicoPort-API on Win32 when not UWP (WinRT seems to be buggy, and the above only helps in some cases)
    - I will want to revisit this in the future, but this seems to be the best way to make a quick fix after I spent several hours trying to make workarounds for WinRT - UWP isn't used much anyway (as far as I know)
- Removed the initial get-condition command for DreamPicoPort as this seems to fail every so often, and it isn't needed anyway

This fix pairs with [this MR on DreamPicoPort](https://github.com/OrangeFox86/DreamPicoPort/pull/194).