### PR TITLE
Fix issues relating to multiple MapleLink devices

### DIFF
--- a/core/input/maplelink.h
+++ b/core/input/maplelink.h
@@ -19,6 +19,7 @@
 #include "hw/maple/maple_devs.h"
 #include "emulator.h"
 #include <array>
+#include <list>
 #include <memory>
 #include <mutex>
 

--- a/core/input/maplelink.h
+++ b/core/input/maplelink.h
@@ -43,6 +43,7 @@ public:
 	virtual bool storageEnabled() = 0;
 	//! True if the link is operational
 	virtual bool isConnected() = 0;
+	//! @return number of active links made for this MapleLink on the given bus
 	std::size_t activeLinkCount(int bus) const;
 
 	//! Returns the maple link at the given location if any

--- a/core/input/maplelink.h
+++ b/core/input/maplelink.h
@@ -42,11 +42,15 @@ public:
 	virtual bool storageEnabled() = 0;
 	//! True if the link is operational
 	virtual bool isConnected() = 0;
+	std::size_t activeLinkCount(int bus) const;
 
 	//! Returns the maple link at the given location if any
 	static Ptr GetMapleLink(int bus, int port) {
 		std::lock_guard<std::mutex> _(Mutex);
-		return Links[bus][port];
+		std::list<MapleLink::Ptr>& list = Links[bus][port];
+		if (list.empty())
+			return nullptr;
+		return list.front();
 	}
 	//! True if any maple link currently has storage enabled
 	static bool StorageEnabled();
@@ -61,7 +65,9 @@ protected:
 
 private:
 	static std::mutex Mutex;
-	static std::array<std::array<Ptr, 2>, 4> Links;
+	//! Indexed by [bus][extension port][priority idx]
+	//! Multiple links may be registered for a bus/port, and the last added to front takes precedence
+	static std::array<std::array<std::list<Ptr>, 2>, 4> Links;
 };
 
 class BaseMapleLink : public MapleLink

--- a/core/sdl/dreamlink.cpp
+++ b/core/sdl/dreamlink.cpp
@@ -101,7 +101,7 @@ void DreamLinkGamepad::close()
 const char* DreamLinkGamepad::dreamLinkStatus()
 {
 	using namespace i18n;
-	return dreamlink->isConnected() ? T("Connected") : T("Disconnected");
+	return (dreamlink->isConnected() && dreamlink->activeLinkCount(maple_port()) > 0) ? T("Connected") : T("Disconnected");
 }
 
 void DreamLinkGamepad::set_maple_port(int port)

--- a/core/sdl/dreampicoport.cpp
+++ b/core/sdl/dreampicoport.cpp
@@ -1276,9 +1276,6 @@ public:
 	{
 		if (!DreamLink::isValidPort(software_bus))
 			return;
-		int portCount = maple_getPortCount(config::MapleMainDevices[software_bus]);
-		if (portCount == 0)
-			return;
 
 		u32 portOneFn = getFunctionCode(0);
 		if (portOneFn & MFID_1_Storage) {
@@ -1294,25 +1291,22 @@ public:
 			config::MapleExpansionDevices[software_bus][0] = MDT_None;
 		}
 
-		if (portCount >= 2)
-		{
-			u32 portTwoFn = getFunctionCode(1);
-			if (portTwoFn & MFID_8_Vibration) {
-				config::MapleExpansionDevices[software_bus][1] = MDT_PurupuruPack;
-				registerLink(software_bus, 1);
+		u32 portTwoFn = getFunctionCode(1);
+		if (portTwoFn & MFID_8_Vibration) {
+			config::MapleExpansionDevices[software_bus][1] = MDT_PurupuruPack;
+			registerLink(software_bus, 1);
+		}
+		else if (portTwoFn & MFID_1_Storage) {
+			config::MapleExpansionDevices[software_bus][1] = MDT_SegaVMU;
+			registerLink(software_bus, 1);
+			if (storageEnabled() && isGameStarted())
+			{
+				sendGameId(1);
+				emu.run([bus=this->software_bus]() { maple_ReconnectDevice(bus, 1); });
 			}
-			else if (portTwoFn & MFID_1_Storage) {
-				config::MapleExpansionDevices[software_bus][1] = MDT_SegaVMU;
-				registerLink(software_bus, 1);
-				if (storageEnabled() && isGameStarted())
-				{
-					sendGameId(1);
-					emu.run([bus=this->software_bus]() { maple_ReconnectDevice(bus, 1); });
-				}
-			}
-			else {
-				config::MapleExpansionDevices[software_bus][1] = MDT_None;
-			}
+		}
+		else {
+			config::MapleExpansionDevices[software_bus][1] = MDT_None;
 		}
 	}
 


### PR DESCRIPTION
This fixes some issues relating to multiple DreamPicoPort devices. 
- The DreamPicoPort links weren't registering unless the Dreamcast Device was set to Sega Controller before the port was set
- Swapping around DreamPicoPort Port letters and having devices share the same port for a short while would kick off the previously set device
- The DreamLink status wasn't indicative of what device had been linked and what wasn't when multiple devices were linked on the same port

Here is what this looks like now:
![Recording 2026-01-20 162020](https://github.com/user-attachments/assets/e789ecf5-88d5-4886-baa0-ac841cf9a990)
