### PR TITLE
Language Picker

### DIFF
--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -33,6 +33,7 @@ Option<int> Cable("Dreamcast.Cable", 3);			// TV Composite
 Option<int> Region("Dreamcast.Region", 1);			// USA
 Option<int> Broadcast("Dreamcast.Broadcast", 0);	// NTSC
 Option<int> Language("Dreamcast.Language", 1);		// English
+OptionString UILanguage("UILanguage", "");
 Option<bool> AutoLoadState("Dreamcast.AutoLoadState");
 Option<bool> AutoSaveState("Dreamcast.AutoSaveState");
 Option<int, false> SavestateSlot("Dreamcast.SavestateSlot");

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -360,6 +360,7 @@ extern Option<int> Cable;		// 0 -> VGA, 1 -> VGA, 2 -> RGB, 3 -> TV Composite
 extern Option<int> Region;		// 0 -> JP, 1 -> USA, 2 -> EU, 3 -> default
 extern Option<int> Broadcast;	// 0 -> NTSC, 1 -> PAL, 2 -> PAL/M, 3 -> PAL/N, 4 -> default
 extern Option<int> Language;	// 0 -> JP, 1 -> EN, 2 -> DE, 3 -> FR, 4 -> SP, 5 -> IT, 6 -> default
+extern OptionString UILanguage;
 extern Option<bool> AutoLoadState;
 extern Option<bool> AutoSaveState;
 extern Option<int, false> SavestateSlot;

--- a/core/input/gamepad_device.cpp
+++ b/core/input/gamepad_device.cpp
@@ -878,6 +878,13 @@ void GamepadDevice::rampAnalog()
 	}
 }
 
+void GamepadDevice::refreshAllNames()
+{
+	Lock _(_gamepads_mutex);
+	for (auto& gamepad : _gamepads)
+		gamepad->refreshName();
+}
+
 void GamepadDevice::RampAnalog()
 {
 	Lock _(_gamepads_mutex);

--- a/core/input/gamepad_device.h
+++ b/core/input/gamepad_device.h
@@ -43,6 +43,9 @@ public:
 	virtual bool gamepad_axis_input(u32 code, int value);
 	virtual ~GamepadDevice() = default;
 
+	virtual void refreshName() {}
+	static void refreshAllNames();
+
 	void detectInput(bool combo, input_detected_cb input_changed);
 	void cancel_detect_input() {
 		_input_detected = nullptr;

--- a/core/input/keyboard_device.h
+++ b/core/input/keyboard_device.h
@@ -74,6 +74,11 @@ class KeyboardDevice : public GamepadDevice
 protected:
 	KeyboardDevice(int maple_port, const char* apiName, bool remappable = true)
 		: GamepadDevice(maple_port, apiName, remappable) {
+		refreshName();
+	}
+
+	void refreshName() override
+	{
 		_name = i18n::Ts("Keyboard");
 	}
 

--- a/core/input/mouse.h
+++ b/core/input/mouse.h
@@ -54,6 +54,11 @@ class Mouse : public GamepadDevice
 {
 protected:
 	Mouse(const char *apiName, int maplePort = 0) : GamepadDevice(maplePort, apiName) {
+		refreshName();
+	}
+
+	void refreshName() override
+	{
 		this->_name = i18n::Ts("Mouse");
 	}
 
@@ -115,9 +120,14 @@ class TouchMouse : public SystemMouse
 public:
 	TouchMouse() : SystemMouse("Flycast", -1, true)
 	{
-		_name = i18n::Ts("Touch Mouse");
+		refreshName();
 		_unique_id = "touch_mouse";
 		loadMapping();
+	}
+
+	void refreshName() override
+	{
+		_name = i18n::Ts("Touch Mouse");
 	}
 };
 

--- a/core/input/virtual_gamepad.h
+++ b/core/input/virtual_gamepad.h
@@ -27,13 +27,18 @@ public:
 	VirtualGamepad(const char *api_name, int maple_port = 0)
 		: GamepadDevice(maple_port, api_name, false)
 	{
-		_name = i18n::Ts("Virtual Gamepad");
+		refreshName();
 		_unique_id = "virtual_gamepad_uid";
 		input_mapper = std::make_shared<IdentityInputMapping>();
 		// hasAnalogStick = true; // TODO has an analog stick but input mapping isn't persisted
 
 		input_mapper->addTrigger(DC_AXIS_LT, false);
 		input_mapper->addTrigger(DC_AXIS_RT, false);
+	}
+
+	void refreshName() override
+	{
+		_name = i18n::Ts("Virtual Gamepad");
 	}
 
 	bool is_virtual_gamepad() override {

--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -100,6 +100,7 @@ int flycast_init(int argc, char* argv[])
 			LogManager::Init();
 			config::Settings::instance().load(false);
 		}
+		i18n::reloadLanguage();
 		gui_init();
 		os_CreateWindow();
 		os_SetupInput();

--- a/core/oslib/i18n.cpp
+++ b/core/oslib/i18n.cpp
@@ -18,6 +18,7 @@
  */
 #include "i18n.h"
 #include "resources.h"
+#include "cfg/option.h"
 #include "tinygettext/tinygettext.hpp"
 #include "tinygettext/file_system.hpp"
 #include "tinygettext/log.hpp"
@@ -28,6 +29,7 @@
 #endif
 #include <vector>
 #include <sstream>
+#include <algorithm>
 #include <unordered_set>
 
 using namespace tinygettext;
@@ -54,6 +56,13 @@ class ResourceFileSystem : public FileSystem
 };
 
 static Dictionary *dictionary;
+
+static Dictionary& getDictionary()
+{
+	if (dictionary == nullptr)
+		reloadLanguage();
+	return *dictionary;
+}
 
 static std::string getUnixLocaleVariant(const std::string& locale)
 {
@@ -130,20 +139,26 @@ void init()
 		if (!msg.empty())
 			ERROR_LOG(COMMON, "%s", msg.substr(0, msg.length() - 1).c_str());
 	});
+}
 
+void reloadLanguage()
+{
 	std::string locale = getCurrentLocale();
 	std::string language, country, variant;
 	parseLocale(locale, language, country, variant);
 
-	static DictionaryManager dictMgr(std::make_unique<ResourceFileSystem>());
-	dictMgr.set_language(Language::from_spec(language, country, variant));
-	dictMgr.add_directory("i18n");
-	dictionary = &dictMgr.get_dictionary();
+	static std::unique_ptr<DictionaryManager> dictMgr;
+	if (!dictMgr)
+	{
+		dictMgr = std::make_unique<DictionaryManager>(std::make_unique<ResourceFileSystem>());
+		dictMgr->add_directory("i18n");
+	}
+	dictMgr->set_language(Language::from_spec(language, country, variant));
+	dictionary = &dictMgr->get_dictionary();
 }
 
 static const std::string& translate(const std::string& msg) {
-	init();
-	return dictionary->translate(msg);
+	return getDictionary().translate(msg);
 }
 
 std::string Ts(const std::string& msg) {
@@ -163,7 +178,7 @@ const char *T(const char *msg)
 }
 
 std::string translateCtx_s(const std::string& context, const std::string& msg) {
-	return dictionary->translate_ctxt(context, msg);
+	return getDictionary().translate_ctxt(context, msg);
 }
 
 const char *translateCtx(const std::string& context, const char *msg)
@@ -171,7 +186,7 @@ const char *translateCtx(const std::string& context, const char *msg)
 	if (msg == nullptr)
 		return nullptr;
 	std::string smsg(msg);
-	const std::string& tr = dictionary->translate_ctxt(context, smsg);
+	const std::string& tr = getDictionary().translate_ctxt(context, smsg);
 	if (&tr == &smsg)
 		return msg;
 	else
@@ -179,7 +194,7 @@ const char *translateCtx(const std::string& context, const char *msg)
 }
 
 std::string translatePlural_s(const std::string& msg, const std::string& msgPlural, int num) {
-	return dictionary->translate_plural(msg, msgPlural, num);
+	return getDictionary().translate_plural(msg, msgPlural, num);
 }
 
 const char *translatePlural(const char *msg, const char *msgPlural, int num) {
@@ -187,7 +202,7 @@ const char *translatePlural(const char *msg, const char *msgPlural, int num) {
 		return nullptr;
 	std::string smsg(msg);
 	std::string smsgPlural(msgPlural);
-	const std::string& tr = dictionary->translate_plural(smsg, smsgPlural, num);
+	const std::string& tr = getDictionary().translate_plural(smsg, smsgPlural, num);
 	if (&tr == &smsg)
 		return msg;
 	else if (&tr == &smsgPlural)
@@ -196,9 +211,10 @@ const char *translatePlural(const char *msg, const char *msgPlural, int num) {
 		return tr.c_str();
 }
 
-#if !defined(LIBRETRO) && defined(_WIN32)
-std::string getCurrentLocale()
+#if !defined(__ANDROID__) && !defined(__SWITCH__) && !defined(LIBRETRO) && !defined(TARGET_MAC)
+std::string getSystemLocale()
 {
+#if defined(_WIN32)
 	ULONG numLanguages = 0;
 	ULONG bufferSize = 0;
 	if (!GetUserPreferredUILanguages(MUI_LANGUAGE_NAME, &numLanguages, nullptr, &bufferSize) || bufferSize == 0)
@@ -220,6 +236,21 @@ std::string getCurrentLocale()
 
 	ERROR_LOG(COMMON, "UTF-16 to UTF-8 conversion failed");
 	return "en";
+#else
+	const char* locale = setlocale(LC_MESSAGES, nullptr);
+	return locale ? locale : "en";
+#endif
 }
 #endif
+
+#ifndef LIBRETRO
+std::string getCurrentLocale()
+{
+	std::string locale = config::UILanguage;
+	if (!locale.empty())
+		return locale;
+	return getSystemLocale();
+}
+#endif
+
 }

--- a/core/oslib/i18n.h
+++ b/core/oslib/i18n.h
@@ -30,6 +30,7 @@ namespace i18n
 #if defined(__ANDROID__) && !defined(LIBRETRO)
 
 std::string getCurrentLocale();
+std::string getSystemLocale();
 std::string formatShortDateTime(time_t time);
 
 #else
@@ -38,17 +39,8 @@ using std::locale;
 
 void init();
 
-#if !defined(LIBRETRO) && !defined(__SWITCH__) && !defined(_WIN32) && !defined(TARGET_MAC)
-
-static inline std::string getCurrentLocale() {
-	return setlocale(LC_MESSAGES, nullptr);
-}
-
-#else
-
 std::string getCurrentLocale();
-
-#endif
+std::string getSystemLocale();
 
 static inline std::string formatShortDateTime(time_t time)
 {
@@ -71,6 +63,7 @@ static inline std::string formatShortDateTime(time_t time)
 
 #endif	// !ANDROID
 
+void reloadLanguage();
 std::string Ts(const std::string& msg);
 const char *T(const char *msg);
 

--- a/core/sdl/sdl_gamepad.cpp
+++ b/core/sdl/sdl_gamepad.cpp
@@ -690,15 +690,20 @@ bool SDLGamepad::find_mapping(int system)
 	return ret;
 }
 
-SDLMouse::SDLMouse(u32 mouseId) : Mouse("SDL")
+SDLMouse::SDLMouse(u32 mouseId) : Mouse("SDL"), mouseId(mouseId)
 {
-	if (mouseId == 0) {
-		this->_name = i18n::Ts("Default Mouse");
+	refreshName();
+	if (mouseId == 0)
 		this->_unique_id = "sdl_mouse";
-	}
-	else {
-		this->_name = strprintf(i18n::T("Mouse %d"), mouseId);
+	else
 		this->_unique_id = "sdl_mouse_" + std::to_string(mouseId);
-	}
 	loadMapping();
+}
+
+void SDLMouse::refreshName()
+{
+	if (mouseId == 0)
+		this->_name = i18n::Ts("Default Mouse");
+	else
+		this->_name = strprintf(i18n::T("Mouse %d"), mouseId);
 }

--- a/core/sdl/sdl_gamepad.h
+++ b/core/sdl/sdl_gamepad.h
@@ -116,4 +116,8 @@ class SDLMouse : public Mouse
 public:
 	SDLMouse(u32 mouseId);
 	void setAbsPos(int x, int y);
+	void refreshName() override;
+
+private:
+	u32 mouseId;
 };

--- a/core/ui/settings_general.cpp
+++ b/core/ui/settings_general.cpp
@@ -24,6 +24,7 @@
 #include "stdclass.h"
 #include "achievements/achievements.h"
 #include "imgui_stdlib.h"
+#include "input/gamepad_device.h"
 
 static std::vector<std::string>* g_currentPathList = nullptr;
 static void managePathListCallback(std::string selection)
@@ -185,8 +186,58 @@ void gui_settings_general()
 	{
 		DisabledScope scope(settings.platform.isArcade());
 
+		struct LangItem
+		{
+			const char* label;
+			const char* value;
+		};
+		static constexpr LangItem kLanguages[] = {
+			{ "English", "en" },
+			{ "Français", "fr" },
+			{ "Magyar", "hu" },
+//			{ "日本語", "ja" }, // FIXME: Use this when we have dynamic font loading
+			{ "Japanese", "ja" },
+			{ "Português (Brasil)", "pt_BR" },
+			{ "Svenska", "sv" },
+		};
+
+		// Determine the preview text
+		std::string currentLanguage = config::UILanguage.get();
+		std::string preview = T("System Default");
+		for (const auto& it : kLanguages)
+		{
+			if (currentLanguage == it.value)
+			{
+				preview = it.label;
+				break;
+			}
+		}
+
+		if (ImGui::BeginCombo(T("UI Language"), preview.c_str()))
+		{
+			for (int i = -1; i < (int)std::size(kLanguages); i++)
+			{
+				const char* label = (i == -1) ? T("System Default") : kLanguages[i].label;
+				const char* value = (i == -1) ? "" : kLanguages[i].value;
+				bool selected = (currentLanguage == value);
+
+				ImGui::PushID(i);
+				if (ImGui::Selectable(label, selected))
+				{
+					config::UILanguage = value;
+					i18n::reloadLanguage();
+					GamepadDevice::refreshAllNames();
+				}
+				if (selected)
+					ImGui::SetItemDefaultFocus();
+				ImGui::PopID();
+			}
+
+			ImGui::EndCombo();
+		}
+
 		const char *languages[] = { T("Japanese"), T("English"), T("German"), T("French"), T("Spanish"), T("Italian"), T("Default") };
-		OptionComboBox(T("Language"), config::Language, languages, std::size(languages),
+		OptionComboBox(T("Dreamcast Language"), config::Language, languages, std::size(languages),
 				T("The language as configured in the Dreamcast BIOS"));
 
 		const char *broadcast[] = { "NTSC", "PAL", "PAL/M", "PAL/N", T("Default") };

--- a/shell/android-studio/flycast/src/main/jni/src/i18n.cpp
+++ b/shell/android-studio/flycast/src/main/jni/src/i18n.cpp
@@ -50,7 +50,7 @@ std::string formatShortDateTime(time_t t) {
 	return str.to_string();
 }
 
-std::string getCurrentLocale() {
+std::string getSystemLocale() {
 	jni::String str(jni::env()->CallStaticObjectMethod(clazz, getCurrentLocaleID));
 	return str.to_string();
 }

--- a/shell/apple/emulator-osx/emulator-osx/osx-main.mm
+++ b/shell/apple/emulator-osx/emulator-osx/osx-main.mm
@@ -285,7 +285,7 @@ std::string getScreenshotsPath()
 namespace i18n
 {
 
-std::string getCurrentLocale()
+std::string getSystemLocale()
 {
 	return [[[NSLocale preferredLanguages] objectAtIndex:0] UTF8String];
 }

--- a/shell/switch/i18n.cpp
+++ b/shell/switch/i18n.cpp
@@ -23,7 +23,7 @@ namespace i18n
 {
 static std::string systemLanguage;
 
-std::string getCurrentLocale()
+std::string getSystemLocale()
 {
 	if (systemLanguage.empty())
 	{


### PR DESCRIPTION
Add UI language picker in Settings

- Implement runtime UI language switching (no restart required)
  - Separate UI language from Dreamcast BIOS language
  - Refresh device names dynamically after language change
  - Support system default language fallback
- System locale handling
  - If system locale matches an available translation, it is applied automatically
  - Translation availability is detected by scanning .po files (checking if `Settings` string is translated)
- Language list is currently hand-crafted
  - New translations must be manually added to the list
  - If system locale's translation is available but we didn't add it into the list yet, we will display a `System Default (locale)` item in the picker as a fallback now

- Japanese font won't be loaded when switching to this language before #2190 lands