### PR TITLE
Fix Load State cannot load Custom Texture

### DIFF
--- a/core/emulator.cpp
+++ b/core/emulator.cpp
@@ -887,7 +887,10 @@ void Emulator::stepRange(u32 from, u32 to)
 void Emulator::loadstate(Deserializer& deser)
 {
 	if (!custom_texture.preloaded())
+	{
 		custom_texture.terminate();
+		custom_texture.init();
+	}
 #if FEAT_AREC == DYNAREC_JIT
 	aica::arm::recompiler::flush();
 #endif
@@ -1109,6 +1112,7 @@ void Emulator::diskChange()
 {
 	config::Settings::instance().reset();
 	config::Settings::instance().load(false);
+	custom_texture.terminate();
 	if (!settings.content.path.empty())
 	{
 		hostfs::FileInfo info = hostfs::storage().getFileInfo(settings.content.path);
@@ -1124,7 +1128,6 @@ void Emulator::diskChange()
 	cheatManager.reset(settings.content.gameId);
 	if (cheatManager.isWidescreen())
 		config::ScreenStretching.override(134);	// 4:3 -> 16:9
-	custom_texture.terminate();
 	EventManager::event(Event::DiskChange);
 }
 

--- a/core/rend/TexCache.h
+++ b/core/rend/TexCache.h
@@ -262,8 +262,6 @@ public:
 
 	void Clear()
 	{
-		if (!custom_texture.preloaded())
-			custom_texture.terminate();
 		for (auto& [id, texture] : cache)
 			texture.Delete();
 


### PR DESCRIPTION
The cause:
We removed async `custom_texture.init()`, but `TexCache.Clear()` is called (which calls `custom_texture.terminate()`) when loading state / switching graphics API, but we don't have a point of init for the `custom_texture`

So:
- No longer terminate custom texture during `TexCache.Clear()`
- fix `diskChange()` custom texture terminate/init also