### PR TITLE
ci: libretro android build fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@
     - mv $BUILD_DIR/${CORENAME}_libretro.so $LIBNAME
     - if [ $STRIP_CORE_LIB -eq 1 ]; then $NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip $LIBNAME; fi
   variables:
-    API_LEVEL: 18
+    API_LEVEL: 21
 
 # Inclusion templates, required for the build to work
 include:

--- a/core/oslib/i18n.h
+++ b/core/oslib/i18n.h
@@ -17,7 +17,7 @@
     along with Flycast.  If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
-#ifdef __ANDROID__
+#if defined(__ANDROID__) && !defined(LIBRETRO)
 #include "android_locale.h"
 #endif
 #include <string>


### PR DESCRIPTION
- Attempt to fix failing libretro CI: https://git.libretro.com/libretro/flycast-upstream/-/jobs/653789
- Sync the API level for consistency with:
https://github.com/flyinghead/flycast/blob/37a9077304908196193b20d5f314dd86fe0578e1/shell/android-studio/flycast/build.gradle#L26