### PR TITLE
Fix Full Screen menu shortcut on newer macOS versions

### DIFF
--- a/shell/apple/emulator-osx/emulator-osx/SDLApplicationDelegate.mm
+++ b/shell/apple/emulator-osx/emulator-osx/SDLApplicationDelegate.mm
@@ -225,8 +225,7 @@ static void setupWindowMenu(void)
     [menuItem release];
     
     menuItem = [[NSMenuItem alloc] initWithTitle:@"Enter Full Screen" action:@selector(toggleFullScreen:) keyEquivalent:@"f"];
-    /* Hides Globe key from keyboard shortcuts, only prints it when user is holding the Globe key */
-    [menuItem setKeyEquivalentModifierMask:NSEventModifierFlagHelp];
+    [menuItem setKeyEquivalentModifierMask:NSEventModifierFlagFunction];
     [windowMenu addItem:menuItem];
     [menuItem release];
     


### PR DESCRIPTION
Change the Full Screen modifier mask from `NSEventModifierFlagHelp` to `NSEventModifierFlagFunction` 

Always display the `Globe + F` / `Fn + F` hint, still prints `Cmd + Ctrl + F` as alternate when user is holding Cmd + Ctrl