### PR TITLE
Refactor CustomTexture lookup to FIFO for clearer priority logic

### DIFF
--- a/core/rend/CustomTexture.cpp
+++ b/core/rend/CustomTexture.cpp
@@ -184,6 +184,8 @@ bool CustomTexture::init()
 		std::string game_id = getGameId();
 		if (game_id.length() > 0)
 		{
+			// The first source added has highest priority.
+			// Add your source after the default `CustomTextureSource`(data/textures/<game id> folder), so end-users can override your textures.
 			addSource(std::make_unique<CustomTextureSource>(game_id));
 		}
 	}
@@ -266,7 +268,7 @@ u8* CustomTexture::loadTexture(u32 hash, int& width, int& height)
 		return buffer;
 	}
 
-	for (auto it = sources.rbegin(); it != sources.rend(); ++it)
+	for (auto it = sources.begin(); it != sources.end(); ++it)
 	{
 		auto& source = *it;
 		if (source->shouldReplace())
@@ -288,7 +290,7 @@ bool CustomTexture::isTextureReplaced(BaseTextureCacheData* texture)
 	if (texture->old_texture_hash != 0 && preloaded_textures.count(texture->old_texture_hash))
 		return true;
 
-	for (auto it = sources.rbegin(); it != sources.rend(); ++it)
+	for (auto it = sources.begin(); it != sources.end(); ++it)
 	{
 		auto& source = *it;
 		if (source->shouldReplace())


### PR DESCRIPTION
Switches custom texture lookup from LIFO to FIFO, making the priority logic easier to reason about.

Also adds a comment guiding future developers to add their sources *after* the default one, ensuring end-users can always override bundled textures via the standard local folder.