### PR TITLE
Fix physical VMU writing with DreamPicoPort

### DIFF
--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -2256,10 +2256,23 @@ struct MapleLinkVmu : public maple_sega_vmu
 						return rc;
 					break;
 				}
+
 				case MDCF_GetMediaInfo:
 					// block 255 contains the media info
 					readBlock(255);
 					break;
+
+				case MDCF_GetLastError:
+				{
+					auto link = MapleLink::GetMapleLink(bus_id, bus_port);
+					if (link == nullptr) {
+						ERROR_LOG(MAPLE, "MapleLinkVmu[%s]::GetLastError: MapleLink is null", logical_port);
+						return MDRE_FileError;
+					} else if (!link->handleGetLastError(*inMsg)) {
+						ERROR_LOG(MAPLE, "MapleLinkVmu[%s]::GetLastError: I/O error", logical_port);
+						return MDRE_FileError;
+					}
+				}
 
 				default:
 					// do nothing

--- a/core/input/maplelink.cpp
+++ b/core/input/maplelink.cpp
@@ -144,3 +144,9 @@ bool BaseMapleLink::storageEnabled()
 	else
 		return vmuStorage;
 }
+
+bool BaseMapleLink::handleGetLastError(const MapleMsg&)
+{
+	// Just acknowledge by default
+	return true;
+}

--- a/core/input/maplelink.h
+++ b/core/input/maplelink.h
@@ -34,6 +34,10 @@ public:
 	virtual bool send(const MapleMsg& msg) = 0;
 	//! Sends a message to the controller and waits for a response
 	virtual bool sendReceive(const MapleMsg& txMsg, MapleMsg& rxMsg) = 0;
+	//! Called on GetLastError command over previous writes
+	//! @param[in] msg The message which contains GetLastError command
+	//! @return true iff successful
+	virtual bool handleGetLastError(const MapleMsg& msg) = 0;
 	//! True if VMU reads and writes should be sent to the device
 	virtual bool storageEnabled() = 0;
 	//! True if the link is operational
@@ -65,6 +69,7 @@ class BaseMapleLink : public MapleLink
 public:
 	~BaseMapleLink();
 	bool storageEnabled() override;
+	bool handleGetLastError(const MapleMsg& msg) override;
 
 protected:
 	BaseMapleLink(bool storageSupported);


### PR DESCRIPTION
Handle GetLastError VMU commands through DreamPicoPort. I decided to keep this simple rather than to add back in any complexity since I'm trying to move toward a generalized device soon anyway.

Additionally, the gameid wasn't being sent on game start. I fixed that here too.