### PR TITLE
macOS: Use MAP_JIT from now on

### DIFF
--- a/core/linux/posix_vmem.cpp
+++ b/core/linux/posix_vmem.cpp
@@ -255,12 +255,11 @@ bool prepare_jit_block(void *code_area, size_t size, void **code_area_rwx)
         *code_area_rwx = code_area;
         return true;
     }
-#ifndef TARGET_ARM_MAC
+#ifndef TARGET_MAC
     void *ret_ptr = MAP_FAILED;
     if (code_area != nullptr)
     {
 		// Well it failed, use another approach, unmap the memory area and remap it back.
-		// Seems it works well on Darwin according to reicast code :P
         munmap(code_area, size);
         ret_ptr = mmap(code_area, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_FIXED | MAP_PRIVATE | MAP_ANON, 0, 0);
     }
@@ -272,7 +271,7 @@ bool prepare_jit_block(void *code_area, size_t size, void **code_area_rwx)
             return false;
     }
 #else
-    // MAP_JIT and toggleable write protection is required on Apple Silicon
+    // MAP_JIT and toggleable write protection is required on modern macOS.
     // Cannot use MAP_FIXED with MAP_JIT
     void *ret_ptr = mmap(NULL, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANON | MAP_JIT, -1, 0);
     if ( ret_ptr == MAP_FAILED )

--- a/core/oslib/virtmem.h
+++ b/core/oslib/virtmem.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "types.h"
 
-#if defined(_WIN32) || defined(TARGET_IPHONE) || defined(TARGET_ARM_MAC)
+#if defined(_WIN32) || defined(__APPLE__)
 #define DECLARE_CODE_CACHE(Name, Size) static u8 *Name;
 #elif defined(__ANDROID__)
 #define DECLARE_CODE_CACHE(Name, Size) alignas(4096) static u8 Name[Size];
@@ -9,8 +9,6 @@
 #define DECLARE_CODE_CACHE(Name, Size) alignas(4096) static u8 Name[Size] __attribute__((section(".openbsd.mutable")));
 #elif defined(__unix__) || defined(__SWITCH__) || defined(__HAIKU__)
 #define DECLARE_CODE_CACHE(Name, Size) alignas(4096) static u8 Name[Size] __attribute__((section(".text")));
-#elif defined(__APPLE__)
-#define DECLARE_CODE_CACHE(Name, Size) alignas(4096) static u8 Name[Size] __attribute__((section("__TEXT,.text")));
 #else
 #error Unknown platform for dynarec code cache declaration
 #endif


### PR DESCRIPTION
With the introduction of `MAP_JIT` in macOS 10.14, the security becomes stricter and stricter for every OS releases.

I just discovered that in Intel macOS 12, Flycast would crash immediately with SIGKILL signal 9. 
So we can't use the `munmap` and `mmap` with `MAP_FIXED` anymore, it will be killed directly by Apple's Mobile File Integrity (AMFI) service, and no crashdump can be generated. 

Since our deployment target is 10.15 now, we can safely move to use `MAP_JIT` for all Intel and Apple Silicon.