### PR TITLE
docs: Added missing Linux build requirements to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Get fresh builds for your system [**on the builds page**](https://flyinghead.git
 
 **New:** Now automated test results are available as well. 
 
+### Build requirements (Linux):
+
+- **C/C++ compiler toolchain** (e.g. `gcc`/`g++`)
+- **CMake**
+- **make**
+- **libcurl** (development headers)
+- **libudev** (development headers)
+- **SDL2** (development headers)
+- **Graphics API**: Vulcan, OpenGL
+
 ### Build instructions:
 ```
 $ git clone --recursive https://github.com/flyinghead/flycast.git


### PR DESCRIPTION
## Summary
 
The "Build instructions" section lists the commands to compile Flycast but does
not mention any of the prerequisites. On a minimal Linux system (including
WSL2), several required libraries are absent and either the build fails or the emulator doesn't behave as it should.
 
## Changes
 
Added a **"Build requirements (Linux)"** section immediately above the existing
"Build instructions" block, listing:
 
- C/C++ compiler toolchain
- CMake
- make
- libcurl (development headers)
- libudev (development headers)
- SDL2 (development headers)
- Graphics API: Vulkan, OpenGL