### PR TITLE
Add async maple device

### DIFF
--- a/core/hw/maple/maple_cfg.cpp
+++ b/core/hw/maple/maple_cfg.cpp
@@ -426,6 +426,9 @@ void mcfg_DestroyDevices(bool full)
 
 void mcfg_SerializeDevices(Serializer& ser)
 {
+	// This is needed to purge current hardware operations
+	maple_pre_serialize();
+
 	ser << maple_ddt_pending_reset;
 	ser << SDCKBOccupied;
 	ser << (u32)mapleDmaOut.size();

--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -1718,31 +1718,9 @@ struct RFIDReaderWriter : maple_base
 
 	// Surprisingly recipient and sender aren't swapped in the response so we override RawDma for this reason
 	// vf4tuned and mushiking do care
-	std::vector<u32> RawDma(u32* buffer_in, u32 buffer_in_len) override
+	u32 frame(u32 resp, u32 send, u32 reci, u32 size) override
 	{
-		u32 command=buffer_in[0] &0xFF;
-		//Recipient address
-		u32 reci = (buffer_in[0] >> 8) & 0xFF;
-		//Sender address
-		u32 send = (buffer_in[0] >> 16) & 0xFF;
-		u32 resp = Dma(command, &buffer_in[1], buffer_in_len - 4);
-
-		if (reci & 0x20)
-			reci |= maple_GetAttachedDevices(bus_id);
-
-		verify(u8(dma_buffer_out.size() / 4) * 4 == dma_buffer_out.size());
-		std::vector<u32> output;
-		output.reserve(1 + (dma_buffer_out.size() / 4));
-		output.push_back((resp << 0 ) | (reci << 8) | (send << 16) | ((dma_buffer_out.size() / 4) << 24));
-
-		for (std::size_t i = 0; i < dma_buffer_out.size(); i+=4)
-		{
-			output.push_back(*(u32*)&dma_buffer_out[i]);
-		}
-
-		dma_buffer_out.clear();
-
-		return output;
+		return ((resp << 0 ) | (reci << 8) | (send << 16) | ((size / 4) << 24));
 	}
 
 	u32 dma(u32 cmd) override

--- a/core/hw/maple/maple_if.cpp
+++ b/core/hw/maple/maple_if.cpp
@@ -440,18 +440,21 @@ static int maple_schd(int tag, int cycles, int jitter, void *arg)
 	if (maple_check_processing_cmd() >= 0)
 	{
 		const u64 now = sh4_sched_now64();
-		if (now >= processingCmdsTimeoutCycle)
-		{
-			// Timeout - Force blocking operation
-			maple_check_processing_cmd(true);
-		}
 
 		if (!processingCmds.empty())
 		{
-			// Still not done processing yet
-			// Delay for 5 ms before trying again
-			sh4_sched_request(maple_schid, sh4CyclesForXfer(5, 1000));
-			return 0;
+			if (now >= processingCmdsTimeoutCycle)
+			{
+				// Timeout - Force blocking operation then continue to processing below
+				maple_check_processing_cmd(true);
+			}
+			else
+			{
+				// Still not done processing yet
+				// Delay for 5 ms before trying again
+				sh4_sched_request(maple_schid, sh4CyclesForXfer(5, 1000));
+				return 0;
+			}
 		}
 		else
 		{

--- a/core/hw/maple/maple_if.cpp
+++ b/core/hw/maple/maple_if.cpp
@@ -235,10 +235,9 @@ static void maple_DoDma()
 					p_data = maple_in_buf;
 				}
 				inlen = (inlen + 1) * 4;
-				u32 outbuf[1024 / 4];
-				u32 outlen = MapleDevices[bus][port]->RawDma(&p_data[0], inlen, outbuf);
+				std::vector<u32> outbuf = MapleDevices[bus][port]->RawDma(&p_data[0], inlen);
 				xferIn += inlen + 3; // start, parity and stop bytes
-				xferOut += outlen + 3;
+				xferOut += (outbuf.size() * 4) + 3;
 #ifdef STRICT_MODE
 				if (!check_mdapro(header_2 + outlen - 1))
 				{
@@ -249,9 +248,9 @@ static void maple_DoDma()
 				}
 #endif
 				if (swap_msb)
-					for (u32 i = 0; i < outlen / 4; i++)
+					for (u32 i = 0; i < outbuf.size(); i++)
 						outbuf[i] = SWAP32(outbuf[i]);
-				mapleDmaOut.emplace_back(header_2, std::vector<u32>(outbuf, outbuf + outlen / 4));
+				mapleDmaOut.emplace_back(header_2, outbuf);
 			}
 			else
 			{

--- a/core/hw/maple/maple_if.cpp
+++ b/core/hw/maple/maple_if.cpp
@@ -235,7 +235,8 @@ static void maple_DoDma()
 					p_data = maple_in_buf;
 				}
 				inlen = (inlen + 1) * 4;
-				std::vector<u32> outbuf = MapleDevices[bus][port]->RawDma(&p_data[0], inlen);
+				std::future<std::vector<u32>> futureOut = MapleDevices[bus][port]->RawDma(&p_data[0], inlen);
+				std::vector<u32> outbuf = futureOut.get(); // TODO: block elsewhere
 				xferIn += inlen + 3; // start, parity and stop bytes
 				xferOut += (outbuf.size() * 4) + 3;
 #ifdef STRICT_MODE
@@ -250,7 +251,7 @@ static void maple_DoDma()
 				if (swap_msb)
 					for (u32 i = 0; i < outbuf.size(); i++)
 						outbuf[i] = SWAP32(outbuf[i]);
-				mapleDmaOut.emplace_back(header_2, outbuf);
+				mapleDmaOut.emplace_back(header_2, std::move(outbuf));
 			}
 			else
 			{

--- a/core/hw/maple/maple_if.cpp
+++ b/core/hw/maple/maple_if.cpp
@@ -466,8 +466,9 @@ static int maple_schd(int tag, int cycles, int jitter, void *arg)
 			else
 			{
 				// Still not done processing yet
-				// Delay for 5 ms before trying again
-				sh4_sched_request(maple_schid, sh4CyclesForXfer(5, 1000));
+				// Delay for up to 5 ms before trying again
+				const u32 delay = std::min(static_cast<u32>(processingCmdsTimeoutCycle - now), sh4CyclesForXfer(5, 1000));
+				sh4_sched_request(maple_schid, delay);
 				return 0;
 			}
 		}

--- a/core/hw/maple/maple_if.h
+++ b/core/hw/maple/maple_if.h
@@ -10,3 +10,4 @@ void maple_Term();
 void maple_ReconnectDevices();
 
 void maple_vblank();
+void maple_pre_serialize();

--- a/core/hw/maple/maple_jvs.cpp
+++ b/core/hw/maple/maple_jvs.cpp
@@ -1966,9 +1966,6 @@ std::future<std::vector<u32>> maple_naomi_jamma::RawDma(u32* buffer_in, u32 buff
 	std::vector<u32> output;
 	pack_payload(output);
 
-	dma_buffer_out.clear();
-	dma_buffer_out.shrink_to_fit();
-
 	return output_to_future(std::move(output));
 }
 

--- a/core/hw/maple/maple_jvs.cpp
+++ b/core/hw/maple/maple_jvs.cpp
@@ -260,7 +260,7 @@ protected:
 			y = mapleInputState[playerNum].absPos.y;
 		}
 	}
-	
+
 	virtual s16 readRotaryEncoders(int channel, s16 relX, s16 relY)
 	{
 		switch (channel)
@@ -1483,10 +1483,11 @@ bool maple_naomi_jamma::receive_jvs_messages(u32 channel)
 	else
 		w8(sense_line(jvs_receive_buffer[channel][0]));	// bit 0 is sense line level. If set during F1 <n>, more I/O boards need addressing
 
-	memcpy(dma_buffer_out, jvs_receive_buffer[channel], jvs_receive_length[channel]);
-	memset(dma_buffer_out + jvs_receive_length[channel], 0, dword_length * 4 - headerLength - jvs_receive_length[channel]);
-	dma_buffer_out += dword_length * 4 - headerLength;
-	*dma_count_out += dword_length * 4 - headerLength;
+	const std::size_t footerStart = dma_buffer_out.size();
+	const std::size_t footerSize = dword_length * 4 - headerLength;
+	dma_buffer_out.resize(dma_buffer_out.size() + footerSize);
+	memcpy(&dma_buffer_out[footerStart], jvs_receive_buffer[channel], jvs_receive_length[channel]);
+	memset(&dma_buffer_out[footerStart + jvs_receive_length[channel]], 0, footerSize - jvs_receive_length[channel]);
 	jvs_receive_length[channel] = 0;
 
 	return true;
@@ -1682,9 +1683,7 @@ void maple_naomi_jamma::handle_86_subcommand()
 			w8(0x00);
 			w8(0x20);
 			w8(0x01);
-			memcpy(dma_buffer_out, eeprom, 4);
-			dma_buffer_out += 4;
-			*dma_count_out += 4;
+			dma_buffer_out.insert(dma_buffer_out.end(), &eeprom[0], &eeprom[4]);
 		}
 		break;
 
@@ -1698,9 +1697,7 @@ void maple_naomi_jamma::handle_86_subcommand()
 			w8(0x20);
 			w8(0x20);
 			int size = sizeof(eeprom) - address;
-			memcpy(dma_buffer_out, eeprom + address, size);
-			dma_buffer_out += size;
-			*dma_count_out += size;
+			dma_buffer_out.insert(dma_buffer_out.end(), eeprom + address, eeprom + address + size);
 		}
 		break;
 
@@ -1798,7 +1795,7 @@ void maple_naomi_jamma::handle_86_subcommand()
 	}
 }
 
-u32 maple_naomi_jamma::RawDma(u32* buffer_in, u32 buffer_in_len, u32* buffer_out)
+std::vector<u32> maple_naomi_jamma::RawDma(u32* buffer_in, u32 buffer_in_len)
 {
 #ifdef DUMP_JVS
 	printf("JVS IN: ");
@@ -1807,9 +1804,7 @@ u32 maple_naomi_jamma::RawDma(u32* buffer_in, u32 buffer_in_len, u32* buffer_out
 	printf("\n");
 #endif
 
-	u32 out_len = 0;
-	dma_buffer_out = (u8 *)buffer_out;
-	dma_count_out = &out_len;
+	dma_buffer_out.clear();
 
 	dma_buffer_in = (u8 *)buffer_in + 4;
 	dma_count_in = buffer_in_len - 4;
@@ -1970,7 +1965,19 @@ u32 maple_naomi_jamma::RawDma(u32* buffer_in, u32 buffer_in_len, u32* buffer_out
 	printf("\n");
 #endif
 
-	return out_len;
+	verify(u8(dma_buffer_out.size() / 4) * 4 == dma_buffer_out.size());
+	std::vector<u32> output;
+	output.reserve(dma_buffer_out.size() / 4);
+
+	for (std::size_t i = 0; i < dma_buffer_out.size(); i+=4)
+	{
+		output.push_back(*(u32*)&dma_buffer_out[i]);
+	}
+
+	dma_buffer_out.clear();
+	dma_buffer_out.shrink_to_fit();
+
+	return output;
 }
 
 void maple_naomi_jamma::serialize(Serializer& ser) const

--- a/core/hw/maple/maple_jvs.cpp
+++ b/core/hw/maple/maple_jvs.cpp
@@ -1793,7 +1793,7 @@ void maple_naomi_jamma::handle_86_subcommand()
 	}
 }
 
-std::vector<u32> maple_naomi_jamma::RawDma(u32* buffer_in, u32 buffer_in_len)
+std::future<std::vector<u32>> maple_naomi_jamma::RawDma(u32* buffer_in, u32 buffer_in_len)
 {
 #ifdef DUMP_JVS
 	printf("JVS IN: ");
@@ -1969,7 +1969,7 @@ std::vector<u32> maple_naomi_jamma::RawDma(u32* buffer_in, u32 buffer_in_len)
 	dma_buffer_out.clear();
 	dma_buffer_out.shrink_to_fit();
 
-	return output;
+	return output_to_future(std::move(output));
 }
 
 void maple_naomi_jamma::serialize(Serializer& ser) const

--- a/core/hw/maple/maple_jvs.cpp
+++ b/core/hw/maple/maple_jvs.cpp
@@ -1483,11 +1483,9 @@ bool maple_naomi_jamma::receive_jvs_messages(u32 channel)
 	else
 		w8(sense_line(jvs_receive_buffer[channel][0]));	// bit 0 is sense line level. If set during F1 <n>, more I/O boards need addressing
 
-	const std::size_t footerStart = dma_buffer_out.size();
-	const std::size_t footerSize = dword_length * 4 - headerLength;
-	dma_buffer_out.resize(dma_buffer_out.size() + footerSize);
-	memcpy(&dma_buffer_out[footerStart], jvs_receive_buffer[channel], jvs_receive_length[channel]);
-	memset(&dma_buffer_out[footerStart + jvs_receive_length[channel]], 0, footerSize - jvs_receive_length[channel]);
+	wptr(jvs_receive_buffer[channel], jvs_receive_length[channel]);
+	wset(0, dword_length * 4 - headerLength - jvs_receive_length[channel]);
+
 	jvs_receive_length[channel] = 0;
 
 	return true;
@@ -1683,7 +1681,7 @@ void maple_naomi_jamma::handle_86_subcommand()
 			w8(0x00);
 			w8(0x20);
 			w8(0x01);
-			dma_buffer_out.insert(dma_buffer_out.end(), &eeprom[0], &eeprom[4]);
+			wptr(eeprom, 4);
 		}
 		break;
 
@@ -1697,7 +1695,7 @@ void maple_naomi_jamma::handle_86_subcommand()
 			w8(0x20);
 			w8(0x20);
 			int size = sizeof(eeprom) - address;
-			dma_buffer_out.insert(dma_buffer_out.end(), eeprom + address, eeprom + address + size);
+			wptr(eeprom + address, size);
 		}
 		break;
 
@@ -1965,14 +1963,8 @@ std::vector<u32> maple_naomi_jamma::RawDma(u32* buffer_in, u32 buffer_in_len)
 	printf("\n");
 #endif
 
-	verify(u8(dma_buffer_out.size() / 4) * 4 == dma_buffer_out.size());
 	std::vector<u32> output;
-	output.reserve(dma_buffer_out.size() / 4);
-
-	for (std::size_t i = 0; i < dma_buffer_out.size(); i+=4)
-	{
-		output.push_back(*(u32*)&dma_buffer_out[i]);
-	}
+	pack_payload(output);
 
 	dma_buffer_out.clear();
 	dma_buffer_out.shrink_to_fit();

--- a/core/sdl/dreamlink.h
+++ b/core/sdl/dreamlink.h
@@ -26,6 +26,7 @@
 #include "types.h"
 #include "emulator.h"
 #include "sdl_gamepad.h"
+#include "hw/maple/maple_devs.h"
 
 #include <functional>
 #include <memory>
@@ -66,7 +67,7 @@ class DreamLink : public std::enable_shared_from_this<DreamLink>
 {
 public:
 	//! Number of physical dreamcast ports
-	static constexpr const int NUM_PORTS = 4;
+	static constexpr const int NUM_PORTS = MAPLE_PORTS;
 	// The active DreamLink, if any, for each port.
 	// Note that multiple gamepad DreamLinks may exist for a given port, in which case only one is active.
 	static std::array<std::shared_ptr<DreamLink>, NUM_PORTS> activeDreamLinks;


### PR DESCRIPTION
The purpose of this PR is mainly to add `maple_async_base` for use in a future PR. This base class will allow for asynchronous maple command processing without blocking game emulation. Currently, the `std::future` is always immediately filled with data, so there is no difference in runtime operation other than the delivery delay is max of each bus delivery delay instead of the total.

I tested asynchronous delays by changing `maple_base::output_to_future` to:
```cpp
	std::future<std::vector<u32>> output_to_future(std::vector<u32>&& output)
	{
		return std::async(
			std::launch::async,
			[output]()
			{
				std::this_thread::sleep_for(std::chrono::milliseconds(15));
				return output;
			}
		);
	}
```

I tested this with delays of 0 ms up to 50 ms with different timeout values in `maple_if`. There is a hard block for data once that timeout is reached. If that timeout is too high, then data potentially gets lost. If that timeout is too low, then flycast may unnecessarily slow down.

Games start to miss inputs if the timeout and delay are set at or above 25 ms. It generally seemed like gameplay was just fine at a 20 ms timeout with 20 ms processing delay on all commands. I pulled that timeout down to 15 ms to get some headroom because I'd rather have a bit jittery gameplay than missed inputs, and this ensures delivery of data before 1x 60 Hz frame has completed as I know the controller is polled on each 60 Hz frame. 

Other notes:
- Delivery of the data must still delay at least as long as the computed transmission delay in `maple_if`
- Before serialization (save state) can take place, all data must be retrieved from std::future values. I added `maple_pre_serialize()` to ensure data is loaded into `mapleDmaOut` before serialization. This is called from `mcfg_SerializeDevices()`
- I did the same tests with lightgun to ensure SDCKB occupy mechanisms still work, even with delays up to the timeout value, and that seems to be ok