### PR TITLE
deps: prevent installing DreamPicoPort artifacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,7 +498,7 @@ if(NOT LIBRETRO)
 
 			# DreamPicoPort-API
 			option(DREAMPICOPORT_ADD_LIBUSB "Add internal libusb library" OFF) # Already included above, when applicable
-			add_subdirectory(core/deps/DreamPicoPort-API)
+			add_subdirectory(core/deps/DreamPicoPort-API EXCLUDE_FROM_ALL)
 			target_link_libraries(${PROJECT_NAME} PRIVATE dream_pico_port_api)
 		endif()
 


### PR DESCRIPTION
Currently the `install`-target of the `DreamPicoPort-API` dependency is executed when installing flycast. This results in the include file `DreamPicoPortApi.hpp` and the static library `libdream_pico_port_api.a` to be installed alongside flycast.

Add `EXCLUDE_FROM_ALL` to `add_subdirectory` to prevent this.