### PR TITLE
macOS: Improve menu item handling and add traditional fullscreen shortcut

### DIFF
--- a/shell/apple/emulator-osx/emulator-osx/SDLApplicationDelegate.h
+++ b/shell/apple/emulator-osx/emulator-osx/SDLApplicationDelegate.h
@@ -12,5 +12,7 @@
 @interface SDLApplicationDelegate : NSObject <NSApplicationDelegate>
 @end
 
+#define MENU_TAG_TOGGLE_MENU 501
+
 #endif /* _SDLMain_h_ */
 

--- a/shell/apple/emulator-osx/emulator-osx/SDLApplicationDelegate.mm
+++ b/shell/apple/emulator-osx/emulator-osx/SDLApplicationDelegate.mm
@@ -163,7 +163,9 @@ static void setApplicationMenu(void)
     
     [appleMenu addItemWithTitle:@"New Instance" action:@selector(newInstance:) keyEquivalent:@"n"];
 
-    [appleMenu addItemWithTitle:@"Toggle Menu" action:@selector(toggleMenu:) keyEquivalent:@"m"];
+    NSMenuItem *toggleMenuItem = [appleMenu addItemWithTitle:@"Toggle Menu" action:@selector(toggleMenu:) keyEquivalent:@"M"];
+    [toggleMenuItem setTag:MENU_TAG_TOGGLE_MENU];
+    [appleMenu setAutoenablesItems:NO];
 
     [appleMenu addItem:[NSMenuItem separatorItem]];
     
@@ -171,7 +173,7 @@ static void setApplicationMenu(void)
     [appleMenu addItemWithTitle:title action:@selector(hide:) keyEquivalent:@"h"];
     
     menuItem = (NSMenuItem *)[appleMenu addItemWithTitle:@"Hide Others" action:@selector(hideOtherApplications:) keyEquivalent:@"h"];
-    [menuItem setKeyEquivalentModifierMask:(NSAlternateKeyMask|NSCommandKeyMask)];
+    [menuItem setKeyEquivalentModifierMask:(NSEventModifierFlagOption | NSEventModifierFlagCommand)];
     
     [appleMenu addItemWithTitle:@"Show All" action:@selector(unhideAllApplications:) keyEquivalent:@""];
     
@@ -222,6 +224,20 @@ static void setupWindowMenu(void)
     [windowMenu addItem:menuItem];
     [menuItem release];
     
+    menuItem = [[NSMenuItem alloc] initWithTitle:@"Enter Full Screen" action:@selector(toggleFullScreen:) keyEquivalent:@"f"];
+    /* Hides Globe key from keyboard shortcuts, only prints it when user is holding the Globe key */
+    [menuItem setKeyEquivalentModifierMask:NSEventModifierFlagHelp];
+    [windowMenu addItem:menuItem];
+    [menuItem release];
+    
+    /* "Ctrl + Cmd + F" was the standard Full Screen shortcut from OS X 10.7 Lion through macOS 11 Big Sur.
+       Add it back as an alternative shortcut for user without an Apple keyboard */
+    menuItem = [[NSMenuItem alloc] initWithTitle:@"Enter Full Screen" action:@selector(toggleFullScreen:) keyEquivalent:@"f"];
+    [menuItem setKeyEquivalentModifierMask:(NSEventModifierFlagControl | NSEventModifierFlagCommand)];
+    [menuItem setAlternate:YES];
+    [windowMenu addItem:menuItem];
+    [menuItem release];
+    
     /* Put menu into the menubar */
     windowMenuItem = [[NSMenuItem alloc] initWithTitle:@"Window" action:nil keyEquivalent:@""];
     [windowMenuItem setSubmenu:windowMenu];
@@ -240,13 +256,9 @@ static void setupHelpMenu(void)
 {
     NSMenu      *helpMenu;
     NSMenuItem  *helpMenuItem;
-    NSMenuItem  *menuItem;
     
     helpMenu = [[NSMenu alloc] initWithTitle:@"Help"];
     
-    /* Standard Apple Help item */
-    menuItem = [[NSMenuItem alloc] initWithTitle:@"" action:@selector(showHelp:) keyEquivalent:@"/"];
-
     /* Put menu into the menubar */
     helpMenuItem = [[NSMenuItem alloc] initWithTitle:@"Help" action:nil keyEquivalent:@""];
     [helpMenuItem setSubmenu:helpMenu];

--- a/shell/apple/emulator-osx/emulator-osx/osx-main.mm
+++ b/shell/apple/emulator-osx/emulator-osx/osx-main.mm
@@ -22,6 +22,8 @@
 #include "oslib/oslib.h"
 #include "emulator.h"
 #include "ui/mainui.h"
+#include "ui/gui.h"
+#include "SDLApplicationDelegate.h"
 #include <future>
 
 int darw_printf(const char* text, ...)
@@ -53,6 +55,11 @@ void os_DoEvents() {
 #if defined(USE_SDL)
 	NSMenuItem *editMenuItem = [[NSApp mainMenu] itemAtIndex:1];
 	[editMenuItem setEnabled:SDL_IsTextInputActive()];
+
+	NSMenuItem *toggleMenuItem = [[[[NSApp mainMenu] itemAtIndex:0] submenu] itemWithTag:MENU_TAG_TOGGLE_MENU];
+	if (toggleMenuItem) {
+		[toggleMenuItem setEnabled:emu.running() || gui_state == GuiState::Commands];
+	}
 #endif
 }
 


### PR DESCRIPTION
User reported that he cannot go fullscreen by keyboard shortcut when he is not using an Apple keyboard.

`Ctrl + Cmd + F` was the standard Full Screen shortcut from OS X 10.7 Lion through macOS 11 Big Sur, 

![Feb-02-2026 16-18-02](https://github.com/user-attachments/assets/cfdddd1e-979d-4a63-8661-6dfa96372db4)


- So we provide the legacy keycombo as an alternate like Chromium to support both the new `Globe + F` and `Ctrl + Cmd + F`
- Disables `Toggle Menu` when there is no command menu for toggling
- Change `Toggle Menu` to Cmd + Shift + M to avoid clashing with `Minimize`