### PR TITLE
Minor bug fixes for DreamPicoPort

### DIFF
--- a/core/sdl/dreamconn.cpp
+++ b/core/sdl/dreamconn.cpp
@@ -131,7 +131,7 @@ public:
 	}
 
     u32 getFunctionCode(int forPort) const override {
-		MapleDeviceType deviceType = expansionDevs.at(forPort - 1);
+		MapleDeviceType deviceType = expansionDevs.at(forPort);
 		if (deviceType == MDT_SegaVMU) {
 			return 0x0E000000;
 		}
@@ -142,7 +142,7 @@ public:
 	}
 
 	std::array<u32, 3> getFunctionDefinitions(int forPort) const override {
-		MapleDeviceType deviceType = expansionDevs.at(forPort - 1);
+		MapleDeviceType deviceType = expansionDevs.at(forPort);
 		if (deviceType == MDT_SegaVMU)
 			// For clock, LCD, storage
 			return std::array<u32, 3>{0x403f7e7e, 0x00100500, 0x00410f00};

--- a/core/sdl/dreamlink.h
+++ b/core/sdl/dreamlink.h
@@ -21,7 +21,7 @@
 #ifdef USE_DREAMLINK_DEVICES
 
 // This file contains abstraction layer for access to different kinds of remote peripherals.
-// This includes both real Dreamcast controllers, VMUs, rumble packs etc. but also emulated VMUs.
+// This includes both real Dreamcast controllers, VMUs, jump packs etc. but also emulated VMUs.
 
 #include "types.h"
 #include "emulator.h"
@@ -95,11 +95,11 @@ public:
 	//! When called, do teardown stuff like reset screen
 	virtual inline void gameTermination() {}
 
-    //! @param[in] forPort The port number to get the function code of (1 or 2)
+    //! @param[in] forPort The port number to get the function code of
     //! @return the device type for the given port
     virtual u32 getFunctionCode(int forPort) const = 0;
 
-    //! @param[in] forPort The port number to get the function definitions of (1 or 2)
+    //! @param[in] forPort The port number to get the function definitions of
 	//! @return the 3 function definitions for the supported function codes
     virtual std::array<u32, 3> getFunctionDefinitions(int forPort) const = 0;
 
@@ -154,7 +154,7 @@ public:
 
 	//! Disconnect from the hardware controller
 	virtual void disconnect() = 0;
-	
+
 	//! Sends the current game id to a DreamLink backed expansion device if supported
 	virtual void sendGameId(int expansion, const std::string& gameId) {}
 };

--- a/core/sdl/dreampicoport.cpp
+++ b/core/sdl/dreampicoport.cpp
@@ -1154,7 +1154,19 @@ public:
 		return software_bus;
 	}
 
+	//! Transform flycast port index into DreamPicoPort port index
+	static int fcPortToDppPort(int forPort) {
+		// Flycast uses port index 5 for main peripheral and 0 is the first sub-peripheral slot
+		// DreamPicoPort uses port index 0 for main peripheral and 1 is the first sub-peripheral slot
+		if (forPort >= 5) {
+			return 0;
+		} else {
+			return forPort + 1;
+		}
+	}
+
     u32 getFunctionCode(int forPort) const override {
+		forPort = fcPortToDppPort(forPort);
 		u32 mask = 0;
 		if ((int)peripherals.size() > forPort) {
 			for (const auto& peripheral : peripherals[forPort]) {
@@ -1166,6 +1178,7 @@ public:
 	}
 
 	std::array<u32, 3> getFunctionDefinitions(int forPort) const override {
+		forPort = fcPortToDppPort(forPort);
 		std::array<u32, 3> arr{0, 0, 0};
 		if ((int)peripherals.size() > forPort) {
 			std::size_t idx = 0;
@@ -1239,7 +1252,7 @@ public:
 	}
 
 	bool needsRefresh() override {
-		// TODO: implementing this method may also help to support hot plugging of VMUs/rumble packs here.
+		// TODO: implementing this method may also help to support hot plugging of VMUs/jump packs here.
 		return false;
 	}
 
@@ -1304,7 +1317,7 @@ public:
 		int vibrationCount = 0;
 
 		if (software_bus >= 0 && static_cast<std::size_t>(software_bus) < config::MapleExpansionDevices.size()) {
-			u32 portOneFn = getFunctionCode(1);
+			u32 portOneFn = getFunctionCode(0);
 			if (portOneFn & MFID_1_Storage) {
 				config::MapleExpansionDevices[software_bus][0] = MDT_SegaVMU;
 				++vmuCount;
@@ -1313,7 +1326,7 @@ public:
 				config::MapleExpansionDevices[software_bus][0] = MDT_None;
 			}
 
-			u32 portTwoFn = getFunctionCode(2);
+			u32 portTwoFn = getFunctionCode(1);
 			if (portTwoFn & MFID_8_Vibration) {
 				config::MapleExpansionDevices[software_bus][1] = MDT_PurupuruPack;
 				++vibrationCount;
@@ -1329,7 +1342,7 @@ public:
 
 		NOTICE_LOG(
 			INPUT,
-			"Connected to DreamPicoPort[%d]: Type:%s, VMU:%d, Rumble Pack:%d",
+			"Connected to DreamPicoPort[%d]: Type:%s, VMU:%d, Jump Pack:%d",
 			software_bus,
 			getName().c_str(),
 			vmuCount,


### PR DESCRIPTION
- @nexus382 was having trouble using memory & vibration pack - this needs to be treated as vibration when it is detected in the second slot
- DreamLink now indexes peripheral ports the same as the rest of flycast to reduce confusion
- Changed references of `rumble` to `jump` in logs/comments as this is Dreamcast terminology
- Updated to DreamPicoPort-API v1.0.3 which cleans up compiler warnings