### PR TITLE
Fix macOS/AMD render corruption and depth issues

### DIFF
--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -116,6 +116,7 @@ Option<bool> NativeDepthInterpolation("rend.NativeDepthInterpolation", true);
 #else
 Option<bool> NativeDepthInterpolation("rend.NativeDepthInterpolation", false);
 #endif
+Option<bool> NonReversedDepth("rend.NonReversedDepth", false);
 Option<bool> EmulateFramebuffer("rend.EmulateFramebuffer", false);
 Option<bool> FixUpscaleBleedingEdge("rend.FixUpscaleBleedingEdge", true);
 Option<bool> CustomGpuDriver("rend.CustomGpuDriver", false);

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -472,6 +472,7 @@ extern Option<int> TextureFiltering; // 0: default, 1: force nearest, 2: force l
 extern Option<bool> ThreadedRendering;
 extern Option<bool> DupeFrames;
 extern Option<bool> NativeDepthInterpolation;
+extern Option<bool> NonReversedDepth;
 extern Option<bool> EmulateFramebuffer;
 extern Option<bool> FixUpscaleBleedingEdge;
 extern Option<bool> CustomGpuDriver;

--- a/core/rend/gl4/glsl.h
+++ b/core/rend/gl4/glsl.h
@@ -38,14 +38,24 @@ struct Pixel { \n\
 #define DST_ALPHA			6 \n\
 #define INVERSE_DST_ALPHA	7 \n\
  \n\
-void setFragDepth(float z) \n\
+float computeFragDepth(float z) \n\
 { \n\
 #if DIV_POS_Z == 1 \n\
 	float w = 100000.0 / z; \n\
 #else \n\
 	float w = 100000.0 * z; \n\
 #endif \n\
-	gl_FragDepth = log2(1.0 + max(w, -0.999999)) / 34.0; \n\
+	float depth = log2(1.0 + max(w, -0.999999)) / 34.0; \n\
+#if REVERSED_DEPTH == 1 \n\
+	return depth; \n\
+#else \n\
+	return 1.0 - depth; \n\
+#endif \n\
+} \n\
+\n\
+void setFragDepth(float z) \n\
+{ \n\
+	gl_FragDepth = computeFragDepth(z); \n\
 } \n\
 \n\
 struct PolyParam { \n\

--- a/core/rend/vulkan/drawer.cpp
+++ b/core/rend/vulkan/drawer.cpp
@@ -566,10 +566,10 @@ vk::CommandBuffer TextureDrawer::BeginRenderPass()
 	framebuffers[GetCurrentImage()] = device.createFramebufferUnique(vk::FramebufferCreateInfo(vk::FramebufferCreateFlags(),
 			rttPipelineManager->GetRenderPass(), imageViews, widthPow2, heightPow2, 1));
 
-	const std::array<vk::ClearValue, 2> clear_colors = { vk::ClearColorValue(std::array<float, 4> { 0.f, 0.f, 0.f, 1.f }), vk::ClearDepthStencilValue { 0.f, 0 } };
+	const std::array<vk::ClearValue, 2> clear_colors = { vk::ClearColorValue(std::array<float, 4> { 0.f, 0.f, 0.f, 1.f }), vk::ClearDepthStencilValue { GetContext()->getDepthClearValue(), 0 } };
 	commandBuffer.beginRenderPass(vk::RenderPassBeginInfo(rttPipelineManager->GetRenderPass(),	*framebuffers[GetCurrentImage()],
 			vk::Rect2D( { 0, 0 }, { width, height }), clear_colors), vk::SubpassContents::eInline);
-	commandBuffer.setViewport(0, vk::Viewport(0.0f, 0.0f, (float)upscaledWidth, (float)upscaledHeight, 1.0f, 0.0f));
+	commandBuffer.setViewport(0, GetContext()->makeViewport(0.0f, 0.0f, (float)upscaledWidth, (float)upscaledHeight));
 	u32 minX = rendContext->getFramebufferMinX() * upscaledWidth / origWidth;
 	u32 minY = rendContext->getFramebufferMinY() * upscaledHeight / origHeight;
 	getRenderToTextureDimensions(minX, minY, widthPow2, heightPow2);
@@ -756,13 +756,13 @@ vk::CommandBuffer ScreenDrawer::BeginRenderPass()
 
 		vk::RenderPass renderPass = clearNeeded[GetCurrentImage()] || rendContext->clearFramebuffer ? *renderPassClear : *renderPassLoad;
 		clearNeeded[GetCurrentImage()] = false;
-		const std::array<vk::ClearValue, 2> clear_colors = { vk::ClearColorValue(std::array<float, 4> { 0.f, 0.f, 0.f, 1.f }), vk::ClearDepthStencilValue { 0.f, 0 } };
+		const std::array<vk::ClearValue, 2> clear_colors = { vk::ClearColorValue(std::array<float, 4> { 0.f, 0.f, 0.f, 1.f }), vk::ClearDepthStencilValue { GetContext()->getDepthClearValue(), 0 } };
 		commandBuffer.beginRenderPass(vk::RenderPassBeginInfo(renderPass, *framebuffers[GetCurrentImage()],
 				vk::Rect2D( { 0, 0 }, viewport), clear_colors), vk::SubpassContents::eInline);
 		currentCommandBuffer = commandBuffer;
 		renderPassStarted = true;
 	}
-	currentCommandBuffer.setViewport(0, vk::Viewport(0.0f, 0.0f, (float)viewport.width, (float)viewport.height, 1.0f, 0.0f));
+	currentCommandBuffer.setViewport(0, GetContext()->makeViewport(0.0f, 0.0f, (float)viewport.width, (float)viewport.height));
 
 	matrices.CalcMatrices(rendContext, viewport.width, viewport.height);
 

--- a/core/rend/vulkan/oit/oit_drawer.cpp
+++ b/core/rend/vulkan/oit/oit_drawer.cpp
@@ -355,8 +355,8 @@ bool OITDrawer::Draw(const Texture *fogTexture, const Texture *paletteTexture)
 			(u32)offsets.polyParamsSize, depthAttachments[0]->GetStencilView(),
 			depthAttachments[0]->GetImageView(), paletteTexture->GetImageView(), oitBuffers);
 	descriptorSets.bindPerFrameDescriptorSets(cmdBuffer);
-	descriptorSets.updateColorInputDescSet(0, colorAttachments[0]->GetImageView());
-	descriptorSets.updateColorInputDescSet(1, colorAttachments[1]->GetImageView());
+	descriptorSets.updateColorInputDescSet(0, colorAttachments[0]->GetImageView(), depthAttachments[0]->GetImageView());
+	descriptorSets.updateColorInputDescSet(1, colorAttachments[1]->GetImageView(), depthAttachments[1]->GetImageView());
 
 	// Bind vertex and index buffers
 	cmdBuffer.bindVertexBuffers(0, curMainBuffer, {0});
@@ -372,8 +372,8 @@ bool OITDrawer::Draw(const Texture *fogTexture, const Texture *paletteTexture)
 	const std::array<vk::ClearValue, 4> clear_colors = {
 			rendContext->isRTT ? vk::ClearColorValue(std::array<float, 4>{0.f, 0.f, 0.f, 1.f}) : getBorderColor(),
 			rendContext->isRTT ? vk::ClearColorValue(std::array<float, 4>{0.f, 0.f, 0.f, 1.f}) : getBorderColor(),
-			vk::ClearDepthStencilValue{ 0.f, 0 },
-			vk::ClearDepthStencilValue{ 0.f, 0 },
+			vk::ClearDepthStencilValue{ GetContext()->getDepthClearValue(), 0 },
+			vk::ClearDepthStencilValue{ GetContext()->getDepthClearValue(), 0 },
 	};
 
 	RenderPass previous_pass = {};
@@ -405,7 +405,8 @@ bool OITDrawer::Draw(const Texture *fogTexture, const Texture *paletteTexture)
 		DrawList(cmdBuffer, ListType_Opaque, false, Pass::Depth, rendContext->global_param_op, previous_pass.op_count, current_pass.op_count);
 		DrawList(cmdBuffer, ListType_Punch_Through, false, Pass::Depth, rendContext->global_param_pt, previous_pass.pt_count, current_pass.pt_count);
 
-		DrawModifierVolumes<false>(cmdBuffer, previous_pass.mvo_count, current_pass.mvo_count - previous_pass.mvo_count, rendContext->global_param_mvo.data());
+		if (GetContext()->useReversedDepth())
+			DrawModifierVolumes<false>(cmdBuffer, previous_pass.mvo_count, current_pass.mvo_count - previous_pass.mvo_count, rendContext->global_param_mvo.data());
 
 		// Color subpass
 		cmdBuffer.nextSubpass(vk::SubpassContents::eInline);
@@ -447,7 +448,7 @@ bool OITDrawer::Draw(const Texture *fogTexture, const Texture *paletteTexture)
 		}
 
 		// Tr modifier volumes
-		if (GetContext()->GetVendorID() != VulkanContext::VENDOR_QUALCOMM)	// Adreno bug
+		if (GetContext()->useReversedDepth() && GetContext()->GetVendorID() != VulkanContext::VENDOR_QUALCOMM)	// Adreno bug
 		{
 			if (current_pass.mv_op_tr_shared)
 				DrawModifierVolumes<true>(cmdBuffer, previous_pass.mvo_count, current_pass.mvo_count - previous_pass.mvo_count, rendContext->global_param_mvo.data());
@@ -648,7 +649,7 @@ vk::CommandBuffer OITTextureDrawer::NewFrame()
 	framebuffer = device.createFramebufferUnique(vk::FramebufferCreateInfo(vk::FramebufferCreateFlags(),
 			rttPipelineManager->GetRenderPass(true, true), imageViews, widthPow2, heightPow2, 1));
 
-	commandBuffer.setViewport(0, vk::Viewport(0.0f, 0.0f, (float)upscaledWidth, (float)upscaledHeight, 1.0f, 0.0f));
+	commandBuffer.setViewport(0, GetContext()->makeViewport(0.0f, 0.0f, (float)upscaledWidth, (float)upscaledHeight));
 	u32 minX = rendContext->getFramebufferMinX() * upscaledWidth / origWidth;
 	u32 minY = rendContext->getFramebufferMinY() * upscaledHeight / origHeight;
 	getRenderToTextureDimensions(minX, minY, widthPow2, heightPow2);
@@ -724,7 +725,8 @@ vk::CommandBuffer OITScreenDrawer::NewFrame()
 	SetBaseScissor(viewport.extent);
 
 	currentCommandBuffer.setScissor(0, baseScissor);
-	currentCommandBuffer.setViewport(0, vk::Viewport((float)viewport.offset.x, (float)viewport.offset.y, (float)viewport.extent.width, (float)viewport.extent.height, 1.0f, 0.0f));
+	currentCommandBuffer.setViewport(0, GetContext()->makeViewport((float)viewport.offset.x, (float)viewport.offset.y,
+			(float)viewport.extent.width, (float)viewport.extent.height));
 
 	return currentCommandBuffer;
 }

--- a/core/rend/vulkan/oit/oit_pipeline.cpp
+++ b/core/rend/vulkan/oit/oit_pipeline.cpp
@@ -68,6 +68,8 @@ void OITPipelineManager::CreatePipeline(u32 listType, bool autosort, const PolyP
 		depthOp = vk::CompareOp::eGreaterOrEqual;
 	else
 		depthOp = depthOps[pp.isp.DepthMode];
+	if (!GetContext()->useReversedDepth())
+		depthOp = reverseDepthCompareOp(depthOp);
 	bool depthWriteEnable;
 	// Z Write Disable seems to be ignored for punch-through.
 	// Fixes Worms World Party, Bust-a-Move 4 and Re-Volt
@@ -87,10 +89,18 @@ void OITPipelineManager::CreatePipeline(u32 listType, bool autosort, const PolyP
 	}
 	else
 		stencilOpState = vk::StencilOpState(vk::StencilOp::eKeep, vk::StencilOp::eKeep, vk::StencilOp::eKeep, vk::CompareOp::eNever);
+	bool depthTestEnable = true;
+	if (!GetContext()->useReversedDepth())
+	{
+		depthTestEnable = pass == Pass::Depth
+				|| (pass == Pass::Color && listType != ListType_Translucent && listType != ListType_Punch_Through);
+		if (pass == Pass::OIT)
+			depthTestEnable = false;
+	}
 	vk::PipelineDepthStencilStateCreateInfo pipelineDepthStencilStateCreateInfo
 	(
 	  vk::PipelineDepthStencilStateCreateFlags(), // flags
-	  true,                                       // depthTestEnable
+	  depthTestEnable,                            // depthTestEnable
 	  depthWriteEnable,                           // depthWriteEnable
 	  depthOp,                                    // depthCompareOp
 	  false,                                      // depthBoundTestEnable
@@ -121,19 +131,40 @@ void OITPipelineManager::CreatePipeline(u32 listType, bool autosort, const PolyP
 	}
 	else
 	{
-		if (pass == Pass::Depth || pass == Pass::OIT)
-			colorComponentFlags = vk::ColorComponentFlags();
-		pipelineColorBlendAttachmentState =
+		if (GetContext()->useReversedDepth())
 		{
-		  false,                      // blendEnable
-		  vk::BlendFactor::eZero,     // srcColorBlendFactor
-		  vk::BlendFactor::eZero,     // dstColorBlendFactor
-		  vk::BlendOp::eAdd,          // colorBlendOp
-		  vk::BlendFactor::eZero,     // srcAlphaBlendFactor
-		  vk::BlendFactor::eZero,     // dstAlphaBlendFactor
-		  vk::BlendOp::eAdd,          // alphaBlendOp
-		  colorComponentFlags		  // colorWriteMask
-		};
+			if (pass == Pass::Depth || pass == Pass::OIT)
+				colorComponentFlags = vk::ColorComponentFlags();
+			pipelineColorBlendAttachmentState =
+			{
+			  false,                      // blendEnable
+			  vk::BlendFactor::eZero,     // srcColorBlendFactor
+			  vk::BlendFactor::eZero,     // dstColorBlendFactor
+			  vk::BlendOp::eAdd,          // colorBlendOp
+			  vk::BlendFactor::eZero,     // srcAlphaBlendFactor
+			  vk::BlendFactor::eZero,     // dstAlphaBlendFactor
+			  vk::BlendOp::eAdd,          // alphaBlendOp
+			  colorComponentFlags		  // colorWriteMask
+			};
+		}
+		else
+		{
+			if (pass == Pass::Depth)
+				colorComponentFlags = vk::ColorComponentFlags();
+			pipelineColorBlendAttachmentState =
+			{
+			  pass == Pass::OIT,                              // blendEnable
+			  vk::BlendFactor::eZero,                         // srcColorBlendFactor
+			  pass == Pass::OIT ? vk::BlendFactor::eOne
+							   : vk::BlendFactor::eZero,      // dstColorBlendFactor
+			  vk::BlendOp::eAdd,                              // colorBlendOp
+			  vk::BlendFactor::eZero,                         // srcAlphaBlendFactor
+			  pass == Pass::OIT ? vk::BlendFactor::eOne
+							   : vk::BlendFactor::eZero,      // dstAlphaBlendFactor
+			  vk::BlendOp::eAdd,                              // alphaBlendOp
+			  colorComponentFlags		                      // colorWriteMask
+			};
+		}
 	}
 
 	vk::PipelineColorBlendStateCreateInfo pipelineColorBlendStateCreateInfo
@@ -168,6 +199,7 @@ void OITPipelineManager::CreatePipeline(u32 listType, bool autosort, const PolyP
 	params.twoVolume = twoVolume;
 	params.palette = gpuPalette;
 	params.divPosZ = divPosZ;
+	params.reversedDepth = GetContext()->useReversedDepth();
 	vk::ShaderModule fragment_module = shaderManager->GetFragmentShader(params);
 
 	std::array<vk::PipelineShaderStageCreateInfo, 2> stages = {
@@ -253,7 +285,7 @@ void OITPipelineManager::CreateFinalPipeline(bool dithering)
 	vk::PipelineDynamicStateCreateInfo pipelineDynamicStateCreateInfo(vk::PipelineDynamicStateCreateFlags(), dynamicStates);
 
 	vk::ShaderModule vertex_module = shaderManager->GetFinalVertexShader();
-	vk::ShaderModule fragment_module = shaderManager->GetFinalShader(dithering);
+	vk::ShaderModule fragment_module = shaderManager->GetFinalShader(dithering, GetContext()->useReversedDepth());
 
 	std::array<vk::PipelineShaderStageCreateInfo, 2> stages = {
 			vk::PipelineShaderStageCreateInfo(vk::PipelineShaderStageCreateFlags(), vk::ShaderStageFlagBits::eVertex, vertex_module, "main"),
@@ -277,7 +309,8 @@ void OITPipelineManager::CreateFinalPipeline(bool dithering)
 	  2                                           // subpass
 	);
 
-	finalPipelines[dithering] = GetContext()->GetDevice().createGraphicsPipelineUnique(GetContext()->GetPipelineCache(), graphicsPipelineCreateInfo).value;
+	finalPipelines[dithering][GetContext()->useReversedDepth()] =
+			GetContext()->GetDevice().createGraphicsPipelineUnique(GetContext()->GetPipelineCache(), graphicsPipelineCreateInfo).value;
 }
 
 void OITPipelineManager::CreateClearPipeline()
@@ -326,7 +359,7 @@ void OITPipelineManager::CreateClearPipeline()
 	vk::PipelineDynamicStateCreateInfo pipelineDynamicStateCreateInfo(vk::PipelineDynamicStateCreateFlags(), dynamicStates);
 
 	vk::ShaderModule vertex_module = shaderManager->GetFinalVertexShader();
-	vk::ShaderModule fragment_module = shaderManager->GetClearShader();
+	vk::ShaderModule fragment_module = shaderManager->GetClearShader(GetContext()->useReversedDepth());
 
 	std::array<vk::PipelineShaderStageCreateInfo, 2> stages = {
 			vk::PipelineShaderStageCreateInfo(vk::PipelineShaderStageCreateFlags(), vk::ShaderStageFlagBits::eVertex, vertex_module, "main"),
@@ -350,7 +383,8 @@ void OITPipelineManager::CreateClearPipeline()
 	  1                                           // subpass
 	);
 
-	clearPipeline = GetContext()->GetDevice().createGraphicsPipelineUnique(GetContext()->GetPipelineCache(), graphicsPipelineCreateInfo).value;
+	clearPipelines[GetContext()->useReversedDepth()] =
+			GetContext()->GetDevice().createGraphicsPipelineUnique(GetContext()->GetPipelineCache(), graphicsPipelineCreateInfo).value;
 }
 
 void OITPipelineManager::CreateModVolPipeline(ModVolMode mode, int cullMode, bool naomi2)
@@ -414,7 +448,7 @@ void OITPipelineManager::CreateModVolPipeline(ModVolMode mode, int cullMode, boo
 	  vk::PipelineDepthStencilStateCreateFlags(), // flags
 	  mode == ModVolMode::Xor || mode == ModVolMode::Or, // depthTestEnable
 	  false,                                      // depthWriteEnable
-	  vk::CompareOp::eGreater,                    // depthCompareOp
+	  GetContext()->useReversedDepth() ? vk::CompareOp::eGreater : vk::CompareOp::eLess, // depthCompareOp
 	  false,                                      // depthBoundTestEnable
 	  true,                                       // stencilTestEnable
 	  stencilOpState,                             // front
@@ -437,7 +471,8 @@ void OITPipelineManager::CreateModVolPipeline(ModVolMode mode, int cullMode, boo
 	vk::PipelineDynamicStateCreateInfo pipelineDynamicStateCreateInfo(vk::PipelineDynamicStateCreateFlags(), dynamicStates);
 
 	vk::ShaderModule vertex_module = shaderManager->GetModVolVertexShader(OITShaderManager::ModVolShaderParams{ naomi2, !settings.platform.isNaomi2() && config::NativeDepthInterpolation });
-	vk::ShaderModule fragment_module = shaderManager->GetModVolShader(!settings.platform.isNaomi2() && config::NativeDepthInterpolation);
+	vk::ShaderModule fragment_module = shaderManager->GetModVolShader(!settings.platform.isNaomi2() && config::NativeDepthInterpolation,
+			GetContext()->useReversedDepth());
 
 	std::array<vk::PipelineShaderStageCreateInfo, 2> stages = {
 			vk::PipelineShaderStageCreateInfo(vk::PipelineShaderStageCreateFlags(), vk::ShaderStageFlagBits::eVertex, vertex_module, "main"),
@@ -522,7 +557,8 @@ void OITPipelineManager::CreateTrModVolPipeline(ModVolMode mode, int cullMode, b
 
 	bool divPosZ = !settings.platform.isNaomi2() && config::NativeDepthInterpolation;
 	vk::ShaderModule vertex_module = shaderManager->GetModVolVertexShader(OITShaderManager::ModVolShaderParams{ naomi2, divPosZ });
-	vk::ShaderModule fragment_module = shaderManager->GetTrModVolShader(OITShaderManager::TrModVolShaderParams{ mode, divPosZ });
+	vk::ShaderModule fragment_module = shaderManager->GetTrModVolShader(
+			OITShaderManager::TrModVolShaderParams{ mode, divPosZ, GetContext()->useReversedDepth() });
 
 	std::array<vk::PipelineShaderStageCreateInfo, 2> stages = {
 			vk::PipelineShaderStageCreateInfo(vk::PipelineShaderStageCreateFlags(), vk::ShaderStageFlagBits::eVertex, vertex_module, "main"),
@@ -558,7 +594,9 @@ void OITPipelineManager::checkMaxLayers()
 	{
 		maxLayers = layers;
 		trModVolPipelines.clear();
-		finalPipelines[0].reset();
-		finalPipelines[1].reset();
+		finalPipelines[0][0].reset();
+		finalPipelines[0][1].reset();
+		finalPipelines[1][0].reset();
+		finalPipelines[1][1].reset();
 	}
 }

--- a/core/rend/vulkan/oit/oit_pipeline.h
+++ b/core/rend/vulkan/oit/oit_pipeline.h
@@ -142,14 +142,18 @@ public:
 		getContext()->GetDevice().updateDescriptorSets(writeDescriptorSets, nullptr);
 	}
 
-	void updateColorInputDescSet(int index, vk::ImageView colorImageView)
+	void updateColorInputDescSet(int index, vk::ImageView colorImageView, vk::ImageView depthImageView)
 	{
 		colorInputDescSets[index] = colorInputAlloc.alloc();
 
 		vk::DescriptorImageInfo colorImageInfo(vk::Sampler(), colorImageView, vk::ImageLayout::eShaderReadOnlyOptimal);
-		vk::WriteDescriptorSet writeDescriptorSet(colorInputDescSets[index], 0, 0, vk::DescriptorType::eInputAttachment, colorImageInfo);
+		vk::DescriptorImageInfo depthImageInfo(vk::Sampler(), depthImageView, vk::ImageLayout::eDepthStencilReadOnlyOptimal);
+		std::array<vk::WriteDescriptorSet, 2> writeDescriptorSets = {
+			vk::WriteDescriptorSet(colorInputDescSets[index], 0, 0, vk::DescriptorType::eInputAttachment, colorImageInfo),
+			vk::WriteDescriptorSet(colorInputDescSets[index], 1, 0, vk::DescriptorType::eInputAttachment, depthImageInfo),
+		};
 
-		getContext()->GetDevice().updateDescriptorSets(writeDescriptorSet, nullptr);
+		getContext()->GetDevice().updateDescriptorSets(writeDescriptorSets, nullptr);
 	}
 
 	void bindPerPolyDescriptorSets(vk::CommandBuffer cmdBuffer, const PolyParam& poly, int polyNumber, vk::Buffer buffer,
@@ -295,9 +299,12 @@ public:
 			perFrameLayout = device.createDescriptorSetLayoutUnique(
 					vk::DescriptorSetLayoutCreateInfo(vk::DescriptorSetLayoutCreateFlags(), perFrameBindings));
 
-			vk::DescriptorSetLayoutBinding colorInputBinding(0, vk::DescriptorType::eInputAttachment, 1, vk::ShaderStageFlagBits::eFragment);		// color input attachment
+			std::array<vk::DescriptorSetLayoutBinding, 2> colorInputBindings = {
+				vk::DescriptorSetLayoutBinding(0, vk::DescriptorType::eInputAttachment, 1, vk::ShaderStageFlagBits::eFragment),		// color input attachment
+				vk::DescriptorSetLayoutBinding(1, vk::DescriptorType::eInputAttachment, 1, vk::ShaderStageFlagBits::eFragment),		// depth input attachment
+			};
 			colorInputLayout = device.createDescriptorSetLayoutUnique(
-					vk::DescriptorSetLayoutCreateInfo(vk::DescriptorSetLayoutCreateFlags(), colorInputBinding));
+					vk::DescriptorSetLayoutCreateInfo(vk::DescriptorSetLayoutCreateFlags(), colorInputBindings));
 
 			std::array<vk::DescriptorSetLayoutBinding, 4> perPolyBindings = {
 					vk::DescriptorSetLayoutBinding(0, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment),	// texture 0
@@ -321,9 +328,12 @@ public:
 		pipelines.clear();
 		modVolPipelines.clear();
 		trModVolPipelines.clear();
-		finalPipelines[0].reset();
-		finalPipelines[1].reset();
-		clearPipeline.reset();
+		finalPipelines[0][0].reset();
+		finalPipelines[0][1].reset();
+		finalPipelines[1][0].reset();
+		finalPipelines[1][1].reset();
+		clearPipelines[0].reset();
+		clearPipelines[1].reset();
 	}
 
 	vk::Pipeline GetPipeline(u32 listType, bool autosort, const PolyParam& pp, Pass pass, int gpuPalette)
@@ -362,15 +372,17 @@ public:
 	vk::Pipeline GetFinalPipeline(bool dithering)
 	{
 		checkMaxLayers();
-		if (!finalPipelines[dithering])
+		bool reversedDepth = GetContext()->useReversedDepth();
+		if (!finalPipelines[dithering][reversedDepth])
 			CreateFinalPipeline(dithering);
-		return *finalPipelines[dithering];
+		return *finalPipelines[dithering][reversedDepth];
 	}
 	vk::Pipeline GetClearPipeline()
 	{
-		if (!clearPipeline)
+		bool reversedDepth = GetContext()->useReversedDepth();
+		if (!clearPipelines[reversedDepth])
 			CreateClearPipeline();
-		return *clearPipeline;
+		return *clearPipelines[reversedDepth];
 	}
 	vk::PipelineLayout GetPipelineLayout() const { return *pipelineLayout; }
 	vk::DescriptorSetLayout GetPerFrameDSLayout() const { return *perFrameLayout; }
@@ -404,12 +416,15 @@ private:
 		hash |= ((u64)gpuPalette << 26) | ((u64)pass << 28) | ((u64)pp->isNaomi2() << 30);
 		hash |= (u64)(!settings.platform.isNaomi2() && config::NativeDepthInterpolation) << 31;
 		hash |= (u64)(pp->tcw.PixelFmt == PixelBumpMap) << 32;
+		hash |= (u64)GetContext()->useReversedDepth() << 34;
 
 		return hash;
 	}
 	u32 hash(ModVolMode mode, int cullMode, bool naomi2) const
 	{
-		return ((int)mode << 2) | cullMode | ((u32)naomi2 << 5) | ((u32)(!settings.platform.isNaomi2() && config::NativeDepthInterpolation) << 6);
+		return ((int)mode << 2) | cullMode | ((u32)naomi2 << 5)
+				| ((u32)(!settings.platform.isNaomi2() && config::NativeDepthInterpolation) << 6)
+				| ((u32)GetContext()->useReversedDepth() << 7);
 	}
 
 	vk::PipelineVertexInputStateCreateInfo GetMainVertexInputStateCreateInfo(bool full = true, bool naomi2 = false) const
@@ -467,8 +482,8 @@ private:
 	std::map<u64, vk::UniquePipeline> pipelines;
 	std::map<u32, vk::UniquePipeline> modVolPipelines;
 	std::map<u32, vk::UniquePipeline> trModVolPipelines;
-	vk::UniquePipeline finalPipelines[2];
-	vk::UniquePipeline clearPipeline;
+	vk::UniquePipeline finalPipelines[2][2];
+	vk::UniquePipeline clearPipelines[2];
 
 	vk::UniquePipelineLayout pipelineLayout;
 	vk::UniqueDescriptorSetLayout perFrameLayout;

--- a/core/rend/vulkan/oit/oit_renderpass.cpp
+++ b/core/rend/vulkan/oit/oit_renderpass.cpp
@@ -51,7 +51,10 @@ vk::UniqueRenderPass RenderPasses::MakeRenderPass(bool initial, bool last, bool 
 
     vk::AttachmentReference depthReadOnlyRef(2, vk::ImageLayout::eDepthStencilReadOnlyOptimal);
     vk::AttachmentReference depthReference2(3, vk::ImageLayout::eDepthStencilAttachmentOptimal);
-    vk::AttachmentReference colorInput(1, vk::ImageLayout::eShaderReadOnlyOptimal);
+    std::array<vk::AttachmentReference, 2> finalInputs = {
+		vk::AttachmentReference(1, vk::ImageLayout::eShaderReadOnlyOptimal),
+		vk::AttachmentReference(3, vk::ImageLayout::eDepthStencilReadOnlyOptimal),
+    };
 
     std::array<vk::SubpassDescription, 3> subpasses = {
     	// Depth and modvol pass	FIXME subpass 0 shouldn't reference the color attachment
@@ -68,7 +71,7 @@ vk::UniqueRenderPass RenderPasses::MakeRenderPass(bool initial, bool last, bool 
 				&depthReference2),
     	// Final pass
     	vk::SubpassDescription(vk::SubpassDescriptionFlags(), vk::PipelineBindPoint::eGraphics,
-    			colorInput,
+			finalInputs,
 				swapChainReference,
 				nullptr,
 				&depthReference),	// depth-only Tr pass when continuation
@@ -82,6 +85,10 @@ vk::UniqueRenderPass RenderPasses::MakeRenderPass(bool initial, bool last, bool 
 			vk::AccessFlagBits::eInputAttachmentRead | vk::AccessFlagBits::eShaderRead, vk::DependencyFlagBits::eByRegion);
     dependencies.emplace_back(1, 2, vk::PipelineStageFlagBits::eColorAttachmentOutput, vk::PipelineStageFlagBits::eFragmentShader,
     		vk::AccessFlagBits::eColorAttachmentWrite, vk::AccessFlagBits::eInputAttachmentRead, vk::DependencyFlagBits::eByRegion);
+    dependencies.emplace_back(1, 2, vk::PipelineStageFlagBits::eLateFragmentTests, vk::PipelineStageFlagBits::eFragmentShader,
+			vk::AccessFlagBits::eDepthStencilAttachmentWrite,
+			vk::AccessFlagBits::eInputAttachmentRead | vk::AccessFlagBits::eShaderRead,
+			vk::DependencyFlagBits::eByRegion);
     // This dependency is only needed if the render pass isn't the last: it's needed for the depth-only Tr pass
     // Unfortunately we want all render passes to be compatible, and that means all attachments must be identical
     dependencies.emplace_back(1, 2, vk::PipelineStageFlagBits::eFragmentShader,

--- a/core/rend/vulkan/oit/oit_shaders.cpp
+++ b/core/rend/vulkan/oit/oit_shaders.cpp
@@ -20,6 +20,7 @@
 */
 #include "oit_shaders.h"
 #include "../compiler.h"
+#include "../vulkan_context.h"
 #include "rend/gl4/glsl.h"
 #include "cfg/option.h"
 
@@ -120,9 +121,11 @@ uint getNextPixelIndex()
 	// we should be able to simply use PixelBuffer.pixels.length()
 	// but a regression in the adreno 600 driver (v502) forces us
 	// to use a uniform.
+#if REVERSED_DEPTH == 1
 	if (index >= uniformBuffer.pixelBufferSize)
 		// Buffer overflow
 		discard;
+#endif
 	
 	return index;
 }
@@ -138,7 +141,7 @@ static const char OITFragmentShaderTop[] = R"(
 #define PASS_COLOR 1
 #define PASS_OIT 2
 
-#if PASS == PASS_DEPTH || PASS == PASS_COLOR
+#if PASS == PASS_DEPTH || PASS == PASS_COLOR || (PASS == PASS_OIT && REVERSED_DEPTH == 0)
 layout (location = 0) out vec4 FragColor;
 #define gl_FragColor FragColor
 #endif
@@ -181,7 +184,7 @@ layout (set = 0, binding = 6) uniform sampler2D palette;
 #if PASS == PASS_COLOR
 layout (input_attachment_index = 0, set = 0, binding = 4) uniform usubpassInput shadow_stencil;
 #endif
-#if PASS == PASS_OIT
+#if PASS == PASS_OIT && REVERSED_DEPTH == 1
 layout (input_attachment_index = 0, set = 0, binding = 5) uniform subpassInput DepthTex;
 #endif
 
@@ -202,9 +205,12 @@ layout (set = 0, binding = 2) uniform sampler2D fog_table;
 static const char OITFragmentShaderMain[] = R"(
 void main()
 {
+#if PASS != PASS_OIT || REVERSED_DEPTH == 1
 	setFragDepth(vtx_uv.z);
+#endif
+	float oitDepth = computeFragDepth(vtx_uv.z);
 
-	#if PASS == PASS_OIT
+	#if PASS == PASS_OIT && REVERSED_DEPTH == 1
 		// Manual depth testing
 		float frontDepth = subpassLoad(DepthTex).r;
 		if (gl_FragDepth < frontDepth)
@@ -360,12 +366,25 @@ void main()
 		ivec2 coords = ivec2(gl_FragCoord.xy);
 		uint idx =  getNextPixelIndex();
 		
+#if REVERSED_DEPTH == 1
 		Pixel pixel;
 		pixel.color = packColors(clamp(color, vec4(0.0), vec4(1.0)));
 		pixel.depth = gl_FragDepth;
 		pixel.seq_num = vtx_index;
 		pixel.next = atomicExchange(abufferPointer.pointers[coords.x + coords.y * uniformBuffer.viewportWidth], idx);
 		PixelBuffer.pixels[idx] = pixel;
+#else
+		if (idx < uniformBuffer.pixelBufferSize)
+		{
+			Pixel pixel;
+			pixel.color = packColors(clamp(color, vec4(0.0), vec4(1.0)));
+			pixel.depth = oitDepth;
+			pixel.seq_num = vtx_index;
+			pixel.next = atomicExchange(abufferPointer.pointers[coords.x + coords.y * uniformBuffer.viewportWidth], idx);
+			PixelBuffer.pixels[idx] = pixel;
+		}
+		FragColor = vec4(0.0);
+#endif
 		
 	#endif
 }
@@ -382,6 +401,9 @@ void main()
 
 static const char OITFinalShaderSource[] = R"(
 layout (input_attachment_index = 0, set = 2, binding = 0) uniform subpassInput tex;
+#if REVERSED_DEPTH == 0
+layout (input_attachment_index = 1, set = 2, binding = 1) uniform subpassInput DepthTex;
+#endif
 
 layout (location = 0) out vec4 FragColor;
 
@@ -390,6 +412,9 @@ uint pixel_list[MAX_PIXELS_PER_FRAGMENT];
 
 int fillAndSortFragmentArray(ivec2 coords)
 {
+#if REVERSED_DEPTH == 0
+	const float depthTieEpsilon = 2e-6;
+#endif
 	// Load fragments into a local memory array for sorting
 	uint idx = abufferPointer.pointers[coords.x + coords.y * uniformBuffer.viewportWidth];
 	if (idx == EOL)
@@ -405,8 +430,13 @@ int fillAndSortFragmentArray(ivec2 coords)
 		float jdepth = PixelBuffer.pixels[pixel_list[j]].depth;
 		uint jindex = getPolyIndex(PixelBuffer.pixels[pixel_list[j]]);
 		while (j >= 0
-			   && (jdepth > depth
-				   || (jdepth == depth && jindex > index)))
+			   && (
+#if REVERSED_DEPTH == 1
+				   jdepth > depth || (jdepth == depth && jindex > index)
+#else
+				   jdepth > depth + depthTieEpsilon || (abs(jdepth - depth) <= depthTieEpsilon && jindex < index)
+#endif
+			   ))
 		{
 			pixel_list[j + 1] = pixel_list[j];
 			j--;
@@ -429,11 +459,23 @@ vec4 resolveAlphaBlend(ivec2 coords) {
 	int num_frag = fillAndSortFragmentArray(coords);
 	
 	vec4 finalColor = subpassLoad(tex);
+#if REVERSED_DEPTH == 0
+	const float frontDepthEpsilon = 2e-6;
+	float frontDepth = subpassLoad(DepthTex).r;
+#endif
 	vec4 secondaryBuffer = vec4(0.0); // Secondary accumulation buffer
 	
+#if REVERSED_DEPTH == 1
 	for (int i = 0; i < num_frag; i++)
+#else
+	for (int i = num_frag - 1; i >= 0; i--)
+#endif
 	{
 		const Pixel pixel = PixelBuffer.pixels[pixel_list[i]];
+#if REVERSED_DEPTH == 0
+		if (pixel.depth > frontDepth + frontDepthEpsilon)
+			continue;
+#endif
 		const PolyParam pp = TrPolyParam.tr_poly_params[getPolyNumber(pixel)];
 		bool area1 = false;
 		bool shadowed = false;
@@ -757,6 +799,7 @@ vk::UniqueShaderModule OITShaderManager::compileShader(const FragmentShaderParam
 		.addConstant("ColorClamping", (int)params.clamping)
 		.addConstant("pp_Palette", params.palette)
 		.addConstant("DIV_POS_Z", (int)params.divPosZ)
+		.addConstant("REVERSED_DEPTH", (int)params.reversedDepth)
 		.addConstant("PASS", (int)params.pass)
 		.addSource(GouraudSource)
 		.addSource(OITShaderHeader)
@@ -766,11 +809,12 @@ vk::UniqueShaderModule OITShaderManager::compileShader(const FragmentShaderParam
 	return ShaderCompiler::Compile(vk::ShaderStageFlagBits::eFragment, src.generate());
 }
 
-vk::UniqueShaderModule OITShaderManager::compileFinalShader(bool dithering)
+vk::UniqueShaderModule OITShaderManager::compileFinalShader(bool dithering, bool reversedDepth)
 {
 	VulkanSource src;
 	src.addConstant("MAX_PIXELS_PER_FRAGMENT", maxLayers)
 		.addConstant("DITHERING", dithering)
+		.addConstant("REVERSED_DEPTH", (int)reversedDepth)
 		.addSource(OITShaderHeader)
 		.addSource(OITFinalShaderSource);
 
@@ -781,10 +825,11 @@ vk::UniqueShaderModule OITShaderManager::compileFinalVertexShader()
 	return ShaderCompiler::Compile(vk::ShaderStageFlagBits::eVertex, VulkanSource().addSource(OITFinalVertexShaderSource).generate());
 }
 
-vk::UniqueShaderModule OITShaderManager::compileClearShader()
+vk::UniqueShaderModule OITShaderManager::compileClearShader(bool reversedDepth)
 {
 	VulkanSource src;
-	src.addSource(OITShaderHeader)
+	src.addConstant("REVERSED_DEPTH", (int)reversedDepth)
+		.addSource(OITShaderHeader)
 		.addSource(OITClearShaderSource);
 	return ShaderCompiler::Compile(vk::ShaderStageFlagBits::eFragment, src.generate());
 }
@@ -799,10 +844,11 @@ vk::UniqueShaderModule OITShaderManager::compileShader(const ModVolShaderParams&
 			.addSource(ModVolVertexShaderSource);
 	return ShaderCompiler::Compile(vk::ShaderStageFlagBits::eVertex, src.generate());
 }
-vk::UniqueShaderModule OITShaderManager::compileModVolFragmentShader(bool divPosZ)
+vk::UniqueShaderModule OITShaderManager::compileModVolFragmentShader(bool divPosZ, bool reversedDepth)
 {
 	VulkanSource src;
 	src.addConstant("DIV_POS_Z", (int)divPosZ)
+		.addConstant("REVERSED_DEPTH", (int)reversedDepth)
 		.addSource(OITShaderHeader)
 		.addSource(OITModifierVolumeShader);
 	return ShaderCompiler::Compile(vk::ShaderStageFlagBits::eFragment, src.generate());
@@ -813,6 +859,7 @@ vk::UniqueShaderModule OITShaderManager::compileShader(const TrModVolShaderParam
 	src.addConstant("MAX_PIXELS_PER_FRAGMENT", maxLayers)
 		.addConstant("MV_MODE", (int)params.mode)
 		.addConstant("DIV_POS_Z", (int)params.divPosZ)
+		.addConstant("REVERSED_DEPTH", (int)params.reversedDepth)
 		.addSource(OITShaderHeader)
 		.addSource(OITTranslucentModvolShaderSource);
 	return ShaderCompiler::Compile(vk::ShaderStageFlagBits::eFragment, src.generate());
@@ -825,7 +872,9 @@ void OITShaderManager::checkMaxLayers()
 	{
 		maxLayers = layers;
 		trModVolShaders.clear();
-		finalFragmentShaders[0].reset();
-		finalFragmentShaders[1].reset();
+		finalFragmentShaders[0][0].reset();
+		finalFragmentShaders[0][1].reset();
+		finalFragmentShaders[1][0].reset();
+		finalFragmentShaders[1][1].reset();
 	}
 }

--- a/core/rend/vulkan/oit/oit_shaders.h
+++ b/core/rend/vulkan/oit/oit_shaders.h
@@ -60,6 +60,7 @@ public:
 		bool twoVolume;
 		int palette;
 		bool divPosZ;
+		bool reversedDepth;
 		Pass pass;
 
 		u32 hash()
@@ -68,7 +69,8 @@ public:
 				| ((u32)texture << 3) | ((u32)ignoreTexAlpha << 4) | (shaderInstr << 5)
 				| ((u32)offset << 7) | ((u32)fog << 8) | ((u32)gouraud << 10)
 				| ((u32)bumpmap << 11) | ((u32)clamping << 12) | ((u32)twoVolume << 13)
-				| ((u32)palette << 14) | ((int)pass << 16) | ((u32)divPosZ << 18);
+				| ((u32)palette << 14) | ((int)pass << 16) | ((u32)divPosZ << 18)
+				| ((u32)reversedDepth << 19);
 		}
 	};
 
@@ -84,19 +86,20 @@ public:
 	{
 		ModVolMode mode;
 		bool divPosZ;
+		bool reversedDepth;
 
-		u32 hash() { return (u32)mode | ((u32)divPosZ << 3); }
+		u32 hash() { return (u32)mode | ((u32)divPosZ << 3) | ((u32)reversedDepth << 4); }
 	};
 
 	vk::ShaderModule GetVertexShader(const VertexShaderParams& params) { return getShader(vertexShaders, params); }
 	vk::ShaderModule GetFragmentShader(const FragmentShaderParams& params) { return getShader(fragmentShaders, params); }
 	vk::ShaderModule GetModVolVertexShader(const ModVolShaderParams& params) { return getShader(modVolVertexShaders, params); }
 
-	vk::ShaderModule GetModVolShader(bool divPosZ)
+	vk::ShaderModule GetModVolShader(bool divPosZ, bool reversedDepth)
 	{
-		auto& modVolShader = modVolShaders[divPosZ];
+		auto& modVolShader = modVolShaders[divPosZ][reversedDepth];
 		if (!modVolShader)
-			modVolShader = compileModVolFragmentShader(divPosZ);
+			modVolShader = compileModVolFragmentShader(divPosZ, reversedDepth);
 		return *modVolShader;
 	}
 
@@ -105,12 +108,12 @@ public:
 		return getShader(trModVolShaders, params);
 	}
 
-	vk::ShaderModule GetFinalShader(bool dithering)
+	vk::ShaderModule GetFinalShader(bool dithering, bool reversedDepth)
 	{
 		checkMaxLayers();
-		if (!finalFragmentShaders[dithering])
-			finalFragmentShaders[dithering] = compileFinalShader(dithering);
-		return *finalFragmentShaders[dithering];
+		if (!finalFragmentShaders[dithering][reversedDepth])
+			finalFragmentShaders[dithering][reversedDepth] = compileFinalShader(dithering, reversedDepth);
+		return *finalFragmentShaders[dithering][reversedDepth];
 	}
 
 	vk::ShaderModule GetFinalVertexShader()
@@ -119,11 +122,11 @@ public:
 			finalVertexShader = compileFinalVertexShader();
 		return *finalVertexShader;
 	}
-	vk::ShaderModule GetClearShader()
+	vk::ShaderModule GetClearShader(bool reversedDepth)
 	{
-		if (!clearShader)
-			clearShader = compileClearShader();
-		return *clearShader;
+		if (!clearShaders[reversedDepth])
+			clearShaders[reversedDepth] = compileClearShader(reversedDepth);
+		return *clearShaders[reversedDepth];
 	}
 
 	void term()
@@ -131,14 +134,19 @@ public:
 		vertexShaders.clear();
 		fragmentShaders.clear();
 		modVolVertexShaders.clear();
-		modVolShaders[0].reset();
-		modVolShaders[1].reset();
+		modVolShaders[0][0].reset();
+		modVolShaders[0][1].reset();
+		modVolShaders[1][0].reset();
+		modVolShaders[1][1].reset();
 		trModVolShaders.clear();
 
 		finalVertexShader.reset();
-		finalFragmentShaders[0].reset();
-		finalFragmentShaders[1].reset();
-		clearShader.reset();
+		finalFragmentShaders[0][0].reset();
+		finalFragmentShaders[0][1].reset();
+		finalFragmentShaders[1][0].reset();
+		finalFragmentShaders[1][1].reset();
+		clearShaders[0].reset();
+		clearShaders[1].reset();
 	}
 
 private:
@@ -155,22 +163,22 @@ private:
 	vk::UniqueShaderModule compileShader(const VertexShaderParams& params);
 	vk::UniqueShaderModule compileShader(const FragmentShaderParams& params);
 	vk::UniqueShaderModule compileShader(const ModVolShaderParams& params);
-	vk::UniqueShaderModule compileModVolFragmentShader(bool divPosZ);
+	vk::UniqueShaderModule compileModVolFragmentShader(bool divPosZ, bool reversedDepth);
 	vk::UniqueShaderModule compileShader(const TrModVolShaderParams& params);
-	vk::UniqueShaderModule compileFinalShader(bool dithering);
+	vk::UniqueShaderModule compileFinalShader(bool dithering, bool reversedDepth);
 	vk::UniqueShaderModule compileFinalVertexShader();
-	vk::UniqueShaderModule compileClearShader();
+	vk::UniqueShaderModule compileClearShader(bool reversedDepth);
 	void checkMaxLayers();
 
 	std::map<u32, vk::UniqueShaderModule> vertexShaders;
 	std::map<u32, vk::UniqueShaderModule> fragmentShaders;
 	std::map<u32, vk::UniqueShaderModule> modVolVertexShaders;
-	vk::UniqueShaderModule modVolShaders[2];
+	vk::UniqueShaderModule modVolShaders[2][2];
 	std::map<u32, vk::UniqueShaderModule> trModVolShaders;
 
 	vk::UniqueShaderModule finalVertexShader;
-	vk::UniqueShaderModule finalFragmentShaders[2];
-	vk::UniqueShaderModule clearShader;
+	vk::UniqueShaderModule finalFragmentShaders[2][2];
+	vk::UniqueShaderModule clearShaders[2];
 	int maxLayers = 0;
 };
 

--- a/core/rend/vulkan/pipeline.cpp
+++ b/core/rend/vulkan/pipeline.cpp
@@ -93,7 +93,7 @@ void PipelineManager::CreateModVolPipeline(ModVolMode mode, int cullMode, bool n
 	  vk::PipelineDepthStencilStateCreateFlags(), // flags
 	  mode == ModVolMode::Xor || mode == ModVolMode::Or, // depthTestEnable
 	  false,                                      // depthWriteEnable
-	  vk::CompareOp::eGreater,                    // depthCompareOp
+	  GetContext()->useReversedDepth() ? vk::CompareOp::eGreater : vk::CompareOp::eLess, // depthCompareOp
 	  false,                                      // depthBoundTestEnable
 	  true,                                       // stencilTestEnable
 	  stencilOpState,                             // front
@@ -129,7 +129,8 @@ void PipelineManager::CreateModVolPipeline(ModVolMode mode, int cullMode, bool n
 
 	ModVolShaderParams shaderParams { naomi2, !settings.platform.isNaomi2() && config::NativeDepthInterpolation };
 	vk::ShaderModule vertex_module = shaderManager->GetModVolVertexShader(shaderParams);
-	vk::ShaderModule fragment_module = shaderManager->GetModVolShader(!settings.platform.isNaomi2() && config::NativeDepthInterpolation);
+	vk::ShaderModule fragment_module = shaderManager->GetModVolShader(!settings.platform.isNaomi2() && config::NativeDepthInterpolation,
+			GetContext()->useReversedDepth());
 
 	std::array<vk::PipelineShaderStageCreateInfo, 2> stages = {
 			vk::PipelineShaderStageCreateInfo(vk::PipelineShaderStageCreateFlags(), vk::ShaderStageFlagBits::eVertex, vertex_module, "main"),
@@ -208,7 +209,7 @@ void PipelineManager::CreateDepthPassPipeline(int cullMode, bool naomi2)
 	  vk::PipelineDepthStencilStateCreateFlags(), // flags
 	  true,                                       // depthTestEnable
 	  true,                                       // depthWriteEnable
-	  vk::CompareOp::eGreaterOrEqual,             // depthCompareOp
+	  GetContext()->useReversedDepth() ? vk::CompareOp::eGreaterOrEqual : vk::CompareOp::eLessOrEqual, // depthCompareOp
 	  false,                                      // depthBoundTestEnable
 	  false,                                      // stencilTestEnable
 	  stencilOpState,                             // front
@@ -242,7 +243,8 @@ void PipelineManager::CreateDepthPassPipeline(int cullMode, bool naomi2)
 
 	ModVolShaderParams shaderParams { naomi2, !settings.platform.isNaomi2() && config::NativeDepthInterpolation };
 	vk::ShaderModule vertex_module = shaderManager->GetModVolVertexShader(shaderParams);
-	vk::ShaderModule fragment_module = shaderManager->GetModVolShader(!settings.platform.isNaomi2() && config::NativeDepthInterpolation);
+	vk::ShaderModule fragment_module = shaderManager->GetModVolShader(!settings.platform.isNaomi2() && config::NativeDepthInterpolation,
+			GetContext()->useReversedDepth());
 
 	std::array<vk::PipelineShaderStageCreateInfo, 2> stages = {
 			vk::PipelineShaderStageCreateInfo(vk::PipelineShaderStageCreateFlags(), vk::ShaderStageFlagBits::eVertex, vertex_module, "main"),
@@ -324,6 +326,8 @@ void PipelineManager::CreatePipeline(u32 listType, bool sortTriangles, const Pol
 		depthOp = vk::CompareOp::eGreaterOrEqual;
 	else
 		depthOp = depthOps[pp.isp.DepthMode];
+	if (!GetContext()->useReversedDepth())
+		depthOp = reverseDepthCompareOp(depthOp);
 	bool depthWriteEnable;
 	if (sortTriangles /* && !config::PerStripSorting */)
 		// FIXME temporary work-around for intel driver bug
@@ -409,6 +413,7 @@ void PipelineManager::CreatePipeline(u32 listType, bool sortTriangles, const Pol
 	params.palette = gpuPalette;
 	params.divPosZ = divPosZ;
 	params.dithering = dithering;
+	params.reversedDepth = GetContext()->useReversedDepth();
 	vk::ShaderModule fragment_module = shaderManager->GetFragmentShader(params);
 
 	std::array<vk::PipelineShaderStageCreateInfo, 2> stages = {

--- a/core/rend/vulkan/pipeline.h
+++ b/core/rend/vulkan/pipeline.h
@@ -249,6 +249,7 @@ public:
 	{
 		pipelines.clear();
 		modVolPipelines.clear();
+		depthPassPipelines.clear();
 	}
 
 	vk::PipelineLayout GetPipelineLayout() const { return *pipelineLayout; }
@@ -274,16 +275,21 @@ private:
 		hash |= (u64)(!settings.platform.isNaomi2() && config::NativeDepthInterpolation) << 30;
 		hash |= (u64)(pp->tcw.PixelFmt == PixelBumpMap) << 31;
 		hash |= (u64)dithering << 32;
+		hash |= (u64)GetContext()->useReversedDepth() << 33;
 
 		return hash;
 	}
 	u32 hash(ModVolMode mode, int cullMode, bool naomi2) const
 	{
-		return ((int)mode << 2) | cullMode | ((int)naomi2 << 5) | ((int)(!settings.platform.isNaomi2() && config::NativeDepthInterpolation) << 6);
+		return ((int)mode << 2) | cullMode | ((int)naomi2 << 5)
+				| ((int)(!settings.platform.isNaomi2() && config::NativeDepthInterpolation) << 6)
+				| ((u32)GetContext()->useReversedDepth() << 7);
 	}
 	u32 hash(int cullMode, bool naomi2) const
 	{
-		return cullMode | ((int)naomi2 << 2) | ((int)(!settings.platform.isNaomi2() && config::NativeDepthInterpolation) << 3);
+		return cullMode | ((int)naomi2 << 2)
+				| ((int)(!settings.platform.isNaomi2() && config::NativeDepthInterpolation) << 3)
+				| ((u32)GetContext()->useReversedDepth() << 4);
 	}
 
 	vk::PipelineVertexInputStateCreateInfo GetMainVertexInputStateCreateInfo(bool full = true, bool naomi2 = false) const

--- a/core/rend/vulkan/shaders.cpp
+++ b/core/rend/vulkan/shaders.cpp
@@ -22,6 +22,7 @@
 #include "shaders.h"
 #include "compiler.h"
 #include "utils.h"
+#include "vulkan_context.h"
 
 static const char VertexShaderSource[] = R"(
 layout (std140, set = 0, binding = 0) uniform VertexShaderUniforms
@@ -290,7 +291,12 @@ void main()
 #else
 	highp float w = 100000.0 * vtx_uv.z;
 #endif
-	gl_FragDepth = log2(1.0 + max(w, -0.999999)) / 34.0;
+	highp float depth = log2(1.0 + max(w, -0.999999)) / 34.0;
+#if REVERSED_DEPTH == 1
+	gl_FragDepth = depth;
+#else
+	gl_FragDepth = 1.0 - depth;
+#endif
 
 #if DITHERING == 1
 	float ditherTable[16] = float[](
@@ -348,7 +354,12 @@ void main()
 #else
 	highp float w = 100000.0 * depth;
 #endif
-	gl_FragDepth = log2(1.0 + max(w, -0.999999)) / 34.0;
+	highp float fragDepth = log2(1.0 + max(w, -0.999999)) / 34.0;
+#if REVERSED_DEPTH == 1
+	gl_FragDepth = fragDepth;
+#else
+	gl_FragDepth = 1.0 - fragDepth;
+#endif
 	FragColor = vec4(0.0, 0.0, 0.0, pushConstants.sp_ShaderColor);
 }
 )";
@@ -761,6 +772,7 @@ vk::UniqueShaderModule ShaderManager::compileShader(const FragmentShaderParams& 
 		.addConstant("pp_Palette", params.palette)
 		.addConstant("DIV_POS_Z", (int)params.divPosZ)
 		.addConstant("DITHERING", (int)params.dithering)
+		.addConstant("REVERSED_DEPTH", (int)params.reversedDepth)
 		.addSource(GouraudSource)
 		.addSource(FragmentShaderTop)
 		.addSource(FragmentShaderCommon)
@@ -775,10 +787,11 @@ vk::UniqueShaderModule ShaderManager::compileShader(const ModVolShaderParams& pa
 				.addSource(params.naomi2 ? N2ModVolVertexShaderSource : ModVolVertexShaderSource).generate());
 }
 
-vk::UniqueShaderModule ShaderManager::compileModVolFragmentShader(bool divPosZ)
+vk::UniqueShaderModule ShaderManager::compileModVolFragmentShader(bool divPosZ, bool reversedDepth)
 {
 	return ShaderCompiler::Compile(vk::ShaderStageFlagBits::eFragment,
 			VulkanSource().addConstant("DIV_POS_Z", (int)divPosZ)
+				.addConstant("REVERSED_DEPTH", (int)reversedDepth)
 				.addSource(ModVolFragmentShaderSource).generate());
 }
 

--- a/core/rend/vulkan/shaders.h
+++ b/core/rend/vulkan/shaders.h
@@ -52,6 +52,7 @@ struct FragmentShaderParams
 	int palette;
 	bool divPosZ;
 	bool dithering;
+	bool reversedDepth;
 
 	u32 hash()
 	{
@@ -59,7 +60,8 @@ struct FragmentShaderParams
 			| ((u32)texture << 3) | ((u32)ignoreTexAlpha << 4) | (shaderInstr << 5)
 			| ((u32)offset << 7) | ((u32)fog << 8) | ((u32)gouraud << 10)
 			| ((u32)bumpmap << 11) | ((u32)clamping << 12) | ((u32)trilinear << 13)
-			| ((u32)palette << 14) | ((u32)divPosZ << 16) | ((u32)dithering << 17);
+			| ((u32)palette << 14) | ((u32)divPosZ << 16) | ((u32)dithering << 17)
+			| ((u32)reversedDepth << 18);
 	}
 };
 
@@ -110,11 +112,11 @@ public:
 	vk::ShaderModule GetFragmentShader(const FragmentShaderParams& params) { return getShader(fragmentShaders, params); }
 	vk::ShaderModule GetModVolVertexShader(const ModVolShaderParams& params) { return getShader(modVolVertexShaders, params); }
 
-	vk::ShaderModule GetModVolShader(bool divPosZ)
+	vk::ShaderModule GetModVolShader(bool divPosZ, bool reversedDepth)
 	{
-		auto& modVolShader = modVolShaders[divPosZ];
+		auto& modVolShader = modVolShaders[divPosZ][reversedDepth];
 		if (!modVolShader)
-			modVolShader = compileModVolFragmentShader(divPosZ);
+			modVolShader = compileModVolFragmentShader(divPosZ, reversedDepth);
 		return *modVolShader;
 	}
 	vk::ShaderModule GetQuadVertexShader(bool rotate = false)
@@ -153,8 +155,10 @@ public:
 		vertexShaders.clear();
 		fragmentShaders.clear();
 		modVolVertexShaders.clear();
-		modVolShaders[0].reset();
-		modVolShaders[1].reset();
+		modVolShaders[0][0].reset();
+		modVolShaders[0][1].reset();
+		modVolShaders[1][0].reset();
+		modVolShaders[1][1].reset();
 		quadVertexShader.reset();
 		quadRotateVertexShader.reset();
 		quadFragmentShader.reset();
@@ -175,14 +179,14 @@ private:
 	vk::UniqueShaderModule compileShader(const VertexShaderParams& params);
 	vk::UniqueShaderModule compileShader(const FragmentShaderParams& params);
 	vk::UniqueShaderModule compileShader(const ModVolShaderParams& params);
-	vk::UniqueShaderModule compileModVolFragmentShader(bool divPosZ);
+	vk::UniqueShaderModule compileModVolFragmentShader(bool divPosZ, bool reversedDepth);
 	vk::UniqueShaderModule compileQuadVertexShader(bool rotate);
 	vk::UniqueShaderModule compileQuadFragmentShader(bool ignoreTexAlpha);
 
 	std::map<u32, vk::UniqueShaderModule> vertexShaders;
 	std::map<u32, vk::UniqueShaderModule> fragmentShaders;
 	std::map<u32, vk::UniqueShaderModule> modVolVertexShaders;
-	vk::UniqueShaderModule modVolShaders[2];
+	vk::UniqueShaderModule modVolShaders[2][2];
 	vk::UniqueShaderModule quadVertexShader;
 	vk::UniqueShaderModule quadRotateVertexShader;
 	vk::UniqueShaderModule quadFragmentShader;

--- a/core/rend/vulkan/utils.h
+++ b/core/rend/vulkan/utils.h
@@ -37,6 +37,23 @@ static const vk::CompareOp depthOps[] =
 	vk::CompareOp::eAlways,         //7 Always
 };
 
+static inline vk::CompareOp reverseDepthCompareOp(vk::CompareOp op)
+{
+	switch (op)
+	{
+	case vk::CompareOp::eLess:
+		return vk::CompareOp::eGreater;
+	case vk::CompareOp::eLessOrEqual:
+		return vk::CompareOp::eGreaterOrEqual;
+	case vk::CompareOp::eGreater:
+		return vk::CompareOp::eLess;
+	case vk::CompareOp::eGreaterOrEqual:
+		return vk::CompareOp::eLessOrEqual;
+	default:
+		return op;
+	}
+}
+
 static inline vk::BlendFactor getBlendFactor(u32 instr, bool src)
 {
 	switch (instr) {

--- a/core/rend/vulkan/vk_context_lr.cpp
+++ b/core/rend/vulkan/vk_context_lr.cpp
@@ -21,6 +21,7 @@
 #include "vulkan_context.h"
 #include "hw/pvr/Renderer_if.h"
 #include "compiler.h"
+#include "cfg/option.h"
 #include "oslib/oslib.h"
 #include "rend/transform_matrix.h"
 #include "texture.h"
@@ -31,6 +32,23 @@ VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 #endif
 
 VulkanContext *VulkanContext::contextInstance;
+
+bool VulkanContext::useReversedDepth() const
+{
+	return !config::NonReversedDepth;
+}
+
+float VulkanContext::getDepthClearValue() const
+{
+	return useReversedDepth() ? 0.f : 1.f;
+}
+
+vk::Viewport VulkanContext::makeViewport(float x, float y, float viewportWidth, float viewportHeight) const
+{
+	return vk::Viewport(x, y, viewportWidth, viewportHeight,
+			useReversedDepth() ? 1.0f : 0.0f,
+			useReversedDepth() ? 0.0f : 1.0f);
+}
 
 const VkApplicationInfo* VkGetApplicationInfo()
 {

--- a/core/rend/vulkan/vk_context_lr.h
+++ b/core/rend/vulkan/vk_context_lr.h
@@ -93,6 +93,9 @@ public:
 	bool SupportsDedicatedAllocation() const { return dedicatedAllocationSupported; }
 	bool hasPerPixel() override { return fragmentStoresAndAtomics; }
 	bool hasProvokingVertex() { return provokingVertexSupported; }
+	bool useReversedDepth() const;
+	float getDepthClearValue() const;
+	vk::Viewport makeViewport(float x, float y, float width, float height) const;
 	const VMAllocator& GetAllocator() const { return allocator; }
 	vk::DeviceSize GetMaxMemoryAllocationSize() const { return maxMemoryAllocationSize; }
 	f32 GetMaxSamplerAnisotropy() const { return samplerAnisotropy ? maxSamplerAnisotropy : 1.f; }

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -30,6 +30,7 @@
 #include "compiler.h"
 #include "utils.h"
 #include "emulator.h"
+#include "cfg/option.h"
 #include "oslib/oslib.h"
 #include "vulkan_driver.h"
 #include "rend/transform_matrix.h"
@@ -942,7 +943,7 @@ void VulkanContext::BeginRenderPass()
 {
 	if (!IsValid())
 		return;
-	const std::array<vk::ClearValue, 2> clear_colors = { getBorderColor(), vk::ClearDepthStencilValue{ 0.f, 0 } };
+	const std::array<vk::ClearValue, 2> clear_colors = { getBorderColor(), vk::ClearDepthStencilValue{ getDepthClearValue(), 0 } };
 	vk::CommandBuffer commandBuffer = *commandBuffers[currentImage];
 	commandBuffer.beginRenderPass(vk::RenderPassBeginInfo(*renderPass, *framebuffers[currentImage], vk::Rect2D({0, 0}, {width, height}), clear_colors),
 			vk::SubpassContents::eInline);
@@ -1035,13 +1036,30 @@ void VulkanContext::DrawFrame(vk::ImageView imageView, const vk::Extent2D& exten
 	int dy = 0;
 	getWindowboxDimensions(width, height, aspectRatio, dx, dy, config::Rotate90);
 	
-	vk::Viewport viewport(dx, dy, width - dx * 2, height - dy * 2);
+	vk::Viewport viewport = makeViewport(dx, dy, width - dx * 2, height - dy * 2);
 	commandBuffer.setViewport(0, viewport);
 	commandBuffer.setScissor(0, vk::Rect2D(vk::Offset2D(dx, dy), vk::Extent2D(width - dx * 2, height - dy * 2)));
 	if (config::Rotate90)
 		quadRotateDrawer->Draw(commandBuffer, imageView, vtx, !config::LinearInterpolation);
 	else
 		quadDrawer->Draw(commandBuffer, imageView, vtx, !config::LinearInterpolation);
+}
+
+bool VulkanContext::useReversedDepth() const
+{
+	return !config::NonReversedDepth;
+}
+
+float VulkanContext::getDepthClearValue() const
+{
+	return useReversedDepth() ? 0.f : 1.f;
+}
+
+vk::Viewport VulkanContext::makeViewport(float x, float y, float viewportWidth, float viewportHeight) const
+{
+	return vk::Viewport(x, y, viewportWidth, viewportHeight,
+			useReversedDepth() ? 1.0f : 0.0f,
+			useReversedDepth() ? 0.0f : 1.0f);
 }
 
 void VulkanContext::WaitIdle() const

--- a/core/rend/vulkan/vulkan_context.h
+++ b/core/rend/vulkan/vulkan_context.h
@@ -168,6 +168,9 @@ public:
 	}
 	bool hasPerPixel() override { return fragmentStoresAndAtomics; }
 	bool hasProvokingVertex() { return provokingVertexSupported; }
+	bool useReversedDepth() const;
+	float getDepthClearValue() const;
+	vk::Viewport makeViewport(float x, float y, float width, float height) const;
 	bool recreateSwapChainIfNeeded();
 	void addToFlight(Deletable *object) override {
 		inFlightObjects[GetCurrentImageIndex()].emplace_back(object);

--- a/core/ui/settings_video.cpp
+++ b/core/ui/settings_video.cpp
@@ -330,6 +330,9 @@ void gui_settings_video()
     			T("Helps with texture bleeding case when upscaling. Disabling it can help if pixels are warping when upscaling in 2D games (MVC2, CVS, KOF, etc.)"));
     	OptionCheckbox(T("Native Depth Interpolation"), config::NativeDepthInterpolation,
     			T("Helps with texture corruption and depth issues on AMD GPUs. Can also help Intel GPUs in some cases."));
+		if (isVulkan(config::RendererType))
+			OptionCheckbox(T("Non Reversed Depth"), config::NonReversedDepth,
+					T("Use the alternate Vulkan depth path instead of the default reversed-Z path.\nHelps with render corruption and depth issues on macOS with AMD GPU."));
     	OptionCheckbox(T("Copy Rendered Textures to VRAM"), config::RenderToTextureBuffer,
     			T("Copy rendered-to textures back to VRAM. Slower but accurate"));
 		const std::array<int, 5> aniso{ 1, 2, 4, 8, 16 };

--- a/shell/libretro/option.cpp
+++ b/shell/libretro/option.cpp
@@ -94,6 +94,7 @@ Option<bool> PowerVR2Filter(CORE_OPTION_NAME "_pvr2_filtering");
 Option<int64_t> PixelBufferSize("", 512_MB);
 IntOption PerPixelLayers(CORE_OPTION_NAME "_oit_layers");
 Option<bool> NativeDepthInterpolation(CORE_OPTION_NAME "_native_depth_interpolation");
+Option<bool> NonReversedDepth(CORE_OPTION_NAME "_non_reversed_depth");
 Option<bool> EmulateFramebuffer(CORE_OPTION_NAME "_emulate_framebuffer", false);
 Option<bool> FixUpscaleBleedingEdge(CORE_OPTION_NAME "_fix_upscale_bleeding_edge", true);
 


### PR DESCRIPTION
This fixes #1172  Vulkan rendering corruption and depth-ordering issues seen on macOS/AMD, by adding a toggleable non-reversed depth path for both standard and OIT rendering.  

![output](https://github.com/user-attachments/assets/6e129ded-6466-46c6-802c-c662840c0b14)

The new `Non Reversed Depth` Vulkan option keeps the original reversed-Z path as the default, and enables the alternate path only when needed.

On macOS/AMD with Vulkan, the default reversed-Z path could produce incorrect rendering in both regular and OIT scenes, including:

  - incorrect z-order
  - missing translucent alpha textures
  - missing UI elements
  - missing or incorrectly layered shadows

The OIT version also avoids fragment discard during insertion, which was causing missing alpha/UI/shadow on macOS/AMD

The goal of this PR is to verify that the macOS/AMD Vulkan issue can be fixed and to preserve a working reference for that fix.