### PR TITLE
Fix intermittent upside-down image

### DIFF
--- a/core/rend/CustomTexture.cpp
+++ b/core/rend/CustomTexture.cpp
@@ -126,7 +126,7 @@ u8* CustomTextureSource::loadCustomTexture(u32 hash, int& width, int& height)
 	if (file == nullptr)
 		return nullptr;
 	int n;
-	stbi_set_flip_vertically_on_load(1);
+	stbi_set_flip_vertically_on_load_thread(1);
 	u8 *imgData = stbi_load_from_file(file, &width, &height, &n, STBI_rgb_alpha);
 	std::fclose(file);
 	return imgData;

--- a/core/ui/gui_util.cpp
+++ b/core/ui/gui_util.cpp
@@ -788,7 +788,7 @@ static u8 *loadImage(const std::string& path, int& width, int& height)
 		return nullptr;
 
 	int channels;
-	stbi_set_flip_vertically_on_load(0);
+	stbi_set_flip_vertically_on_load_thread(0);
 	u8 *imgData = stbi_load_from_file(file, &width, &height, &channels, STBI_rgb_alpha);
 	std::fclose(file);
 	return imgData;
@@ -858,7 +858,7 @@ ImTextureID ImguiStateTexture::getId()
 			return loadedPic;
 
 		int channels;
-		stbi_set_flip_vertically_on_load(0);
+		stbi_set_flip_vertically_on_load_thread(0);
 		loadedPic.data = stbi_load_from_memory(&pngData[0], pngData.size(), &loadedPic.width, &loadedPic.height, &channels, STBI_rgb_alpha);
 
 		return loadedPic;

--- a/core/ui/vgamepad.cpp
+++ b/core/ui/vgamepad.cpp
@@ -108,7 +108,7 @@ static bool loadOSDButtons(const std::string& path)
 	if (file == nullptr)
 		return false;
 
-	stbi_set_flip_vertically_on_load(1);
+	stbi_set_flip_vertically_on_load_thread(1);
     int width, height, n;
 	u8 *image_data = stbi_load_from_file(file, &width, &height, &n, STBI_rgb_alpha);
 	std::fclose(file);
@@ -143,7 +143,7 @@ static ImTextureID loadOSDButtons()
 	// default in resource
 	size_t size;
 	std::unique_ptr<u8[]> data = resource::load(getButtonsResPath(), size);
-	stbi_set_flip_vertically_on_load(1);
+	stbi_set_flip_vertically_on_load_thread(1);
 	int width, height, n;
 	u8 *image_data = stbi_load_from_memory(data.get(), (int)size, &width, &height, &n, STBI_rgb_alpha);
     if (image_data != nullptr)


### PR DESCRIPTION
User report that sometimes the image is flipped when preloading texture is enabled.

This affects the in game texture and save states preview picture.

e.g.
<img width="3402" height="2026" alt="image" src="https://github.com/user-attachments/assets/a20847e7-65d3-4d06-b3bd-117574e2d9f4" />

since `stbi_set_flip_vertically_on_load` is a global switch, this race condition is easily triggered by booting into a game when skipping the game picker gui.  So that the game is preloading (sets to 1) and drawing other UI stuff (sets to 0) at the same time

Change to `stbi_set_flip_vertically_on_load_thread` to prevent race conditions on the global flip state between the loader and GUI threads.

