### PR TITLE
input: Fix inconsistent axis detection for button-type triggers

### DIFF
--- a/core/input/gamepad_device.cpp
+++ b/core/input/gamepad_device.cpp
@@ -318,6 +318,7 @@ bool GamepadDevice::detectAxis(u32 code, int value)
 //
 bool GamepadDevice::gamepad_axis_input(u32 code, int value)
 {
+	lastRawAxisValues[code] = value;
 	if (detectAxis(code, value))
 		return true;
 
@@ -670,6 +671,8 @@ void GamepadDevice::detectInput(bool combo, input_detected_cb input_changed)
 	_detection_start_time = getTimeMs() + 200;
 	detectionInputs.clear();
 	detectingAxes.clear();
+	for (const auto& [code, value] : lastRawAxisValues)
+		detectingAxes.emplace(code, value);
 }
 
 #ifdef TEST_AUTOMATION

--- a/core/input/gamepad_device.h
+++ b/core/input/gamepad_device.h
@@ -271,6 +271,7 @@ private:
 	bool _is_registered = false;
 	u32 digitalToAnalogState[4];
 	std::unordered_map<DreamcastKey, int> lastAxisValue[4];
+	std::unordered_map<u32, int> lastRawAxisValues;
 	bool perGameMapping = false;
 	bool instanceMapping = false;
 


### PR DESCRIPTION
## Problem
When mapping button-type triggers (digital buttons reported as analog axes, like HORI Fighting Commander OCTA), the reverse flag was inconsistently detected. The same mapping operation could result in either reverse=0 or reverse=1 depending on timing. This issue likely affects many arcade sticks.


https://github.com/user-attachments/assets/3110d749-cf02-4f1a-a42a-379e4244209e



## Fix
Track last known axis values in lastRawAxisValues and use them to initialize detectingAxes at detection start, ensuring the correct idle state is always set regardless of event timing.