### PR TITLE
Adding StartupWMClass

### DIFF
--- a/shell/linux/flycast.desktop
+++ b/shell/linux/flycast.desktop
@@ -23,3 +23,4 @@ Type=Application
 StartupNotify=false
 Categories=Game;Emulator;
 PrefersNonDefaultGPU=true
+StartupWMClass=flycast


### PR DESCRIPTION
This is to avoid certain problems involving icons and Wayland.

But when Flycast works natively on Wayland, this will need to be changed.