### PR TITLE
Libretro - D3D11/GL Delay Frame Swap Fix

### DIFF
--- a/core/hw/pvr/Renderer_if.cpp
+++ b/core/hw/pvr/Renderer_if.cpp
@@ -17,6 +17,11 @@
 #ifdef LIBRETRO
 void retro_rend_present();
 void retro_resize_renderer(int w, int h, float aspectRatio);
+
+// In libretro non-threaded mode, DelayFrameSwapping can make Present() happen
+// before the frame pacing point we want to stop the SH4 executor on. Defer the
+// stop until vblank so delayed presents do not hurt pacing.
+static bool lr_pending_stop_after_present = false;
 #endif
 
 u32 FrameCount=1;
@@ -246,7 +251,14 @@ private:
 		{
 			presented = true;
 			if (!config::ThreadedRendering && !ggpo::active())
-				emu.getSh4Executor()->Stop();
+			{
+#ifdef LIBRETRO
+				if (config::DelayFrameSwapping)
+					lr_pending_stop_after_present = true;
+				else
+#endif
+					emu.getSh4Executor()->Stop();
+			}
 #ifdef LIBRETRO
 			retro_rend_present();
 #endif
@@ -358,6 +370,9 @@ void rend_reset()
 	fb_w_cur = 1;
 	pvrQueue.reset();
 	rendererEnabled = true;
+#ifdef LIBRETRO
+	lr_pending_stop_after_present = false;
+#endif
 	fbAddrHistory[0] = 1;
 	fbAddrHistory[1] = 1;
 }
@@ -474,6 +489,13 @@ void rend_vblank()
 	render_called = false;
 	check_framebuffer_write();
 	emu.vblank();
+#ifdef LIBRETRO
+	if (lr_pending_stop_after_present && !config::ThreadedRendering && !ggpo::active())
+	{
+		lr_pending_stop_after_present = false;
+		emu.getSh4Executor()->Stop();
+	}
+#endif
 }
 
 void check_framebuffer_write()
@@ -554,6 +576,9 @@ void rend_deserialize(Deserializer& deser)
 		deser >> fb_watch_addr_end;
 	}
 	pend_rend = false;
+#ifdef LIBRETRO
+	lr_pending_stop_after_present = false;
+#endif
 	fbAddrHistory[0] = 1;
 	fbAddrHistory[1] = 1;
 }


### PR DESCRIPTION
Fixes https://github.com/flyinghead/flycast/issues/1615

I used AI to come up with a solution to a problem that had been bothering me a lot :p.

Delay Frame Swap is indeed broken on Libretro - D3D11/GL - non-threaded rendering.  I don't use threaded rendering as it adds 1 frame of input lag at the moment https://github.com/libretro/flycast/issues/738.

### This PR fixes the stutter/fluidity issue with DelayFrameSwapping in Libretro non-threaded mode.

The problem was not DelayFrameSwapping itself, but the fact that in this mode we were stopping SH4 execution too early from Present().
When DFW delays presentation, that also shifts the frame stop point, which hurts frame pacing on some games, especially with GL/DX11.

This change keeps DelayFrameSwapping working normally, but moves the SH4 stop to vblank in the affected Libretro non-threaded path.
That restores smoothness while preserving DFW behavior.

Results:
- fixes fluidity/stutter on affected games
- DelayFrameSwapping still works
- no Vulkan regression in testing

**Tests**

- SFIII Double Impact: stutter resolved & DelayFrameSwapping now correctly adds +1 frame ✓
- Street Fighter Zero 3: vertical alternation resolved and DelayFrameSwapping now correctly adds +1 frame ✓
- Street Fighter 3rd Strike: DelayFrameSwapping now correctly adds +1 frame ✓
- Capcom vs SNK 2: no regression ✓
- Vulkan: unaffected ✓
- Threaded rendering: unaffected ✓

*This was developed with the help of ChatGPT and Claude AI.*