### PR TITLE
Add support for libretro VFS (and file IO indirection in general).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1082,12 +1082,14 @@ endif()
 
 target_sources(${PROJECT_NAME} PRIVATE
 		core/build.h
+		core/chd.h
 		core/cheats.cpp
 		core/cheats.h
 		core/emulator.h
 		core/nullDC.cpp
 		core/serialize.cpp
 		core/serialize.h
+		core/stbi.h
 		core/stdclass.cpp
 		core/stdclass.h
 		core/types.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -927,12 +927,15 @@ if(LIBRETRO)
 	target_sources(${PROJECT_NAME} PRIVATE
 		core/deps/libretro-common/memmap/memalign.c
 		core/deps/libretro-common/file/file_path.c
+		core/deps/libretro-common/file/file_path_io.c
 		core/deps/libretro-common/vfs/vfs_implementation.c
 		core/deps/libretro-common/encodings/encoding_utf.c
 		core/deps/libretro-common/compat/compat_strl.c
 		core/deps/libretro-common/compat/fopen_utf8.c
 		core/deps/libretro-common/compat/compat_strcasestr.c
 		core/deps/libretro-common/file/retro_dirent.c
+		core/deps/libretro-common/streams/file_stream.c
+		core/deps/libretro-common/time/rtime.c
 		core/deps/libretro-common/string/stdstring.c)
 	if(USE_OPENGL)
 		target_sources(${PROJECT_NAME} PRIVATE
@@ -957,6 +960,7 @@ if(LIBRETRO)
 		shell/libretro/LogManager.h
 		shell/libretro/option.cpp
 		shell/libretro/oslib.cpp
+		shell/libretro/storage.cpp
 		shell/libretro/vmu_xhair.cpp)
 	if(APPLE)
 		target_sources(${PROJECT_NAME} PRIVATE shell/libretro/oslib_apple.mm)

--- a/core/archive/7zArchive.cpp
+++ b/core/archive/7zArchive.cpp
@@ -29,20 +29,34 @@
 
 static bool crc_tables_generated;
 
+SRes SzArchive::ArchiveStream::Read(const ISeekInStream *p, void *buf, size_t *size)
+{
+	auto file_archive = CONTAINER_FROM_VTBL(p, ArchiveStream, vt);
+	*size = std::fread(buf, 1, *size, file_archive->file);
+	return std::ferror(file_archive->file) ? SZ_ERROR_READ : SZ_OK;
+}
+
+SRes SzArchive::ArchiveStream::Seek(const ISeekInStream *p, Int64 *pos, ESzSeek origin)
+{
+	auto file_archive = CONTAINER_FROM_VTBL(p, ArchiveStream, vt);
+	return std::fseek(file_archive->file, *pos, origin) != 0 ? SZ_ERROR_FAIL : SZ_OK;
+}
+
 bool SzArchive::Open(FILE *file)
 {
 	SzArEx_Init(&szarchive);
 
-	File_Close(&archiveStream.file);
-	File_Construct(&archiveStream.file);
-	archiveStream.file.file = file;
+	if (archiveStream.file != nullptr)
+		std::fclose(archiveStream.file);
+	archiveStream.vt.Read = ArchiveStream::Read;
+	archiveStream.vt.Seek = ArchiveStream::Seek;
+	archiveStream.file = file;
 
-	FileInStream_CreateVTable(&archiveStream);
 	LookToRead2_CreateVTable(&lookStream, 0);
 	lookStream.buf = (Byte *)ISzAlloc_Alloc(&g_Alloc, kInputBufSize);
 	if (lookStream.buf == NULL)
 	{
-		File_Close(&archiveStream.file);
+		std::fclose(archiveStream.file);
 		return false;
 	}
 	lookStream.bufSize = kInputBufSize;
@@ -115,7 +129,7 @@ SzArchive::~SzArchive()
 {
 	if (lookStream.buf != NULL)
 	{
-		File_Close(&archiveStream.file);
+		std::fclose(archiveStream.file);
 		ISzAlloc_Free(&g_Alloc, lookStream.buf);
 		if (out_buffer != NULL)
 			ISzAlloc_Free(&g_Alloc, out_buffer);

--- a/core/archive/7zArchive.cpp
+++ b/core/archive/7zArchive.cpp
@@ -32,22 +32,22 @@ static bool crc_tables_generated;
 SRes SzArchive::ArchiveStream::Read(const ISeekInStream *p, void *buf, size_t *size)
 {
 	auto file_archive = CONTAINER_FROM_VTBL(p, ArchiveStream, vt);
-	*size = std::fread(buf, 1, *size, file_archive->file);
-	return std::ferror(file_archive->file) ? SZ_ERROR_READ : SZ_OK;
+	*size = file_archive->file->read(buf, 1, *size);
+	return file_archive->file->error() ? SZ_ERROR_READ : SZ_OK;
 }
 
 SRes SzArchive::ArchiveStream::Seek(const ISeekInStream *p, Int64 *pos, ESzSeek origin)
 {
 	auto file_archive = CONTAINER_FROM_VTBL(p, ArchiveStream, vt);
-	return std::fseek(file_archive->file, *pos, origin) != 0 ? SZ_ERROR_FAIL : SZ_OK;
+	return file_archive->file->seek(*pos, origin) != 0 ? SZ_ERROR_FAIL : SZ_OK;
 }
 
-bool SzArchive::Open(FILE *file)
+bool SzArchive::Open(hostfs::File *file)
 {
 	SzArEx_Init(&szarchive);
 
 	if (archiveStream.file != nullptr)
-		std::fclose(archiveStream.file);
+		delete archiveStream.file;
 	archiveStream.vt.Read = ArchiveStream::Read;
 	archiveStream.vt.Seek = ArchiveStream::Seek;
 	archiveStream.file = file;
@@ -56,7 +56,7 @@ bool SzArchive::Open(FILE *file)
 	lookStream.buf = (Byte *)ISzAlloc_Alloc(&g_Alloc, kInputBufSize);
 	if (lookStream.buf == NULL)
 	{
-		std::fclose(archiveStream.file);
+		delete archiveStream.file;
 		return false;
 	}
 	lookStream.bufSize = kInputBufSize;
@@ -129,7 +129,7 @@ SzArchive::~SzArchive()
 {
 	if (lookStream.buf != NULL)
 	{
-		std::fclose(archiveStream.file);
+		delete archiveStream.file;
 		ISzAlloc_Free(&g_Alloc, lookStream.buf);
 		if (out_buffer != NULL)
 			ISzAlloc_Free(&g_Alloc, out_buffer);

--- a/core/archive/7zArchive.h
+++ b/core/archive/7zArchive.h
@@ -39,7 +39,7 @@ public:
 	ArchiveFile *OpenFileByCrc(u32 crc) override;
 
 protected:
-	bool Open(FILE *file) override;
+	bool Open(hostfs::File *file) override;
 
 private:
 	struct ArchiveStream
@@ -48,7 +48,7 @@ private:
 		static SRes Seek(const ISeekInStream *p, Int64 *pos, ESzSeek origin);
 
 		ISeekInStream vt;
-		FILE *file;
+		hostfs::File *file;
 	};
 
 	CSzArEx szarchive;

--- a/core/archive/7zArchive.h
+++ b/core/archive/7zArchive.h
@@ -22,7 +22,6 @@
 
 #include "archive.h"
 #include "lzma/7z.h"
-#include "lzma/7zFile.h"
 
 #include <algorithm>
 #include <cstring>
@@ -43,11 +42,20 @@ protected:
 	bool Open(FILE *file) override;
 
 private:
+	struct ArchiveStream
+	{
+		static SRes Read(const ISeekInStream *p, void *buf, size_t *size);
+		static SRes Seek(const ISeekInStream *p, Int64 *pos, ESzSeek origin);
+
+		ISeekInStream vt;
+		FILE *file;
+	};
+
 	CSzArEx szarchive;
 	UInt32 block_idx;				/* it can have any value before first call (if outBuffer = 0) */
 	Byte *out_buffer;				/* it must be 0 before first call for each new archive. */
 	size_t out_buffer_size;			/* it can have any value before first call (if outBuffer = 0) */
-	CFileInStream archiveStream;
+	ArchiveStream archiveStream;
 	CLookToRead2 lookStream;
 
 };

--- a/core/archive/ZipArchive.cpp
+++ b/core/archive/ZipArchive.cpp
@@ -31,7 +31,7 @@ static zip_int64_t ZipSourceCallback(void *userdata, void *data, zip_uint64_t le
 {
 	using Error = std::array<int, 2>;
 	static Error error = {ZIP_ER_OK, 0};
-	auto file = static_cast<FILE*>(userdata);
+	auto file = static_cast<hostfs::File*>(userdata);
 
 	switch (cmd)
 	{
@@ -40,11 +40,11 @@ static zip_int64_t ZipSourceCallback(void *userdata, void *data, zip_uint64_t le
 
 		case ZIP_SOURCE_READ:
 		{
-			const auto bytes_read = std::fread(data, 1, len, file);
+			const auto bytes_read = file->read(data, 1, len);
 
-			if (ferror(file))
+			if (file->error())
 			{
-				error = {ZIP_ER_READ, errno};
+				error = {ZIP_ER_INTERNAL, 0};
 				return -1;
 			}
 
@@ -56,16 +56,11 @@ static zip_int64_t ZipSourceCallback(void *userdata, void *data, zip_uint64_t le
 
 		case ZIP_SOURCE_STAT:
 		{
-			// Obtain file size.
-			std::fpos_t position;
-			std::fgetpos(file, &position);
-			std::fseek(file, 0, SEEK_END);
-			auto size = std::ftell(file);
-			std::fsetpos(file, &position);
+			auto size = file->size();
 
 			if (size == -1)
 			{
-				error = {ZIP_ER_TELL, errno};
+				error = {ZIP_ER_INTERNAL, 0};
 				return -1;
 			}
 
@@ -86,12 +81,7 @@ static zip_int64_t ZipSourceCallback(void *userdata, void *data, zip_uint64_t le
 		}
 
 		case ZIP_SOURCE_FREE:
-			if (std::fclose(file) != 0)
-			{
-				error = {ZIP_ER_CLOSE, errno};
-				return -1;
-			}
-
+			delete file;
 			return 0;
 
 		case ZIP_SOURCE_SEEK:
@@ -105,9 +95,9 @@ static zip_int64_t ZipSourceCallback(void *userdata, void *data, zip_uint64_t le
 				return -1;
 			}
 
-			if (std::fseek(file, seek_info->offset, seek_info->whence) != 0)
+			if (file->seek(seek_info->offset, seek_info->whence) != 0)
 			{
-				error = {ZIP_ER_SEEK, errno};
+				error = {ZIP_ER_INTERNAL, 0};
 				return -1;
 			}
 
@@ -116,11 +106,11 @@ static zip_int64_t ZipSourceCallback(void *userdata, void *data, zip_uint64_t le
 
 		case ZIP_SOURCE_TELL:
 		{
-			const auto position = std::ftell(file);
+			const auto position = file->tell();
 
 			if (position == -1)
 			{
-				error = {ZIP_ER_TELL, errno};
+				error = {ZIP_ER_INTERNAL, 0};
 				return -1;
 			}
 
@@ -150,13 +140,13 @@ static zip_int64_t ZipSourceCallback(void *userdata, void *data, zip_uint64_t le
 	return -1;
 }
 
-bool ZipArchive::Open(FILE *file)
+bool ZipArchive::Open(hostfs::File *file)
 {
 	zip_error_t error;
 	zip_source_t *source = zip_source_function_create(ZipSourceCallback, file, &error);
 	if (source == nullptr)
 	{
-		std::fclose(file);
+		delete file;
 		return false;
 	}
 	zip = zip_open_from_source(source, 0, nullptr);

--- a/core/archive/ZipArchive.cpp
+++ b/core/archive/ZipArchive.cpp
@@ -20,15 +20,140 @@
  */
 #include "ZipArchive.h"
 
+#include <array>
+
 ZipArchive::~ZipArchive()
 {
 	zip_close(zip);
 }
 
+static zip_int64_t ZipSourceCallback(void *userdata, void *data, zip_uint64_t len, zip_source_cmd_t cmd)
+{
+	using Error = std::array<int, 2>;
+	static Error error = {ZIP_ER_OK, 0};
+	auto file = static_cast<FILE*>(userdata);
+
+	switch (cmd)
+	{
+		case ZIP_SOURCE_OPEN:
+			return 0;
+
+		case ZIP_SOURCE_READ:
+		{
+			const auto bytes_read = std::fread(data, 1, len, file);
+
+			if (ferror(file))
+			{
+				error = {ZIP_ER_READ, errno};
+				return -1;
+			}
+
+			return bytes_read;
+		}
+
+		case ZIP_SOURCE_CLOSE:
+			return 0;
+
+		case ZIP_SOURCE_STAT:
+		{
+			// Obtain file size.
+			std::fpos_t position;
+			std::fgetpos(file, &position);
+			std::fseek(file, 0, SEEK_END);
+			auto size = std::ftell(file);
+			std::fsetpos(file, &position);
+
+			if (size == -1)
+			{
+				error = {ZIP_ER_TELL, errno};
+				return -1;
+			}
+
+			auto stat = static_cast<zip_stat_t*>(data);
+			zip_stat_init(stat);
+
+			stat->valid |= ZIP_STAT_SIZE;
+			stat->size = size;
+
+			return sizeof(*stat);
+		}
+
+		case ZIP_SOURCE_ERROR:
+		{
+			auto error_out = static_cast<std::array<int, 2>*>(data);
+			*error_out = error;
+			return sizeof(*error_out);
+		}
+
+		case ZIP_SOURCE_FREE:
+			if (std::fclose(file) != 0)
+			{
+				error = {ZIP_ER_CLOSE, errno};
+				return -1;
+			}
+
+			return 0;
+
+		case ZIP_SOURCE_SEEK:
+		{
+			zip_error_t error;
+			auto seek_info = ZIP_SOURCE_GET_ARGS(zip_source_args_seek, data, len, &error);
+
+			if (seek_info == nullptr)
+			{
+				error = {ZIP_ER_INTERNAL, 0};
+				return -1;
+			}
+
+			if (std::fseek(file, seek_info->offset, seek_info->whence) != 0)
+			{
+				error = {ZIP_ER_SEEK, errno};
+				return -1;
+			}
+
+			return 0;
+		}
+
+		case ZIP_SOURCE_TELL:
+		{
+			const auto position = std::ftell(file);
+
+			if (position == -1)
+			{
+				error = {ZIP_ER_TELL, errno};
+				return -1;
+			}
+
+			return position;
+		}
+
+		case  ZIP_SOURCE_SUPPORTS:
+			return zip_source_make_command_bitmap(
+				ZIP_SOURCE_OPEN,
+				ZIP_SOURCE_READ,
+				ZIP_SOURCE_CLOSE,
+				ZIP_SOURCE_STAT,
+				ZIP_SOURCE_ERROR,
+				ZIP_SOURCE_FREE,
+				ZIP_SOURCE_SEEK,
+				ZIP_SOURCE_TELL,
+				ZIP_SOURCE_SUPPORTS,
+				-1
+			);
+
+		default:
+			break;
+	}
+
+	// Unsupported command.
+	error = {ZIP_ER_OPNOTSUPP, 0};
+	return -1;
+}
+
 bool ZipArchive::Open(FILE *file)
 {
 	zip_error_t error;
-	zip_source_t *source = zip_source_filep_create(file, 0, -1, &error);
+	zip_source_t *source = zip_source_function_create(ZipSourceCallback, file, &error);
 	if (source == nullptr)
 	{
 		std::fclose(file);

--- a/core/archive/ZipArchive.h
+++ b/core/archive/ZipArchive.h
@@ -31,7 +31,7 @@ public:
 	ArchiveFile* OpenFile(const char* name) override;
 	ArchiveFile* OpenFileByCrc(u32 crc) override;
 
-	bool Open(FILE *file) override;
+	bool Open(hostfs::File *file) override;
 	bool Open(const void *data, size_t size);
 
 	ArchiveFile *OpenFirstFile();

--- a/core/archive/archive.cpp
+++ b/core/archive/archive.cpp
@@ -26,7 +26,7 @@
 
 Archive *OpenArchive(const std::string& path)
 {
-	FILE *file = nullptr;
+	hostfs::File *file = nullptr;
 	hostfs::FileInfo fileInfo;
 	try {
 		fileInfo = hostfs::storage().getFileInfo(path);
@@ -74,7 +74,7 @@ Archive *OpenArchive(const std::string& path)
 
 bool Archive::Open(const char* path)
 {
-	FILE *file = nowide::fopen(path, "rb");
+	hostfs::File *file = hostfs::storage().openFile(path, "rb");
 	if (file == nullptr)
 		return false;
 	return Open(file);

--- a/core/archive/archive.h
+++ b/core/archive/archive.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "types.h"
+#include "oslib/storage.h"
 
 class ArchiveFile
 {
@@ -39,7 +40,7 @@ public:
 	virtual ArchiveFile *OpenFileByCrc(u32 crc) = 0;
 
 protected:
-	virtual bool Open(FILE *file) = 0;
+	virtual bool Open(hostfs::File *file) = 0;
 
 private:
 	bool Open(const char *name);

--- a/core/archive/rzip.cpp
+++ b/core/archive/rzip.cpp
@@ -23,27 +23,27 @@
 
 const u8 RZipHeader[8] = { '#', 'R', 'Z', 'I', 'P', 'v', 1, '#' };
 
-bool RZipFile::Open(FILE *file, bool write)
+bool RZipFile::Open(hostfs::File *file, bool write)
 {
 	verify(this->file == nullptr);
 	verify(file != nullptr);
-	startOffset = std::ftell(file);
+	startOffset = file->tell();
 	if (!write)
 	{
 		u8 header[sizeof(RZipHeader)];
-		if (std::fread(header, sizeof(header), 1, file) != 1
+		if (file->read(header, sizeof(header), 1) != 1
 			|| memcmp(header, RZipHeader, sizeof(header))
-			|| std::fread(&maxChunkSize, sizeof(maxChunkSize), 1, file) != 1
-			|| std::fread(&size, sizeof(size), 1, file) != 1)
+			|| file->read(&maxChunkSize, sizeof(maxChunkSize), 1) != 1
+			|| file->read(&size, sizeof(size), 1) != 1)
 		{
-			std::fseek(file, startOffset, SEEK_SET);
+			file->seek(startOffset, SEEK_SET);
 			return false;
 		}
 		// savestates created on 32-bit platforms used to have a 32-bit size
 		if (size >> 32 != 0)
 		{
 			size &= 0xffffffff;
-			std::fseek(file, -4, SEEK_CUR);
+			file->seek(-4, SEEK_CUR);
 		}
 		chunk = new u8[maxChunkSize];
 		chunkIndex = 0;
@@ -52,11 +52,11 @@ bool RZipFile::Open(FILE *file, bool write)
 	else
 	{
 		maxChunkSize = 1_MB;
-		if (std::fwrite(RZipHeader, sizeof(RZipHeader), 1, file) != 1
-			|| std::fwrite(&maxChunkSize, sizeof(maxChunkSize), 1, file) != 1
-			|| std::fwrite(&size, sizeof(size), 1, file) != 1)
+		if (file->write(RZipHeader, sizeof(RZipHeader), 1) != 1
+			|| file->write(&maxChunkSize, sizeof(maxChunkSize), 1) != 1
+			|| file->write(&size, sizeof(size), 1) != 1)
 		{
-			std::fseek(file, startOffset, SEEK_SET);
+			file->seek(startOffset, SEEK_SET);
 			return false;
 		}
 	}
@@ -67,7 +67,7 @@ bool RZipFile::Open(FILE *file, bool write)
 
 bool RZipFile::Open(const std::string& path, bool write)
 {
-	FILE *f = nowide::fopen(path.c_str(), write ? "wb" : "rb");
+	hostfs::File *f = hostfs::storage().openFile(path.c_str(), write ? "wb" : "rb");
 	if (f == nullptr)
 		return false;
 	if (!Open(f, write)) {
@@ -83,10 +83,10 @@ void RZipFile::Close()
 	{
 		if (write)
 		{
-			std::fseek(file, startOffset + sizeof(RZipHeader) + sizeof(maxChunkSize), SEEK_SET);
-			std::fwrite(&size, sizeof(size), 1, file);
+			file->seek(startOffset + sizeof(RZipHeader) + sizeof(maxChunkSize), SEEK_SET);
+			file->write(&size, sizeof(size), 1);
 		}
-		std::fclose(file);
+		delete file;
 		file = nullptr;
 		if (chunk != nullptr)
 		{
@@ -110,12 +110,12 @@ size_t RZipFile::Read(void *data, size_t length)
 			chunkSize = 0;
 			chunkIndex = 0;
 			u32 zippedSize;
-			if (std::fread(&zippedSize, sizeof(zippedSize), 1, file) != 1)
+			if (file->read(&zippedSize, sizeof(zippedSize), 1) != 1)
 				break;
 			if (zippedSize == 0)
 				continue;
 			u8 *zipped = new u8[zippedSize];
-			if (std::fread(zipped, zippedSize, 1, file) != 1)
+			if (file->read(zipped, zippedSize, 1) != 1)
 			{
 				delete [] zipped;
 				break;
@@ -161,8 +161,8 @@ size_t RZipFile::Write(const void *data, size_t length)
 			break;
 		}
 		u32 sz = (u32)zippedSize;
-		if (std::fwrite(&sz, sizeof(sz), 1, file) != 1
-			|| std::fwrite(zipped, zippedSize, 1, file) != 1)
+		if (file->write(&sz, sizeof(sz), 1) != 1
+			|| file->write(zipped, zippedSize, 1) != 1)
 		{
 			rv = 0;
 			break;

--- a/core/archive/rzip.h
+++ b/core/archive/rzip.h
@@ -21,6 +21,7 @@
 
 #pragma once
 #include "types.h"
+#include "oslib/storage.h"
 
 class RZipFile
 {
@@ -28,15 +29,15 @@ public:
 	~RZipFile() { Close(); }
 
 	bool Open(const std::string& path, bool write);
-	bool Open(FILE *file, bool write);
+	bool Open(hostfs::File *file, bool write);
 	void Close();
 	size_t Size() const { return size; }
 	size_t Read(void *data, size_t length);
 	size_t Write(const void *data, size_t length);
-	FILE *rawFile() const { return file; }
+	hostfs::File *rawFile() const { return file; }
 
 private:
-	FILE *file = nullptr;
+	hostfs::File *file = nullptr;
 	u64 size = 0;
 	u32 maxChunkSize = 0;
 	u8 *chunk = nullptr;

--- a/core/cfg/cfg.cpp
+++ b/core/cfg/cfg.cpp
@@ -12,13 +12,13 @@ static IniFile cfgdb;
 
 static void saveFile()
 {
-	FILE* cfgfile = nowide::fopen(cfgPath.c_str(), "wt");
+	hostfs::File* cfgfile = hostfs::storage().openFile(cfgPath.c_str(), "wt");
 	if (!cfgfile) {
 		WARN_LOG(COMMON, "Error: Unable to open file '%s' for saving", cfgPath.c_str());
 	}
 	else {
 		cfgdb.save(cfgfile);
-		std::fclose(cfgfile);
+		delete cfgfile;
 	}
 }
 
@@ -37,10 +37,10 @@ bool open()
 	std::string config_path_read = get_readonly_config_path(filename);
 	cfgPath = get_writable_config_path(filename);
 
-	FILE* cfgfile = nowide::fopen(config_path_read.c_str(), "rt");
+	hostfs::File* cfgfile = hostfs::storage().openFile(config_path_read.c_str(), "rt");
 	if (cfgfile != nullptr) {
 		cfgdb.load(cfgfile);
-		std::fclose(cfgfile);
+		delete cfgfile;
 	}
 	else
 	{

--- a/core/cfg/ini.cpp
+++ b/core/cfg/ini.cpp
@@ -236,13 +236,13 @@ void IniFile::load(const std::string& data, bool cEscape)
 	}
 }
 
-void IniFile::load(FILE *file, bool cEscape)
+void IniFile::load(hostfs::File *file, bool cEscape)
 {
 	std::string data;
 	for (;;)
 	{
 		char buffer[4096];
-		int n = fread(buffer, 1, sizeof(buffer), file);
+		int n = file->read(buffer, 1, sizeof(buffer));
 		if (n <= 0)
 			break;
 		data += std::string(buffer, buffer + n);
@@ -272,11 +272,11 @@ void IniFile::save(std::string& data) const
 	data = ss.str();
 }
 
-void IniFile::save(FILE *file) const
+void IniFile::save(hostfs::File *file) const
 {
 	std::string data;
 	save(data);
-	fwrite(data.c_str(), 1, data.length(), file);
+	file->write(data.c_str(), 1, data.length());
 }
 
 bool IniFile::hasSection(const std::string& section) const {

--- a/core/cfg/ini.h
+++ b/core/cfg/ini.h
@@ -24,15 +24,16 @@
 #include <vector>
 #include <locale>
 #include <sstream>
+#include "../oslib/storage.h"
 
 namespace config {
 
 class IniFile
 {
 public:
-	void load(FILE *file, bool cEscape = false);
+	void load(hostfs::File *file, bool cEscape = false);
 	void load(const std::string& data, bool cEscape = false);
-	void save(FILE *file) const;
+	void save(hostfs::File *file) const;
 	void save(std::string& data) const;
 	bool hasSection(const std::string& section) const;
 	bool hasEntry(const std::string& section, const std::string& name) const;

--- a/core/chd.h
+++ b/core/chd.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdio>
+#include <utility>
+
+#include <libchdr/chd.h>
+
+namespace CHD
+{
+	namespace Callbacks
+	{
+		// Moved out here to avoid being duplicated by the template.
+		inline uint64_t fsize(struct chd_core_file *core_file)
+		{
+			auto file = static_cast<std::FILE*>(core_file->argp);
+			std::fseek(file, 0, SEEK_END);
+			return std::ftell(file);
+		}
+
+		inline size_t fread(void* buffer, size_t size, size_t count, struct chd_core_file *core_file)
+		{
+			auto file = static_cast<std::FILE*>(core_file->argp);
+			return std::fread(buffer, size, count, file);
+		}
+
+		inline int fclose(struct chd_core_file *core_file)
+		{
+			auto file = static_cast<std::FILE*>(core_file->argp);
+			delete core_file;
+			return std::fclose(file);
+		}
+
+		inline int fseek(struct chd_core_file *core_file, int64_t offset, int whence)
+		{
+			auto file = static_cast<std::FILE*>(core_file->argp);
+			return std::fseek(file, offset, whence);
+		}
+	}
+}
+
+template<typename... Ts>
+inline auto chd_open_file(std::FILE *file, Ts &&...args)
+{
+	auto core_file = new struct chd_core_file();
+
+	core_file->argp = file;
+	core_file->fsize = CHD::Callbacks::fsize;
+	core_file->fread = CHD::Callbacks::fread;
+	core_file->fclose = CHD::Callbacks::fclose;
+	core_file->fseek = CHD::Callbacks::fseek;
+
+	return chd_open_core_file(core_file, std::forward<Ts>(args)...);
+}

--- a/core/chd.h
+++ b/core/chd.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <cstdio>
 #include <utility>
 
 #include <libchdr/chd.h>
+
+#include "oslib/storage.h"
 
 namespace CHD
 {
@@ -12,34 +13,34 @@ namespace CHD
 		// Moved out here to avoid being duplicated by the template.
 		inline uint64_t fsize(struct chd_core_file *core_file)
 		{
-			auto file = static_cast<std::FILE*>(core_file->argp);
-			std::fseek(file, 0, SEEK_END);
-			return std::ftell(file);
+			auto file = static_cast<hostfs::File*>(core_file->argp);
+			return file->size();
 		}
 
 		inline size_t fread(void* buffer, size_t size, size_t count, struct chd_core_file *core_file)
 		{
-			auto file = static_cast<std::FILE*>(core_file->argp);
-			return std::fread(buffer, size, count, file);
+			auto file = static_cast<hostfs::File*>(core_file->argp);
+			return file->read(buffer, size, count);
 		}
 
 		inline int fclose(struct chd_core_file *core_file)
 		{
-			auto file = static_cast<std::FILE*>(core_file->argp);
+			auto file = static_cast<hostfs::File*>(core_file->argp);
+			delete file;
 			delete core_file;
-			return std::fclose(file);
+			return 0;
 		}
 
 		inline int fseek(struct chd_core_file *core_file, int64_t offset, int whence)
 		{
-			auto file = static_cast<std::FILE*>(core_file->argp);
-			return std::fseek(file, offset, whence);
+			auto file = static_cast<hostfs::File*>(core_file->argp);
+			return file->seek(offset, whence);
 		}
 	}
 }
 
 template<typename... Ts>
-inline auto chd_open_file(std::FILE *file, Ts &&...args)
+inline auto chd_open_file(hostfs::File *file, Ts &&...args)
 {
 	auto core_file = new struct chd_core_file();
 

--- a/core/cheats.cpp
+++ b/core/cheats.cpp
@@ -391,7 +391,7 @@ void CheatManager::loadCheatFile(const std::string& filename)
 		return;
 	}
 
-	FILE* cheatfile = hostfs::storage().openFile(filename, "r");
+	hostfs::File* cheatfile = hostfs::storage().openFile(filename, "r");
 	if (cheatfile == nullptr)
 	{
 		WARN_LOG(COMMON, "Cannot open cheat file '%s'", filename.c_str());
@@ -399,7 +399,7 @@ void CheatManager::loadCheatFile(const std::string& filename)
 	}
 	config::IniFile cfg;
 	cfg.load(cheatfile);
-	fclose(cheatfile);
+	delete cheatfile;
 
 	int count = cfg.getInt("", "cheats", 0);
 	cheats.clear();
@@ -1098,10 +1098,10 @@ void CheatManager::saveCheatFile(const std::string& filename)
 		i++;
 	}
 	cfg.set("", "cheats", i);
-	FILE *fp = hostfs::storage().openFile(filename.c_str(), "w");
+	hostfs::File *fp = hostfs::storage().openFile(filename.c_str(), "w");
 	if (fp == nullptr)
 		throw FlycastException(Ts("Can't save cheat file"));
 	cfg.save(fp);
-	fclose(fp);
+	delete fp;
 #endif
 }

--- a/core/deps/chdpsr/cdipsr.cpp
+++ b/core/deps/chdpsr/cdipsr.cpp
@@ -11,26 +11,26 @@ unsigned long temp_value;
 
 /////////////////////////////////////////////////////////////////////////////
 
-unsigned long ask_type(FILE *fsource, long header_position)
+unsigned long ask_type(hostfs::File *fsource, long header_position)
 {
 
 unsigned char filename_length;
 unsigned long track_mode;
 
-    fseek(fsource, header_position, SEEK_SET);
-    fread(&temp_value, 4, 1, fsource);
+    fsource->seek(header_position, SEEK_SET);
+    fsource->read(&temp_value, 4, 1);
     if (temp_value != 0)
-       fseek(fsource, 8, SEEK_CUR); // extra data (DJ 3.00.780 and up)
-    fseek(fsource, 24, SEEK_CUR);
-    fread(&filename_length, 1, 1, fsource);
-    fseek(fsource, filename_length, SEEK_CUR);
-    fseek(fsource, 19, SEEK_CUR);
-    fread(&temp_value, 4, 1, fsource);
+       fsource->seek(8, SEEK_CUR); // extra data (DJ 3.00.780 and up)
+    fsource->seek(24, SEEK_CUR);
+    fsource->read(&filename_length, 1, 1);
+    fsource->seek(filename_length, SEEK_CUR);
+    fsource->seek(19, SEEK_CUR);
+    fsource->read(&temp_value, 4, 1);
        if (temp_value == 0x80000000)
-          fseek(fsource, 8, SEEK_CUR); // DJ4
-    fseek(fsource, 16, SEEK_CUR);
-    fread(&track_mode, 4, 1, fsource);
-    fseek(fsource, header_position, SEEK_SET);
+          fsource->seek(8, SEEK_CUR); // DJ4
+    fsource->seek(16, SEEK_CUR);
+    fsource->read(&track_mode, 4, 1);
+    fsource->seek(header_position, SEEK_SET);
     return (track_mode);
 }
 
@@ -38,47 +38,47 @@ unsigned long track_mode;
 /////////////////////////////////////////////////////////////////////////////
 
 
-bool CDI_read_track (FILE *fsource, image_s *image, track_s *track)
+bool CDI_read_track (hostfs::File *fsource, image_s *image, track_s *track)
 {
 
      unsigned char TRACK_START_MARK[10] = { 0, 0, 0x01, 0, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF };
      unsigned char current_start_mark[10];
 
-         fread(&temp_value, 4, 1, fsource);
+         fsource->read(&temp_value, 4, 1);
          if (temp_value != 0)
-            fseek(fsource, 8, SEEK_CUR); // extra data (DJ 3.00.780 and up)
+            fsource->seek(8, SEEK_CUR); // extra data (DJ 3.00.780 and up)
 
-         fread(&current_start_mark, 10, 1, fsource);
+         fsource->read(&current_start_mark, 10, 1);
          if (memcmp(TRACK_START_MARK, current_start_mark, 10)) {
         	 printf("CDI_read_track: Unsupported format: Could not find the track start mark\n");
         	 return false;
          }
 
-         fread(&current_start_mark, 10, 1, fsource);
+         fsource->read(&current_start_mark, 10, 1);
          if (memcmp(TRACK_START_MARK, current_start_mark, 10)) {
         	 printf("CDI_read_track: Unsupported format: Could not find the track start mark\n");
         	 return false;
          }
 
-         fseek(fsource, 4, SEEK_CUR);
-         fread(&track->filename_length, 1, 1, fsource);
-         fseek(fsource, track->filename_length, SEEK_CUR);
-         fseek(fsource, 11, SEEK_CUR);
-         fseek(fsource, 4, SEEK_CUR);
-         fseek(fsource, 4, SEEK_CUR);
-         fread(&temp_value, 4, 1, fsource);
+         fsource->seek(4, SEEK_CUR);
+         fsource->read(&track->filename_length, 1, 1);
+         fsource->seek(track->filename_length, SEEK_CUR);
+         fsource->seek(11, SEEK_CUR);
+         fsource->seek(4, SEEK_CUR);
+         fsource->seek(4, SEEK_CUR);
+         fsource->read(&temp_value, 4, 1);
             if (temp_value == 0x80000000)
-               fseek(fsource, 8, SEEK_CUR); // DJ4
-         fseek(fsource, 2, SEEK_CUR);
-         fread(&track->pregap_length, 4, 1, fsource);
-         fread(&track->length, 4, 1, fsource);
-         fseek(fsource, 6, SEEK_CUR);
-         fread(&track->mode, 4, 1, fsource);
-         fseek(fsource, 12, SEEK_CUR);
-         fread(&track->start_lba, 4, 1, fsource);
-         fread(&track->total_length, 4, 1, fsource);
-         fseek(fsource, 16, SEEK_CUR);
-         fread(&track->sector_size_value, 4, 1, fsource);
+               fsource->seek(8, SEEK_CUR); // DJ4
+         fsource->seek(2, SEEK_CUR);
+         fsource->read(&track->pregap_length, 4, 1);
+         fsource->read(&track->length, 4, 1);
+         fsource->seek(6, SEEK_CUR);
+         fsource->read(&track->mode, 4, 1);
+         fsource->seek(12, SEEK_CUR);
+         fsource->read(&track->start_lba, 4, 1);
+         fsource->read(&track->total_length, 4, 1);
+         fsource->seek(16, SEEK_CUR);
+         fsource->read(&track->sector_size_value, 4, 1);
 
          switch(track->sector_size_value)
                {
@@ -96,34 +96,34 @@ bool CDI_read_track (FILE *fsource, image_s *image, track_s *track)
         	 return false;
          }
 
-         fseek(fsource, 29, SEEK_CUR);
+         fsource->seek(29, SEEK_CUR);
          if (image->version != CDI_V2)
          {
-            fseek(fsource, 5, SEEK_CUR);
-            fread(&temp_value, 4, 1, fsource);
+            fsource->seek(5, SEEK_CUR);
+            fsource->read(&temp_value, 4, 1);
             if (temp_value == 0xffffffff)
-                fseek(fsource, 78, SEEK_CUR); // extra data (DJ 3.00.780 and up)
+                fsource->seek(78, SEEK_CUR); // extra data (DJ 3.00.780 and up)
          }
          return true;
 }
 
 
-void CDI_skip_next_session (FILE *fsource, image_s *image)
+void CDI_skip_next_session (hostfs::File *fsource, image_s *image)
 {
-     fseek(fsource, 4, SEEK_CUR);
-     fseek(fsource, 8, SEEK_CUR);
-     if (image->version != CDI_V2) fseek(fsource, 1, SEEK_CUR);
+     fsource->seek(4, SEEK_CUR);
+     fsource->seek(8, SEEK_CUR);
+     if (image->version != CDI_V2) fsource->seek(1, SEEK_CUR);
 }
 
-bool CDI_get_tracks (FILE *fsource, image_s *image)
+bool CDI_get_tracks (hostfs::File *fsource, image_s *image)
 {
-     return fread(&image->tracks, 2, 1, fsource) == 1;
+     return fsource->read(&image->tracks, 2, 1) == 1;
 }
 
-bool CDI_init (FILE *fsource, image_s *image, const char *fsourcename)
+bool CDI_init (hostfs::File *fsource, image_s *image, const char *fsourcename)
 {
-	fseek(fsource, 0, SEEK_END);
-	image->length = ftell(fsource);
+	fsource->seek(0, SEEK_END);
+	image->length = fsource->tell();
 
 	if (image->length < 8)
 	{
@@ -131,9 +131,9 @@ bool CDI_init (FILE *fsource, image_s *image, const char *fsourcename)
 		return false;
 	}
 
-	fseek(fsource, image->length-8, SEEK_SET);
-	if (fread(&image->version, 4, 1, fsource) != 1
-			|| fread(&image->header_offset, 4, 1, fsource) != 1)
+	fsource->seek(image->length-8, SEEK_SET);
+	if (fsource->read(&image->version, 4, 1) != 1
+			|| fsource->read(&image->header_offset, 4, 1) != 1)
 		return false;
 
 	if ((image->version != CDI_V2 && image->version != CDI_V3 && image->version != CDI_V35)
@@ -145,17 +145,17 @@ bool CDI_init (FILE *fsource, image_s *image, const char *fsourcename)
 	return true;
 }
 
-bool CDI_get_sessions (FILE *fsource, image_s *image)
+bool CDI_get_sessions (hostfs::File *fsource, image_s *image)
 {
 #ifndef DEBUG_CDI
      if (image->version == CDI_V35)
-        fseek(fsource, (image->length - image->header_offset), SEEK_SET);
+        fsource->seek((image->length - image->header_offset), SEEK_SET);
      else
-        fseek(fsource, image->header_offset, SEEK_SET);
+        fsource->seek(image->header_offset, SEEK_SET);
 
 #else
-     fseek(fsource, 0L, SEEK_SET);
+     fsource->seek(0L, SEEK_SET);
 #endif
-     return fread(&image->sessions, 2, 1, fsource) == 1;
+     return fsource->read(&image->sessions, 2, 1) == 1;
 }
 

--- a/core/deps/chdpsr/cdipsr.h
+++ b/core/deps/chdpsr/cdipsr.h
@@ -1,6 +1,8 @@
 #ifndef __CDI_H__
 #define __CDI_H__
 
+#include "../../oslib/storage.h"
+
 /* Basic structures */
 
 typedef struct image_s
@@ -36,11 +38,11 @@ typedef struct track_s
 #define CDI_V3  0x80000005
 #define CDI_V35 0x80000006
 
-unsigned long ask_type(FILE *fsource, long header_position);
-bool CDI_init(FILE *fsource, image_s *image, const char *fsourcename);
-bool CDI_get_sessions(FILE *fsource, image_s *image);
-bool CDI_get_tracks(FILE *fsource, image_s *image);
-bool CDI_read_track(FILE *fsource, image_s *image, track_s *track);
-void CDI_skip_next_session(FILE *fsource, image_s *image);
+unsigned long ask_type(hostfs::File *fsource, long header_position);
+bool CDI_init(hostfs::File *fsource, image_s *image, const char *fsourcename);
+bool CDI_get_sessions(hostfs::File *fsource, image_s *image);
+bool CDI_get_tracks(hostfs::File *fsource, image_s *image);
+bool CDI_read_track(hostfs::File *fsource, image_s *image, track_s *track);
+void CDI_skip_next_session(hostfs::File *fsource, image_s *image);
 
 #endif

--- a/core/deps/libretro-common/file/file_path.c
+++ b/core/deps/libretro-common/file/file_path.c
@@ -1,4 +1,4 @@
-/* Copyright  (C) 2010-2019 The RetroArch team
+/* Copyright  (C) 2010-2020 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this file (file_path.c).
@@ -24,16 +24,15 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <errno.h>
+#include <locale.h>
 
 #include <sys/stat.h>
 
 #include <boolean.h>
 #include <file/file_path.h>
-#include <retro_assert.h>
+#include <retro_miscellaneous.h>
 #include <string/stdstring.h>
-#define VFS_FRONTEND
-#include <vfs/vfs_implementation.h>
+#include <time/rtime.h>
 
 /* TODO: There are probably some unnecessary things on this huge include list now but I'm too afraid to touch it */
 #ifdef __APPLE__
@@ -46,56 +45,11 @@
 #include <compat/strl.h>
 #include <compat/posix_string.h>
 #endif
-#include <compat/strcasestr.h>
-#include <retro_miscellaneous.h>
 #include <encodings/utf.h>
 
-#if defined(_WIN32)
-#ifdef _MSC_VER
-#define setmode _setmode
-#endif
-#include <sys/stat.h>
-#ifdef _XBOX
-#include <xtl.h>
-#define INVALID_FILE_ATTRIBUTES -1
-#else
-#include <io.h>
-#include <fcntl.h>
+#ifdef _WIN32
 #include <direct.h>
-#include <windows.h>
-#if defined(_MSC_VER) && _MSC_VER <= 1200
-#define INVALID_FILE_ATTRIBUTES ((DWORD)-1)
-#endif
-#endif
-#elif defined(VITA)
-#define SCE_ERROR_ERRNO_EEXIST 0x80010011
-#include <psp2/io/fcntl.h>
-#include <psp2/io/dirent.h>
-#include <psp2/io/stat.h>
 #else
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#endif
-
-#if defined(PSP)
-#include <pspkernel.h>
-#endif
-
-#if defined(PS2)
-#include <fileXio_rpc.h>
-#include <fileXio.h>
-#endif
-
-#if defined(__CELLOS_LV2__)
-#include <cell/cell_fs.h>
-#endif
-
-#if defined(VITA)
-#define FIO_S_ISDIR SCE_S_ISDIR
-#endif
-
-#if (defined(__CELLOS_LV2__) && !defined(__PSL1GHT__)) || defined(__QNX__) || defined(PSP) || defined(PS2)
 #include <unistd.h> /* stat() is defined here */
 #endif
 
@@ -114,135 +68,98 @@
 
 #endif
 
-static retro_vfs_stat_t path_stat_cb   = NULL;
-static retro_vfs_mkdir_t path_mkdir_cb = NULL;
-
-void path_vfs_init(const struct retro_vfs_interface_info* vfs_info)
+/* Time format strings with AM-PM designation require special
+ * handling due to platform dependence */
+size_t strftime_am_pm(char *s, size_t len, const char* format,
+      const void *ptr)
 {
-   const struct retro_vfs_interface* 
-      vfs_iface           = vfs_info->iface;
-
-   path_stat_cb           = NULL;
-   path_mkdir_cb          = NULL;
-
-   if (vfs_info->required_interface_version < PATH_REQUIRED_VFS_VERSION || !vfs_iface)
-      return;
-
-   path_stat_cb           = vfs_iface->stat;
-   path_mkdir_cb          = vfs_iface->mkdir;
-}
-
-#define path_stat_internal(path, size) ((path_stat_cb != NULL) ? path_stat_cb((path), (size)) : retro_vfs_stat_impl((path), (size)))
-
-#define path_mkdir_norecurse(dir) ((path_mkdir_cb != NULL) ? path_mkdir_cb((dir)) : retro_vfs_mkdir_impl((dir)))
-
-int path_stat(const char *path)
-{
-   return path_stat_internal(path, NULL);
-}
-
-/**
- * path_is_directory:
- * @path               : path
- *
- * Checks if path is a directory.
- *
- * Returns: true (1) if path is a directory, otherwise false (0).
- */
-bool path_is_directory(const char *path)
-{
-   return (path_stat_internal(path, NULL) & RETRO_VFS_STAT_IS_DIRECTORY) != 0;
-}
-
-bool path_is_character_special(const char *path)
-{
-   return (path_stat_internal(path, NULL) & RETRO_VFS_STAT_IS_CHARACTER_SPECIAL) != 0;
-}
-
-bool path_is_valid(const char *path)
-{
-   return (path_stat_internal(path, NULL) & RETRO_VFS_STAT_IS_VALID) != 0;
-}
-
-int32_t path_get_size(const char *path)
-{
-   int32_t filesize = 0;
-   if (path_stat_internal(path, &filesize) != 0)
-      return filesize;
-
-   return -1;
-}
-
-/**
- * path_mkdir:
- * @dir                : directory
- *
- * Create directory on filesystem.
- *
- * Returns: true (1) if directory could be created, otherwise false (0).
- **/
-bool path_mkdir(const char *dir)
-{
-   bool         sret  = false;
-   bool norecurse     = false;
-   char     *basedir  = NULL;
-
-   if (!(dir && *dir))
-      return false;
-
-   /* Use heap. Real chance of stack 
-    * overflow if we recurse too hard. */
-   basedir            = strdup(dir);
-
-   if (!basedir)
-	   return false;
-
-   path_parent_dir(basedir);
-
-   if (!*basedir || !strcmp(basedir, dir))
+   size_t _len              = 0;
+#if !(defined(__linux__) && !defined(ANDROID))
+   char *local              = NULL;
+#endif
+   const struct tm *timeptr = (const struct tm*)ptr;
+   /* Ensure correct locale is set
+    * > Required for localised AM/PM strings */
+   setlocale(LC_TIME, "");
+   _len = strftime(s, len, format, timeptr);
+#if !(defined(__linux__) && !defined(ANDROID))
+   if ((local = local_to_utf8_string_alloc(s)))
    {
-      free(basedir);
-      return false;
-   }
+      if (!string_is_empty(local))
+         _len = strlcpy(s, local, len);
 
-#if defined(GEKKO)
-   {
-      size_t len = strlen(basedir);
-
-      /* path_parent_dir() keeps the trailing slash.
-       * On Wii, mkdir() fails if the path has a
-       * trailing slash...
-       * We must therefore remove it. */
-      if (len > 0)
-         if (basedir[len - 1] == '/')
-            basedir[len - 1] = '\0';
+      free(local);
+      local = NULL;
    }
 #endif
+   return _len;
+}
 
-   if (path_is_directory(basedir))
-      norecurse = true;
+/**
+ * Create a new linked list with one node in it
+ * The path on this node will be set to NULL
+**/
+struct path_linked_list* path_linked_list_new(void)
+{
+   struct path_linked_list* paths_list =
+      (struct path_linked_list*)malloc(sizeof(*paths_list));
+   if (!paths_list)
+      return NULL;
+   paths_list->next = NULL;
+   paths_list->path = NULL;
+   return paths_list;
+}
+
+/**
+ * path_linked_list_free:
+ *
+ * Free the entire linked list
+ **/
+void path_linked_list_free(struct path_linked_list *in_path_llist)
+{
+   struct path_linked_list *node_tmp = in_path_llist;
+   while (node_tmp)
+   {
+      struct path_linked_list *hold = node_tmp;
+      node_tmp = node_tmp->next;
+      free(hold->path); /* free(NULL) is safe per C89 */
+      free(hold);
+   }
+}
+
+/**
+ * path_linked_list_add_path:
+ *
+ * Add a node to the linked list with this path
+ * If the first node's path if it's not yet set the path
+ * on this node instead
+**/
+void path_linked_list_add_path(struct path_linked_list *in_path_llist,
+      char *path)
+{
+   /* If the first item does not have a path this is
+      a list which has just been created, so we just fill
+      the path for the first item
+   */
+   if (!in_path_llist->path)
+      in_path_llist->path = strdup(path);
    else
    {
-      sret      = path_mkdir(basedir);
+      struct path_linked_list *node =
+         (struct path_linked_list*)malloc(sizeof(*node));
 
-      if (sret)
-         norecurse = true;
+      if (node)
+      {
+         struct path_linked_list *tail = in_path_llist;
+
+         node->next = NULL;
+         node->path = strdup(path);
+
+         while (tail->next)
+            tail = tail->next;
+         tail->next = node;
+      }
    }
-
-   free(basedir);
-
-   if (norecurse)
-   {
-      int ret = path_mkdir_norecurse(dir);
-
-      /* Don't treat this as an error. */
-      if (ret == -2 && path_is_directory(dir))
-         return true;
-
-      return (ret == 0);
-   }
-
-   return sret;
 }
 
 /**
@@ -252,31 +169,51 @@ bool path_mkdir(const char *dir)
  * Find delimiter of an archive file. Only the first '#'
  * after a compression extension is considered.
  *
- * Returns: pointer to the delimiter in the path if it contains
+ * @return pointer to the delimiter in the path if it contains
  * a path inside a compressed file, otherwise NULL.
- */
+ **/
 const char *path_get_archive_delim(const char *path)
 {
-   const char *last  = find_last_slash(path);
-   const char *delim = NULL;
+   /* Find delimiter position
+    * > Since filenames may contain '#' characters,
+    *   must loop until we find the first '#' that
+    *   is directly *after* a compression extension */
+   const char *delim = strchr(path, '#');
 
-   if (!last)
-      return NULL;
+   while (delim)
+   {
+      long d = (long)(delim - path);
 
-   /* Test if it's .zip */
-   delim = strcasestr(last, ".zip#");
+      /* Check whether this is a known archive type
+       * > Inline case-insensitive checks to avoid
+       *   strlcpy + string_to_lower + string_is_equal overhead */
+      if (d > 3)
+      {
+         char c3 = delim[-3] | 0x20;
+         char c2 = delim[-2] | 0x20;
+         char c1 = delim[-1] | 0x20;
 
-   if (!delim) /* If it's not a .zip, test if it's .apk */
-      delim = strcasestr(last, ".apk#");
+         /* Check ".7z" */
+         if (delim[-3] == '.' && delim[-2] == '7' && c1 == 'z')
+            return delim;
 
-   if (delim)
-      return delim + 4;
+         if (d > 4)
+         {
+            char c4 = delim[-4];
 
-   /* If it's not a .zip or .apk file, test if it's .7z */
-   delim = strcasestr(last, ".7z#");
+            /* Check ".zip" */
+            if (c4 == '.' && c3 == 'z' && c2 == 'i' && c1 == 'p')
+               return delim;
 
-   if (delim)
-      return delim + 3;
+            /* Check ".apk" */
+            if (c4 == '.' && c3 == 'a' && c2 == 'p' && c1 == 'k')
+               return delim;
+         }
+      }
+
+      delim++;
+      delim = strchr(delim, '#');
+   }
 
    return NULL;
 }
@@ -288,39 +225,59 @@ const char *path_get_archive_delim(const char *path)
  * Gets extension of file. Only '.'s
  * after the last slash are considered.
  *
- * Returns: extension part from the path.
- */
+ * @return extension part from the path.
+ **/
 const char *path_get_extension(const char *path)
 {
    const char *ext;
-   if (!string_is_empty(path) && ((ext = strrchr(path_basename(path), '.'))))
+   if (!string_is_empty(path) && ((ext = (char*)strrchr(path_basename(path), '.'))))
       return ext + 1;
    return "";
 }
 
 /**
- * path_remove_extension:
+ * path_get_extension_mutable:
  * @path               : path
+ *
+ * Specialized version of path_get_extension(). Return
+ * value is mutable.
+ *
+ * Gets extension of file. Only '.'s
+ * after the last slash are considered.
+ *
+ * @return extension part from the path.
+ **/
+char *path_get_extension_mutable(const char *path)
+{
+   char *ext = NULL;
+   if (    !string_is_empty(path)
+       && ((ext = (char*)strrchr(path_basename(path), '.'))))
+      return ext;
+   return NULL;
+}
+
+/**
+ * path_remove_extension:
+ * @s                  : path
  *
  * Mutates path by removing its extension. Removes all
  * text after and including the last '.'.
  * Only '.'s after the last slash are considered.
  *
- * Returns:
+ * @return
  * 1) If path has an extension, returns path with the
  *    extension removed.
  * 2) If there is no extension, returns NULL.
  * 3) If path is empty or NULL, returns NULL
- */
-char *path_remove_extension(char *path)
+ **/
+char *path_remove_extension(char *s)
 {
-   char *last = !string_is_empty(path)
-      ? (char*)strrchr(path_basename(path), '.') : NULL;
+   char *last = path_get_extension_mutable(s);
    if (!last)
       return NULL;
    if (*last)
       *last = '\0';
-   return path;
+   return s;
 }
 
 /**
@@ -329,378 +286,381 @@ char *path_remove_extension(char *path)
  *
  * Checks if path is a compressed file.
  *
- * Returns: true (1) if path is a compressed file, otherwise false (0).
+ * @return true if path is a compressed file, otherwise false.
  **/
 bool path_is_compressed_file(const char* path)
 {
    const char *ext = path_get_extension(path);
-
-   if (     strcasestr(ext, "zip")
-         || strcasestr(ext, "apk")
-         || strcasestr(ext, "7z"))
-      return true;
-
+   if (!string_is_empty(ext))
+      return (   string_is_equal_noncase(ext, "zip")
+              || string_is_equal_noncase(ext, "apk")
+              || string_is_equal_noncase(ext, "7z"));
    return false;
 }
 
 /**
  * fill_pathname:
- * @out_path           : output path
+ * @s                  : output path
  * @in_path            : input  path
  * @replace            : what to replace
- * @size               : buffer size of output path
+ * @len                : buffer size of output path
  *
  * FIXME: Verify
  *
- * Replaces filename extension with 'replace' and outputs result to out_path.
+ * Replaces filename extension with 'replace' and outputs result to @s.
  * The extension here is considered to be the string from the last '.'
  * to the end.
  *
  * Only '.'s after the last slash are considered as extensions.
  * If no '.' is present, in_path and replace will simply be concatenated.
- * 'size' is buffer size of 'out_path'.
+ * 'len' is buffer size of 's'.
  * E.g.: in_path = "/foo/bar/baz/boo.c", replace = ".asm" =>
- * out_path = "/foo/bar/baz/boo.asm"
+ * s = "/foo/bar/baz/boo.asm"
  * E.g.: in_path = "/foo/bar/baz/boo.c", replace = ""     =>
- * out_path = "/foo/bar/baz/boo"
+ * s = "/foo/bar/baz/boo"
+ *
+ * @return Length of the string copied into @out
  */
-void fill_pathname(char *out_path, const char *in_path,
-      const char *replace, size_t size)
+size_t fill_pathname(char *s, const char *in_path,
+      const char *replace, size_t len)
 {
-   char tmp_path[PATH_MAX_LENGTH];
-   char *tok                      = NULL;
-
-   tmp_path[0] = '\0';
-
-   strlcpy(tmp_path, in_path, sizeof(tmp_path));
-   if ((tok = (char*)strrchr(path_basename(tmp_path), '.')))
-      *tok = '\0';
-
-   fill_pathname_noext(out_path, tmp_path, replace, size);
+   char *tok   = NULL;
+   size_t _len = strlcpy(s, in_path, len);
+   if ((tok = (char*)strrchr(path_basename(s), '.')))
+   {
+      *tok = '\0'; _len = tok - s;
+   }
+   _len += strlcpy(s + _len, replace,  len - _len);
+   return _len;
 }
+
 
 /**
- * fill_pathname_noext:
- * @out_path           : output path
- * @in_path            : input  path
- * @replace            : what to replace
- * @size               : buffer size of output path
+ * find_last_slash:
+ * @str                : path
+ * @size               : size of path
  *
- * Appends a filename extension 'replace' to 'in_path', and outputs
- * result in 'out_path'.
- *
- * Assumes in_path has no extension. If an extension is still
- * present in 'in_path', it will be ignored.
- *
- */
-void fill_pathname_noext(char *out_path, const char *in_path,
-      const char *replace, size_t size)
-{
-   strlcpy(out_path, in_path, size);
-   strlcat(out_path, replace, size);
-}
+ * Find last slash in path. Tries to find
+ * a backslash as used for Windows paths,
+ * otherwise checks for a regular slash.
 
+ * @return pointer to last slash/backslash found in @str.
+ **/
 char *find_last_slash(const char *str)
 {
-   const char *slash     = strrchr(str, '/');
-#ifdef _WIN32
-   const char *backslash = strrchr(str, '\\');
+   const char *p;
+   const char *last_slash     = NULL;
+   const char *last_backslash = NULL;
 
-   if (!slash || (backslash > slash))
-      return (char*)backslash;
-#endif
-   return (char*)slash;
+   /* Traverse the string once */
+   for (p = str; *p != '\0'; ++p)
+   {
+      if (*p == '/')
+         last_slash = p; /*   Update last forward slash */
+      else if (*p == '\\')
+         last_backslash = p; /* Update last backslash */
+   }
+
+   /* Determine which one is last */
+   if (!last_slash) /* Backslash */
+      return (char*)last_backslash;
+   if (!last_backslash) /* Forward slash */
+      return (char*)last_slash;
+   return (last_backslash > last_slash) ? (char*)last_backslash : (char*)last_slash;
 }
 
 /**
  * fill_pathname_slash:
- * @path               : path
- * @size               : size of path
+ * @s                  : path
+ * @len                : size of @s
  *
  * Assumes path is a directory. Appends a slash
  * if not already there.
  **/
-void fill_pathname_slash(char *path, size_t size)
+size_t fill_pathname_slash(char *s, size_t len)
 {
-   size_t path_len;
-   const char *last_slash = find_last_slash(path);
-
+   size_t _len         = strlen(s);
+   char *last_slash    = find_last_slash(s);
    if (!last_slash)
    {
-      strlcat(path, path_default_slash(), size);
-      return;
+      if (_len + 2 <= len)
+      {
+         s[  _len]     = PATH_DEFAULT_SLASH_C();
+         s[++_len]     = '\0';
+      }
    }
-
-   path_len               = strlen(path);
-   /* Try to preserve slash type. */
-   if (last_slash != (path + path_len - 1))
+   else if (last_slash != (s + _len - 1))
    {
-      char join_str[2];
-
-      join_str[0] = '\0';
-
-      strlcpy(join_str, last_slash, sizeof(join_str));
-      strlcat(path, join_str, size);
+      /* Try to preserve slash type. */
+      if (_len + 2 <= len)
+      {
+         s[  _len]     = last_slash[0];
+         s[++_len]     = '\0';
+      }
    }
+   return _len;
 }
 
 /**
  * fill_pathname_dir:
- * @in_dir             : input directory path
- * @in_basename        : input basename to be appended to @in_dir
+ * @s                  : input directory path
+ * @in_basename        : input basename to be appended to @s
  * @replace            : replacement to be appended to @in_basename
  * @size               : size of buffer
  *
- * Appends basename of 'in_basename', to 'in_dir', along with 'replace'.
+ * Appends basename of 'in_basename', to 's', along with 'replace'.
  * Basename of in_basename is the string after the last '/' or '\\',
  * i.e the filename without directories.
  *
  * If in_basename has no '/' or '\\', the whole 'in_basename' will be used.
- * 'size' is buffer size of 'in_dir'.
+ * 'size' is buffer size of 's'.
  *
- * E.g..: in_dir = "/tmp/some_dir", in_basename = "/some_content/foo.c",
- * replace = ".asm" => in_dir = "/tmp/some_dir/foo.c.asm"
+ * E.g..: s = "/tmp/some_dir", in_basename = "/some_content/foo.c",
+ * replace = ".asm" => s = "/tmp/some_dir/foo.c.asm"
  **/
-void fill_pathname_dir(char *in_dir, const char *in_basename,
-      const char *replace, size_t size)
+size_t fill_pathname_dir(char *s, const char *in_basename,
+      const char *replace, size_t len)
 {
-   const char *base = NULL;
-
-   fill_pathname_slash(in_dir, size);
-   base = path_basename(in_basename);
-   strlcat(in_dir, base, size);
-   strlcat(in_dir, replace, size);
+   size_t _len  = fill_pathname_slash(s, len);
+   _len        += strlcpy(s + _len, path_basename(in_basename), len - _len);
+   _len        += strlcpy(s + _len, replace, len - _len);
+   return _len;
 }
 
 /**
  * fill_pathname_base:
- * @out                : output path
+ * @s                  : output path
  * @in_path            : input path
- * @size               : size of output path
+ * @len                : size of output path
  *
- * Copies basename of @in_path into @out_path.
+ * Copies basename of @in_path into @s.
+ *
+ * @return Length of the string copied into @s
  **/
-void fill_pathname_base(char *out, const char *in_path, size_t size)
+size_t fill_pathname_base(char *s, const char *in_path, size_t len)
 {
    const char     *ptr = path_basename(in_path);
-
-   if (!ptr)
-      ptr = in_path;
-
-   strlcpy(out, ptr, size);
-}
-
-void fill_pathname_base_noext(char *out,
-      const char *in_path, size_t size)
-{
-   fill_pathname_base(out, in_path, size);
-   path_remove_extension(out);
-}
-
-void fill_pathname_base_ext(char *out,
-      const char *in_path, const char *ext,
-      size_t size)
-{
-   fill_pathname_base_noext(out, in_path, size);
-   strlcat(out, ext, size);
+   if (ptr)
+      return strlcpy(s, ptr, len);
+   return strlcpy(s, in_path, len);
 }
 
 /**
  * fill_pathname_basedir:
- * @out_dir            : output directory
+ * @s                  : output directory
  * @in_path            : input path
- * @size               : size of output directory
+ * @len                : size of output directory
  *
- * Copies base directory of @in_path into @out_path.
+ * Copies base directory of @in_path into @s.
  * If in_path is a path without any slashes (relative current directory),
- * @out_path will get path "./".
+ * @s will get path "./".
+ *
+ * @return Length of the string copied in @s
  **/
-void fill_pathname_basedir(char *out_dir,
-      const char *in_path, size_t size)
+size_t fill_pathname_basedir(char *s, const char *in_path, size_t len)
 {
-   if (out_dir != in_path)
-      strlcpy(out_dir, in_path, size);
-   path_basedir(out_dir);
-}
-
-void fill_pathname_basedir_noext(char *out_dir,
-      const char *in_path, size_t size)
-{
-   fill_pathname_basedir(out_dir, in_path, size);
-   path_remove_extension(out_dir);
+   if (s != in_path)
+      strlcpy(s, in_path, len);
+   return path_basedir(s);
 }
 
 /**
  * fill_pathname_parent_dir_name:
- * @out_dir            : output directory
+ * @s                  : output string
  * @in_dir             : input directory
- * @size               : size of output directory
+ * @len                : size of @s
  *
- * Copies only the parent directory name of @in_dir into @out_dir.
+ * Copies only the parent directory name of @in_dir into @s.
  * The two buffers must not overlap. Removes trailing '/'.
- * Returns true on success, false if a slash was not found in the path.
+ *
+ * @return Length of the string copied into @s
  **/
-bool fill_pathname_parent_dir_name(char *out_dir,
-      const char *in_dir, size_t size)
+size_t fill_pathname_parent_dir_name(char *s, const char *in_dir, size_t len)
 {
-   bool success = false;
-   char *temp   = strdup(in_dir);
-   char *last   = find_last_slash(temp);
+   size_t _len        = 0;
+   char *tmp          = strdup(in_dir);
+   char *last_slash;
 
-   if (last && last[1] == 0)
+   if (len)
+      s[0]            = '\0';
+
+   if (!tmp)
+      return 0;
+
+   last_slash         = find_last_slash(tmp);
+
+   if (last_slash && last_slash[1] == '\0')
    {
-      *last     = '\0';
-      last      = find_last_slash(temp);
+      *last_slash     = '\0';
+      last_slash      = find_last_slash(tmp);
    }
 
-   if (last)
-      *last     = '\0';
+   /* Cut the last part of the string (the filename) after the slash,
+      leaving the directory name (or nested directory names) only. */
+   if (last_slash)
+      *last_slash     = '\0';
 
-   in_dir       = find_last_slash(temp);
+   /* Point in_dir to the address of the last slash.
+    * If NULL, it means there was no slash in tmp,
+    * so use tmp as-is. */
+   if (!(in_dir = find_last_slash(tmp)))
+       in_dir         = tmp;
 
-   success      = in_dir && in_dir[1];
+   if (in_dir[1])
+   {
+       /* If path starts with a slash, skip past it. */
+       if (path_is_absolute(in_dir) || in_dir[0] == '\\')
+           _len = strlcpy(s, in_dir + 1, len);
+       else
+           _len = strlcpy(s, in_dir,     len);
+   }
 
-   if (success)
-      strlcpy(out_dir, in_dir + 1, size);
-
-   free(temp);
-   return success;
+   free(tmp);
+   return _len;
 }
 
 /**
  * fill_pathname_parent_dir:
- * @out_dir            : output directory
+ * @s                  : output directory
  * @in_dir             : input directory
- * @size               : size of output directory
+ * @len                : size of @s
  *
- * Copies parent directory of @in_dir into @out_dir.
+ * Copies parent directory of @in_dir into @s.
  * Assumes @in_dir is a directory. Keeps trailing '/'.
- * If the path was already at the root directory, @out_dir will be an empty string.
+ * If the path was already at the root directory,
+ * @s will be an empty string.
  **/
-void fill_pathname_parent_dir(char *out_dir,
-      const char *in_dir, size_t size)
+size_t fill_pathname_parent_dir(char *s,
+      const char *in_dir, size_t len)
 {
-   if (out_dir != in_dir)
-      strlcpy(out_dir, in_dir, size);
-   path_parent_dir(out_dir);
+   size_t _len = 0;
+   if (s == in_dir)
+      _len = strlen(s);
+   else
+      _len = strlcpy(s, in_dir, len);
+   return path_parent_dir(s, _len);
 }
 
 /**
  * fill_dated_filename:
- * @out_filename       : output filename
+ * @s                  : output filename
  * @ext                : extension of output filename
- * @size               : buffer size of output filename
+ * @len                : buffer size of output filename
  *
- * Creates a 'dated' filename prefixed by 'RetroArch', and
+ * Creates a 'dated' filename prefixed by 'retroarch', and
  * concatenates extension (@ext) to it.
  *
  * E.g.:
- * out_filename = "RetroArch-{month}{day}-{Hours}{Minutes}.{@ext}"
+ * s = "retroarch-{year}{month}{day}-{Hour}{Minute}{Second}.{@ext}"
  **/
-void fill_dated_filename(char *out_filename,
-      const char *ext, size_t size)
+size_t fill_dated_filename(char *s,
+      const char *ext, size_t len)
 {
-   time_t       cur_time = time(NULL);
-   const struct tm* tm_  = localtime(&cur_time);
-
-   strftime(out_filename, size,
-         "RetroArch-%m%d-%H%M%S", tm_);
-   strlcat(out_filename, ext, size);
+   size_t _len;
+   struct tm tm_;
+   time_t cur_time = time(NULL);
+   rtime_localtime(&cur_time, &tm_);
+   _len  = strftime(s, len,
+         "retroarch-%y%m%d-%H%M%S", &tm_);
+   _len += strlcpy(s + _len, ext, len - _len);
+   return _len;
 }
 
 /**
  * fill_str_dated_filename:
- * @out_filename       : output filename
+ * @s                  : output filename
  * @in_str             : input string
  * @ext                : extension of output filename
- * @size               : buffer size of output filename
+ * @len                : buffer size of output filename
  *
  * Creates a 'dated' filename prefixed by the string @in_str, and
  * concatenates extension (@ext) to it.
  *
  * E.g.:
- * out_filename = "RetroArch-{year}{month}{day}-{Hour}{Minute}{Second}.{@ext}"
+ * s = "RetroArch-{year}{month}{day}-{Hour}{Minute}{Second}.{@ext}"
+ *
+ * @return Length of the string copied into @s
  **/
-void fill_str_dated_filename(char *out_filename,
-      const char *in_str, const char *ext, size_t size)
+size_t fill_str_dated_filename(char *s,
+      const char *in_str, const char *ext, size_t len)
 {
-   char format[256];
-   time_t cur_time      = time(NULL);
-   const struct tm* tm_ = localtime(&cur_time);
-
-   format[0]            = '\0';
-
+   struct tm tm_;
+   size_t _len     = 0;
+   time_t cur_time = time(NULL);
+   rtime_localtime(&cur_time, &tm_);
+   _len      = strlcpy(s, in_str, len);
    if (string_is_empty(ext))
-   {
-      strftime(format, sizeof(format), "-%y%m%d-%H%M%S", tm_);
-      fill_pathname_noext(out_filename, in_str, format, size);
-   }
+      _len += strftime(s + _len, len - _len, "-%y%m%d-%H%M%S", &tm_);
    else
    {
-      strftime(format, sizeof(format), "-%y%m%d-%H%M%S.", tm_);
-
-      fill_pathname_join_concat_noext(out_filename,
-            in_str, format, ext,
-            size);
+      _len  += strftime(s + _len, len - _len, "-%y%m%d-%H%M%S.", &tm_);
+      _len  += strlcpy(s + _len, ext,    len - _len);
    }
+   return _len;
 }
 
 /**
  * path_basedir:
- * @path               : path
+ * @s                  : path
  *
  * Extracts base directory by mutating path.
  * Keeps trailing '/'.
+ *
+ * @return The new size of @s
  **/
-void path_basedir(char *path)
+size_t path_basedir(char *s)
 {
-   char *last = NULL;
-   if (strlen(path) < 2)
-      return;
-
-   last = find_last_slash(path);
-
-   if (last)
-      last[1] = '\0';
-   else
-      snprintf(path, 3, ".%s", path_default_slash());
+   char *last_slash = NULL;
+   if (!s || s[0] == '\0' || s[1] == '\0')
+      return (s && s[0] != '\0') ? 1 : 0;
+   last_slash       = find_last_slash(s);
+   if (last_slash)
+   {
+      last_slash[1] = '\0';
+      return last_slash + 1 - s;
+   }
+   s[0]             = '.';
+   s[1]             = PATH_DEFAULT_SLASH_C();
+   s[2]             = '\0';
+   return 2;
 }
 
 /**
  * path_parent_dir:
- * @path               : path
+ * @s                  : path
+ * @len                : length of @path
  *
  * Extracts parent directory by mutating path.
- * Assumes that path is a directory. Keeps trailing '/'.
+ * Assumes that @s is a directory. Keeps trailing '/'.
  * If the path was already at the root directory, returns empty string
+ *
+ * @return The new size of @s
  **/
-void path_parent_dir(char *path)
+size_t path_parent_dir(char *s, size_t len)
 {
-   size_t len = 0;
+   if (!s)
+      return 0;
 
-   if (!path)
-      return;
-   
-   len = strlen(path);
-
-   if (len && path_char_is_slash(path[len - 1]))
+   if (len && PATH_CHAR_IS_SLASH(s[len - 1]))
    {
-      bool path_was_absolute = path_is_absolute(path);
+      char *last_slash;
+      bool was_absolute = path_is_absolute(s);
 
-      path[len - 1] = '\0';
+      s[len - 1]        = '\0';
+      last_slash        = find_last_slash(s);
 
-      if (path_was_absolute && !find_last_slash(path))
+      if (was_absolute && !last_slash)
       {
          /* We removed the only slash from what used to be an absolute path.
           * On Linux, this goes from "/" to an empty string and everything works fine,
           * but on Windows, we went from C:\ to C:, which is not a valid path and that later
-          * gets errornously treated as a relative one by path_basedir and returns "./".
+          * gets erroneously treated as a relative one by path_basedir and returns "./".
           * What we really wanted is an empty string. */
-         path[0] = '\0';
-         return;
+         s[0] = '\0';
+         return 0;
       }
    }
-   path_basedir(path);
+   return path_basedir(s);
 }
 
 /**
@@ -709,23 +669,33 @@ void path_parent_dir(char *path)
  *
  * Get basename from @path.
  *
- * Returns: basename from path.
+ * @return basename from path.
  **/
 const char *path_basename(const char *path)
 {
-   /* We cut at the first compression-related hash */
-   const char *delim = path_get_archive_delim(path);
-   if (delim)
-      return delim + 1;
+   /* We cut either at the first compression-related hash,
+    * or we cut at the last slash */
+   const char *ptr       = NULL;
+   char *last_slash      = find_last_slash(path);
+   return ((ptr = path_get_archive_delim(path)) || (ptr = last_slash))
+      ? (ptr + 1) : path;
+}
 
-   {
-      /* We cut at the last slash */
-      const char *last  = find_last_slash(path);
-      if (last)
-         return last + 1;
-   }
-
-   return path;
+/* Specialized version */
+/**
+ * path_basename_nocompression:
+ * @path               : path
+ *
+ * Specialized version of path_basename().
+ * Get basename from @path.
+ *
+ * @return basename from path.
+ **/
+const char *path_basename_nocompression(const char *path)
+{
+   /* We cut at the last slash */
+   char *last_slash = find_last_slash(path);
+   return (last_slash) ? (last_slash + 1) : path;
 }
 
 /**
@@ -734,342 +704,438 @@ const char *path_basename(const char *path)
  *
  * Checks if @path is an absolute path or a relative path.
  *
- * Returns: true if path is absolute, false if path is relative.
+ * @return true if path is absolute, false if path is relative.
  **/
 bool path_is_absolute(const char *path)
 {
-   if (path[0] == '/')
-      return true;
-#ifdef _WIN32
-   /* Many roads lead to Rome ... */
-   if ((    strstr(path, "\\\\") == path)
-         || strstr(path, ":/")
-         || strstr(path, ":\\")
-         || strstr(path, ":\\\\"))
-      return true;
-#elif defined(__wiiu__)
-   if (strstr(path, ":/"))
-      return true;
+   if (!string_is_empty(path))
+   {
+      if (path[0] == '/')
+         return true;
+#if defined(_WIN32)
+      /* Many roads lead to Rome...
+       * Note: Drive letter can only be 1 character long */
+      return ( string_starts_with_size(path,     "\\\\", STRLEN_CONST("\\\\"))
+            || string_starts_with_size(path + 1, ":/",   STRLEN_CONST(":/"))
+            || string_starts_with_size(path + 1, ":\\",  STRLEN_CONST(":\\")));
+#elif defined(__wiiu__) || defined(VITA)
+      {
+         const char *separator = strchr(path, ':');
+         return (separator && (separator[1] == '/'));
+      }
 #endif
+   }
+
    return false;
 }
 
 /**
  * path_resolve_realpath:
- * @buf                : buffer for path
- * @size               : size of buffer
+ * @s                  : input and output buffer for path
+ * @len                : size of @s
+ * @resolve_symlinks   : whether to resolve symlinks or not
  *
- * Turns relative paths into absolute paths and
- * resolves use of "." and ".." in absolute paths.
- * If relative, rebases on current working dir.
+ * Resolves use of ".", "..", multiple slashes etc in absolute paths.
+ *
+ * Relative paths are rebased on the current working dir.
+ *
+ * @return @s if successful, NULL otherwise.
+ * Note: Not implemented on consoles
+ * Note: Symlinks are only resolved on Unix-likes
+ * Note: The current working dir might not be what you expect,
+ *       e.g. on Android it is "/"
+ *       Use of fill_pathname_resolve_relative() should be preferred
  **/
-void path_resolve_realpath(char *buf, size_t size)
+char *path_resolve_realpath(char *s, size_t len, bool resolve_symlinks)
 {
 #if !defined(RARCH_CONSOLE) && defined(RARCH_INTERNAL)
-   char tmp[PATH_MAX_LENGTH];
-
-   tmp[0] = '\0';
-
-   strlcpy(tmp, buf, sizeof(tmp));
-
 #ifdef _WIN32
-   if (!_fullpath(buf, tmp, size))
-      strlcpy(buf, tmp, size);
-#else
+   char *ret         = NULL;
+   wchar_t *rel_path = utf8_to_utf16_string_alloc(s);
 
-   /* NOTE: realpath() expects at least PATH_MAX_LENGTH bytes in buf.
-    * Technically, PATH_MAX_LENGTH needn't be defined, but we rely on it anyways.
-    * POSIX 2008 can automatically allocate for you,
-    * but don't rely on that. */
-   if (!realpath(tmp, buf))
-      strlcpy(buf, tmp, size);
-#endif
-#endif
+   if (rel_path)
+   {
+      wchar_t abs_path[PATH_MAX_LENGTH];
+
+      if (_wfullpath(abs_path, rel_path, PATH_MAX_LENGTH))
+      {
+         char *tmp = utf16_to_utf8_string_alloc(abs_path);
+
+         if (tmp)
+         {
+            strlcpy(s, tmp, len);
+            free(tmp);
+            ret = s;
+         }
+      }
+
+      free(rel_path);
+   }
+
+   return ret;
+#else
+   char tmp[PATH_MAX_LENGTH];
+   size_t t;
+   char *p;
+   const char *next;
+   const char *buf_end;
+
+   if (resolve_symlinks)
+   {
+      strlcpy(tmp, s, sizeof(tmp));
+
+      /* NOTE: realpath() expects at least PATH_MAX_LENGTH bytes in @s.
+       * Technically, PATH_MAX_LENGTH needn't be defined, but we rely on it anyways.
+       * POSIX 2008 can automatically allocate for you,
+       * but don't rely on that. */
+      if (!realpath(tmp, s))
+      {
+         strlcpy(s, tmp, len);
+         return NULL;
+      }
+
+      return s;
+   }
+
+   t       = 0; /* length of output */
+   buf_end = s + strlen(s);
+
+   if (!path_is_absolute(s))
+   {
+      size_t _len;
+      /* rebase on working directory */
+      if (!getcwd(tmp, PATH_MAX_LENGTH - 1))
+         return NULL;
+
+      _len = strlen(tmp);
+      t  += _len;
+
+      if (tmp[_len - 1] != '/')
+         tmp[t++] = '/';
+
+      if (string_is_empty(s))
+      {
+         tmp[t] = '\0';
+         strlcpy(s, tmp, len);
+         return s;
+      }
+
+      p = s;
+   }
+   else
+   {
+      /* UNIX paths can start with multiple '/', copy those */
+      for (p = s; *p == '/'; p++)
+         tmp[t++] = '/';
+   }
+
+   /* p points to just after a slash while 'next' points to the next slash
+    * if there are no slashes, they point relative to where one would be */
+   do
+   {
+      if (!(next = strchr(p, '/')))
+         next = buf_end;
+
+      if ((next - p == 2 && p[0] == '.' && p[1] == '.'))
+      {
+         p += 3;
+
+         /* fail for illegal /.., //.. etc */
+         if (t == 1 || tmp[t-2] == '/')
+            return NULL;
+
+         /* delete previous segment in tmp by adjusting size t
+          * tmp[t - 1] == '/', find '/' before that */
+         t -= 2;
+         while (tmp[t] != '/')
+            t--;
+         t++;
+      }
+      else if (next - p == 1 && p[0] == '.')
+         p += 2;
+      else if (next - p == 0)
+         p += 1;
+      else
+      {
+         /* fail when truncating */
+         if (t + next - p + 1 > PATH_MAX_LENGTH - 1)
+            return NULL;
+
+         while (p <= next)
+            tmp[t++] = *p++;
+      }
+   } while(next < buf_end);
+
+   tmp[t] = '\0';
+   strlcpy(s, tmp, len);
+   return s;
+#endif /* !_WIN32 */
+#endif /* !RARCH_CONSOLE && RARCH_INTERNAL */
+   return NULL;
 }
 
 /**
  * path_relative_to:
- * @out                : buffer to write the relative path to
+ * @s                  : buffer to write the relative path to
  * @path               : path to be expressed relatively
  * @base               : base directory to start out on
- * @size               : size of output buffer
+ * @len                : size of @s
  *
- * Turns @path into a path relative to @base and writes it to @out.
+ * Turns @path into a path relative to @base and writes it to @s.
  *
  * @base is assumed to be a base directory, i.e. a path ending with '/' or '\'.
  * Both @path and @base are assumed to be absolute paths without "." or "..".
  *
  * E.g. path /a/b/e/f.cg with base /a/b/c/d/ turns into ../../e/f.cg
+ *
+ * @return Length of the string copied into @s
  **/
-void path_relative_to(char *out,
-      const char *path, const char *base, size_t size)
+size_t path_relative_to(char *s,
+      const char *path, const char *base, size_t len)
 {
-   unsigned i;
+   size_t i, j;
+   size_t _len;
    const char *trimmed_path, *trimmed_base;
 
 #ifdef _WIN32
    /* For different drives, return absolute path */
-   if (strlen(path) >= 2 && strlen(base) >= 2
-         && path[1] == ':' && base[1] == ':'
+   if (
+            path
+         && base
+         && path[0] != '\0'
+         && path[1] != '\0'
+         && base[0] != '\0'
+         && base[1] != '\0'
+         && path[1] == ':'
+         && base[1] == ':'
          && path[0] != base[0])
-   {
-      out[0] = '\0';
-      strlcat(out, path, size);
-   }
+      return strlcpy(s, path, len);
 #endif
 
-   /* Trim common beginning */
-   for (i = 0; path[i] && base[i] && path[i] == base[i]; )
-      i++;
-   trimmed_path = path+i;
-   trimmed_base = base+i;
+   /* Trim common beginning - recognize both slash types */
+   for (i = 0, j = 0; path[i] && base[i] && path[i] == base[i]; i++)
+      if (PATH_CHAR_IS_SLASH(path[i]))
+         j = i + 1;
+
+   trimmed_path = path + j;
+   trimmed_base = base + i;
 
    /* Each segment of base turns into ".." */
-   out[0] = '\0';
+   _len = 0;
    for (i = 0; trimmed_base[i]; i++)
-      if (trimmed_base[i] == '/' || trimmed_base[i] == '\\')
-         strlcat(out, "../", size); /* Use '/' as universal separator */
-   strlcat(out, trimmed_path, size);
+   {
+      if (PATH_CHAR_IS_SLASH(trimmed_base[i]))
+      {
+         if (_len + 3 < len)
+         {
+            s[_len++] = '.';
+            s[_len++] = '.';
+            s[_len++] = PATH_DEFAULT_SLASH_C();
+         }
+      }
+   }
+   s[_len] = '\0';
+
+   _len += strlcpy(s + _len, trimmed_path, len - _len);
+   return _len;
 }
 
 /**
  * fill_pathname_resolve_relative:
- * @out_path           : output path
+ * @s                  : output path
  * @in_refpath         : input reference path
  * @in_path            : input path
- * @size               : size of @out_path
+ * @len                : size of @s
  *
  * Joins basedir of @in_refpath together with @in_path.
- * If @in_path is an absolute path, out_path = in_path.
+ * If @in_path is an absolute path, s = in_path.
  * E.g.: in_refpath = "/foo/bar/baz.a", in_path = "foobar.cg",
- * out_path = "/foo/bar/foobar.cg".
+ * s = "/foo/bar/foobar.cg".
  **/
-void fill_pathname_resolve_relative(char *out_path,
-      const char *in_refpath, const char *in_path, size_t size)
+void fill_pathname_resolve_relative(char *s,
+      const char *in_refpath, const char *in_path, size_t len)
 {
+   size_t _len;
    if (path_is_absolute(in_path))
    {
-      strlcpy(out_path, in_path, size);
+      strlcpy(s, in_path, len);
       return;
    }
 
-   fill_pathname_basedir(out_path, in_refpath, size);
-   strlcat(out_path, in_path, size);
-   path_resolve_realpath(out_path, size);
+   _len = fill_pathname_basedir(s, in_refpath, len);
+   strlcpy(s + _len, in_path, len - _len);
+   path_resolve_realpath(s, len, false);
 }
 
 /**
  * fill_pathname_join:
- * @out_path           : output path
+ * @s                  : output path
  * @dir                : directory
  * @path               : path
- * @size               : size of output path
+ * @len                : size of output path
  *
  * Joins a directory (@dir) and path (@path) together.
  * Makes sure not to get  two consecutive slashes
  * between directory and path.
+ *
+ * Deprecated. Use fill_pathname_join_special() instead
+ * if you can ensure @dir and @s won't overlap.
+ *
+ * @return Length of the string copied into @s
  **/
-void fill_pathname_join(char *out_path,
-      const char *dir, const char *path, size_t size)
+size_t fill_pathname_join(char *s, const char *dir,
+      const char *path, size_t len)
 {
-   if (out_path != dir)
-      strlcpy(out_path, dir, size);
-
-   if (*out_path)
-      fill_pathname_slash(out_path, size);
-
-   strlcat(out_path, path, size);
+   size_t _len = 0;
+   if (s != dir)
+      _len = strlcpy(s, dir, len);
+   if (*s)
+      _len = fill_pathname_slash(s, len);
+   _len   += strlcpy(s + _len, path, len - _len);
+   return _len;
 }
 
-void fill_pathname_join_special_ext(char *out_path,
+/**
+ * fill_pathname_join_special:
+ * @s                  : output path
+ * @dir                : directory. Cannot be identical to @s
+ * @path               : path
+ * @len                : size of @s
+ *
+ * Specialized version of fill_pathname_join.
+ * Unlike fill_pathname_join(),
+ * @dir and @s CANNOT be identical.
+ *
+ * Joins a directory (@dir) and path (@path) together.
+ * Makes sure not to get  two consecutive slashes
+ * between directory and path.
+ *
+ * @return Length of the string copied into @s
+ **/
+size_t fill_pathname_join_special(char *s,
+      const char *dir, const char *path, size_t len)
+{
+   size_t _len = strlcpy(s, dir, len);
+
+   if (*s)
+   {
+      char *last_slash = find_last_slash(s);
+      if (!last_slash)
+      {
+         if (_len + 2 <= len)
+         {
+            s[  _len]     = PATH_DEFAULT_SLASH_C();
+            s[++_len]     = '\0';
+         }
+      }
+      else if (last_slash != (s + _len - 1))
+      {
+         /* Try to preserve slash type. */
+         if (_len + 2 <= len)
+         {
+            s[  _len]     = last_slash[0];
+            s[++_len]     = '\0';
+         }
+      }
+   }
+
+   _len += strlcpy(s + _len, path, len - _len);
+   return _len;
+}
+
+size_t fill_pathname_join_special_ext(char *s,
       const char *dir,  const char *path,
       const char *last, const char *ext,
-      size_t size)
+      size_t len)
 {
-   fill_pathname_join(out_path, dir, path, size);
-   if (*out_path)
-      fill_pathname_slash(out_path, size);
-
-   strlcat(out_path, last, size);
-   strlcat(out_path, ext, size);
-}
-
-void fill_pathname_join_concat_noext(char *out_path,
-      const char *dir, const char *path,
-      const char *concat,
-      size_t size)
-{
-   fill_pathname_noext(out_path, dir, path, size);
-   strlcat(out_path, concat, size);
-}
-
-void fill_pathname_join_concat(char *out_path,
-      const char *dir, const char *path,
-      const char *concat,
-      size_t size)
-{
-   fill_pathname_join(out_path, dir, path, size);
-   strlcat(out_path, concat, size);
-}
-
-void fill_pathname_join_noext(char *out_path,
-      const char *dir, const char *path, size_t size)
-{
-   fill_pathname_join(out_path, dir, path, size);
-   path_remove_extension(out_path);
+   size_t _len = fill_pathname_join(s, dir, path, len);
+   if (*s)
+      _len     = fill_pathname_slash(s, len);
+   _len       += strlcpy(s + _len, last, len - _len);
+   _len       += strlcpy(s + _len, ext,  len - _len);
+   return _len;
 }
 
 /**
  * fill_pathname_join_delim:
- * @out_path           : output path
+ * @s                  : output path
  * @dir                : directory
  * @path               : path
  * @delim              : delimiter
- * @size               : size of output path
+ * @len                : size of output path
  *
  * Joins a directory (@dir) and path (@path) together
  * using the given delimiter (@delim).
  **/
-void fill_pathname_join_delim(char *out_path, const char *dir,
-      const char *path, const char delim, size_t size)
+size_t fill_pathname_join_delim(char *s, const char *dir,
+      const char *path, const char delim, size_t len)
 {
-   size_t copied;
-   /* behavior of strlcpy is undefined if dst and src overlap */
-   if (out_path == dir)
-      copied = strlen(dir);
+   size_t _len;
+   /* Behavior of strlcpy is undefined if dst and src overlap */
+   if (s == dir)
+      _len     = strlen(dir);
    else
-      copied = strlcpy(out_path, dir, size);
-
-   out_path[copied]   = delim;
-   out_path[copied+1] = '\0';
-
+      _len     = strlcpy(s, dir, len);
+   if (len - _len < 2)
+      return _len;
+   s[_len++]   = delim;
+   s[_len  ]   = '\0';
    if (path)
-      strlcat(out_path, path, size);
+      _len    += strlcpy(s + _len, path, len - _len);
+   return _len;
 }
 
-void fill_pathname_join_delim_concat(char *out_path, const char *dir,
-      const char *path, const char delim, const char *concat,
-      size_t size)
-{
-   fill_pathname_join_delim(out_path, dir, path, delim, size);
-   strlcat(out_path, concat, size);
-}
-
-/**
- * fill_short_pathname_representation:
- * @out_rep            : output representation
- * @in_path            : input path
- * @size               : size of output representation
- *
- * Generates a short representation of path. It should only
- * be used for displaying the result; the output representation is not
- * binding in any meaningful way (for a normal path, this is the same as basename)
- * In case of more complex URLs, this should cut everything except for
- * the main image file.
- *
- * E.g.: "/path/to/game.img" -> game.img
- *       "/path/to/myarchive.7z#folder/to/game.img" -> game.img
- */
-void fill_short_pathname_representation(char* out_rep,
-      const char *in_path, size_t size)
-{
-   char path_short[PATH_MAX_LENGTH];
-
-   path_short[0] = '\0';
-
-   fill_pathname(path_short, path_basename(in_path), "",
-            sizeof(path_short));
-
-   strlcpy(out_rep, path_short, size);
-}
-
-void fill_short_pathname_representation_noext(char* out_rep,
-      const char *in_path, size_t size)
-{
-   fill_short_pathname_representation(out_rep, in_path, size);
-   path_remove_extension(out_rep);
-}
-
-void fill_pathname_expand_special(char *out_path,
-      const char *in_path, size_t size)
+size_t fill_pathname_expand_special(char *s, const char *in_path, size_t len)
 {
 #if !defined(RARCH_CONSOLE) && defined(RARCH_INTERNAL)
+   char *app_dir = NULL;
    if (in_path[0] == '~')
    {
-      char *home_dir = (char*)malloc(PATH_MAX_LENGTH * sizeof(char));
-
-      home_dir[0] = '\0';
-
-      fill_pathname_home_dir(home_dir,
-         PATH_MAX_LENGTH * sizeof(char));
-
-      if (*home_dir)
-      {
-         size_t src_size = strlcpy(out_path, home_dir, size);
-         retro_assert(src_size < size);
-
-         out_path  += src_size;
-         size      -= src_size;
-
-         if (!path_char_is_slash(out_path[-1]))
-         {
-            src_size = strlcpy(out_path, path_default_slash(), size);
-            retro_assert(src_size < size);
-
-            out_path += src_size;
-            size -= src_size;
-         }
-
-         in_path += 2;
-      }
-
-      free(home_dir);
+      app_dir    = (char*)malloc(DIR_MAX_LENGTH * sizeof(char));
+      fill_pathname_home_dir(app_dir, DIR_MAX_LENGTH * sizeof(char));
    }
    else if (in_path[0] == ':')
    {
-      char *application_dir = (char*)malloc(PATH_MAX_LENGTH * sizeof(char));
+      app_dir    = (char*)malloc(DIR_MAX_LENGTH * sizeof(char));
+      app_dir[0] = '\0';
+      fill_pathname_application_dir(app_dir, DIR_MAX_LENGTH * sizeof(char));
+   }
 
-      application_dir[0]    = '\0';
-
-      fill_pathname_application_dir(application_dir,
-            PATH_MAX_LENGTH * sizeof(char));
-
-      if (*application_dir)
+   if (app_dir)
+   {
+      if (*app_dir)
       {
-         size_t src_size   = strlcpy(out_path, application_dir, size);
-         retro_assert(src_size < size);
+         size_t _len  = strlcpy(s, app_dir, len);
 
-         out_path  += src_size;
-         size      -= src_size;
+         s           += _len;
+         len         -= _len;
 
-         if (!path_char_is_slash(out_path[-1]))
+         if (!PATH_CHAR_IS_SLASH(s[-1]))
          {
-            src_size = strlcpy(out_path, path_default_slash(), size);
-            retro_assert(src_size < size);
+            _len      = strlcpy(s, PATH_DEFAULT_SLASH(), len);
 
-            out_path += src_size;
-            size     -= src_size;
+            s        += _len;
+            len      -= _len;
          }
 
          in_path += 2;
       }
 
-      free(application_dir);
+      free(app_dir);
    }
 #endif
-
-   retro_assert(strlcpy(out_path, in_path, size) < size);
+   return strlcpy(s, in_path, len);
 }
 
-void fill_pathname_abbreviate_special(char *out_path,
-      const char *in_path, size_t size)
+size_t fill_pathname_abbreviate_special(char *s,
+      const char *in_path, size_t len)
 {
 #if !defined(RARCH_CONSOLE) && defined(RARCH_INTERNAL)
    unsigned i;
    const char *candidates[3];
    const char *notations[3];
-   char *application_dir     = (char*)malloc(PATH_MAX_LENGTH * sizeof(char));
-   char *home_dir            = (char*)malloc(PATH_MAX_LENGTH * sizeof(char));
+   char application_dir[DIR_MAX_LENGTH];
+   char home_dir[DIR_MAX_LENGTH];
 
    application_dir[0] = '\0';
 
@@ -1088,201 +1154,358 @@ void fill_pathname_abbreviate_special(char *out_path,
    notations [1] = "~";
    notations [2] = NULL;
 
-   fill_pathname_application_dir(application_dir,
-         PATH_MAX_LENGTH * sizeof(char));
-   fill_pathname_home_dir(home_dir,
-         PATH_MAX_LENGTH * sizeof(char));
+   fill_pathname_application_dir(application_dir, sizeof(application_dir));
+   fill_pathname_home_dir(home_dir, sizeof(home_dir));
 
    for (i = 0; candidates[i]; i++)
    {
-      if (!string_is_empty(candidates[i]) &&
-            strstr(in_path, candidates[i]) == in_path)
+      if (  !string_is_empty(candidates[i])
+          && string_starts_with(in_path, candidates[i]))
       {
-         size_t src_size  = strlcpy(out_path, notations[i], size);
+         size_t _len     = strlcpy(s, notations[i], len);
 
-         retro_assert(src_size < size);
+         s              += _len;
+         len            -= _len;
+         in_path        += strlen(candidates[i]);
 
-         out_path        += src_size;
-         size            -= src_size;
-         in_path         += strlen(candidates[i]);
-
-         if (!path_char_is_slash(*in_path))
+         if (!PATH_CHAR_IS_SLASH(*in_path))
          {
-            retro_assert(strlcpy(out_path,
-                     path_default_slash(), size) < size);
-            out_path++;
-            size--;
+            size_t sl    = strlcpy(s, PATH_DEFAULT_SLASH(), len);
+            s           += sl;
+            len         -= sl;
          }
 
          break; /* Don't allow more abbrevs to take place. */
       }
    }
-
-   free(application_dir);
-   free(home_dir);
 #endif
+   return strlcpy(s, in_path, len);
+}
 
-   retro_assert(strlcpy(out_path, in_path, size) < size);
+/**
+ * sanitize_path_part:
+ *
+ * @path_part               : directory or filename
+ * @len                     : length of path_part
+ *
+ * Takes single part of a path eg. single filename
+ * or directory, and removes any special chars that are
+ * unavailable.
+ *
+ * @returns newly allocated string that has been sanitized.
+ * Caller is responsible for freeing the returned string.
+ **/
+char *sanitize_path_part(const char *path_part, size_t len)
+{
+   size_t i;
+   size_t j = 0;
+   char *tmp = NULL;
+
+   if (string_is_empty(path_part))
+      return NULL;
+
+   tmp = (char *)malloc((len + 1) * sizeof(char));
+   if (!tmp)
+      return NULL;
+
+   for (i = 0; path_part[i] != '\0'; i++)
+   {
+      char c = path_part[i];
+      /* Skip filesystem-unsafe characters */
+      switch (c)
+      {
+         case '<':
+         case '>':
+         case ':':
+         case '"':
+         case '/':
+         case '\\':
+         case '|':
+         case '?':
+         case '*':
+            break;
+         default:
+            tmp[j++] = c;
+            break;
+      }
+   }
+
+   tmp[j] = '\0';
+
+   return tmp;
+}
+
+/**
+ * pathname_conform_slashes_to_os:
+ *
+ * @s                  : path
+ *
+ * Leaf function.
+ *
+ * Changes the slashes to the correct kind for the OS
+ * So forward slash on linux and backslash on Windows
+ **/
+void pathname_conform_slashes_to_os(char *s)
+{
+   /* Conform slashes to OS standard 
+    * so we get proper matching */
+   char *p;
+   for (p = s; *p; p++)
+      if (*p == '/' || *p == '\\')
+         *p = PATH_DEFAULT_SLASH_C();
+}
+
+/**
+ * pathname_make_slashes_portable:
+ * @s                  : path
+ *
+ * Leaf function.
+ *
+ * Change all slashes to forward so they are more
+ * portable between Windows and Linux
+ **/
+void pathname_make_slashes_portable(char *s)
+{
+   /* Conform slashes to OS standard 
+    * so we get proper matching */
+   char *p;
+   for (p = s; *p; p++)
+      if (*p == '/' || *p == '\\')
+         *p = '/';
+}
+
+/**
+ * get_pathname_num_slashes:
+ * @in_path            : input path
+ *
+ * Leaf function.
+ *
+ * Get the number of slashes in a path.
+ *
+ * @return number of slashes found in @in_path.
+ **/
+static int get_pathname_num_slashes(const char *in_path)
+{
+   int num_slashes = 0;
+   const char *p;
+   for (p = in_path; *p != '\0'; p++)
+   {
+      if (PATH_CHAR_IS_SLASH(*p))
+         num_slashes++;
+   }
+   return num_slashes;
+}
+
+/**
+ * fill_pathname_abbreviated_or_relative:
+ *
+ * Fills the supplied path with either the abbreviated path or
+ * the relative path, which ever one has less 
+ * depth / number of slashes
+ *
+ * If lengths of abbreviated and relative paths are the same,
+ * the relative path will be used
+ * @in_path can be an absolute, relative or abbreviated path
+ *
+ * @return Length of the string copied into @s
+ **/
+size_t fill_pathname_abbreviated_or_relative(char *s,
+      const char *in_refpath, const char *in_path, size_t len)
+{
+   size_t _len;
+   char in_path_conformed[PATH_MAX_LENGTH];
+   char in_refpath_conformed[PATH_MAX_LENGTH];
+   char absolute_path[PATH_MAX_LENGTH];
+   char relative_path[PATH_MAX_LENGTH];
+
+   absolute_path[0]        = '\0';
+   relative_path[0]        = '\0';
+
+   strlcpy(in_path_conformed,    in_path,    sizeof(in_path_conformed));
+   strlcpy(in_refpath_conformed, in_refpath, sizeof(in_refpath_conformed));
+
+   pathname_conform_slashes_to_os(in_path_conformed);
+   pathname_conform_slashes_to_os(in_refpath_conformed);
+
+   /* Expand paths which start with :\ to an absolute path */
+   fill_pathname_expand_special(absolute_path,
+         in_path_conformed, sizeof(absolute_path));
+
+   /* Get the absolute path if it is not already */
+   if (!path_is_absolute(absolute_path))
+      fill_pathname_resolve_relative(absolute_path,
+            in_refpath_conformed, in_path_conformed,
+            sizeof(absolute_path));
+   pathname_conform_slashes_to_os(absolute_path);
+
+   /* Get the relative path and see 
+    * how many directories long it is */
+   path_relative_to(relative_path, absolute_path,
+         in_refpath_conformed, sizeof(relative_path));
+
+   /* Get the abbreviated path and see 
+    * how many directories long it is */
+   _len = fill_pathname_abbreviate_special(s, absolute_path, len);
+
+   /* Use the shortest path, preferring the relative path*/
+   if (     get_pathname_num_slashes(relative_path)
+         <= get_pathname_num_slashes(s))
+      return strlcpy(s, relative_path, len);
+   return _len;
 }
 
 /**
  * path_basedir:
- * @path               : path
+ * @s                  : path
  *
  * Extracts base directory by mutating path.
  * Keeps trailing '/'.
  **/
-void path_basedir_wrapper(char *path)
+void path_basedir_wrapper(char *s)
 {
-   char *last = NULL;
-   if (strlen(path) < 2)
+   char *last_slash = NULL;
+   if (!s || s[0] == '\0' || s[1] == '\0')
       return;
-
 #ifdef HAVE_COMPRESSION
    /* We want to find the directory with the archive in basedir. */
-   last = (char*)path_get_archive_delim(path);
-   if (last)
-      *last = '\0';
+   if ((last_slash  = (char*)path_get_archive_delim(s)))
+      *last_slash   = '\0';
 #endif
-
-   last = find_last_slash(path);
-
-   if (last)
-      last[1] = '\0';
+   last_slash       = find_last_slash(s);
+   if (!last_slash)
+   {
+      s[0]          = '.';
+      s[1]          = PATH_DEFAULT_SLASH_C();
+      s[2]          = '\0';
+   }
    else
-      snprintf(path, 3, ".%s", path_default_slash());
+      last_slash[1] = '\0';
 }
 
 #if !defined(RARCH_CONSOLE) && defined(RARCH_INTERNAL)
-void fill_pathname_application_path(char *s, size_t len)
+size_t fill_pathname_application_path(char *s, size_t len)
 {
-   size_t i;
-#ifdef __APPLE__
-  CFBundleRef bundle = CFBundleGetMainBundle();
-#endif
-#ifdef _WIN32
-   DWORD ret = 0;
-   wchar_t wstr[PATH_MAX_LENGTH] = {0};
-#endif
-#ifdef __HAIKU__
-   image_info info;
-   int32_t cookie = 0;
-#endif
-   (void)i;
-
-   if (!len)
-      return;
-
+   if (len)
+   {
 #if defined(_WIN32)
 #ifdef LEGACY_WIN32
-   ret    = GetModuleFileNameA(NULL, s, len);
+      DWORD ret = GetModuleFileNameA(NULL, s, len);
 #else
-   ret    = GetModuleFileNameW(NULL, wstr, ARRAY_SIZE(wstr));
-
-   if (*wstr)
-   {
-      char *str = utf16_to_utf8_string_alloc(wstr);
-
-      if (str)
+      wchar_t wstr[PATH_MAX_LENGTH] = {0};
+      DWORD ret = GetModuleFileNameW(NULL, wstr, ARRAY_SIZE(wstr));
+      if (*wstr)
       {
-         strlcpy(s, str, len);
-         free(str);
+         char *str = utf16_to_utf8_string_alloc(wstr);
+         if (str)
+         {
+            strlcpy(s, str, len);
+            free(str);
+         }
       }
-   }
 #endif
-   s[ret] = '\0';
+      s[ret] = '\0';
+      return ret;
 #elif defined(__APPLE__)
-   if (bundle)
-   {
-      CFURLRef bundle_url     = CFBundleCopyBundleURL(bundle);
-      CFStringRef bundle_path = CFURLCopyPath(bundle_url);
-      CFStringGetCString(bundle_path, s, len, kCFStringEncodingUTF8);
-      CFRelease(bundle_path);
-      CFRelease(bundle_url);
-
-      retro_assert(strlcat(s, "nobin", len) < len);
-      return;
-   }
-#elif defined(__HAIKU__)
-   while (get_next_image_info(0, &cookie, &info) == B_OK)
-   {
-      if (info.type == B_APP_IMAGE)
+      CFBundleRef bundle = CFBundleGetMainBundle();
+      if (bundle)
       {
-         strlcpy(s, info.name, len);
-         return;
-      }
-   }
-#elif defined(__QNX__)
-   char *buff = malloc(len);
-
-   if (_cmdname(buff))
-      strlcpy(s, buff, len);
-
-   free(buff);
+         size_t rv               = 0;
+         CFURLRef bundle_url     = CFBundleCopyBundleURL(bundle);
+         CFStringRef bundle_path = CFURLCopyPath(bundle_url);
+         CFStringGetCString(bundle_path, s, len, kCFStringEncodingUTF8);
+#ifdef HAVE_COCOATOUCH
+         {
+            /* This needs to be done so that the path becomes
+             * /private/var/... and this
+             * is used consistently throughout for the 
+             * iOS bundle path */
+            char resolved_bundle_dir_buf[DIR_MAX_LENGTH] = {0};
+            if (realpath(s, resolved_bundle_dir_buf))
+            {
+               size_t _len = strlcpy(s, resolved_bundle_dir_buf, len - 1);
+               s[  _len]   = '/';
+               s[++_len]   = '\0';
+               rv          = _len;
+            }
+         }
 #else
-   {
-      pid_t pid;
+         rv = CFStringGetLength(bundle_path);
+#endif
+
+         CFRelease(bundle_path);
+         CFRelease(bundle_url);
+         return rv;
+      }
+#elif defined(__HAIKU__)
+      image_info info;
+      int32_t cookie = 0;
+      while (get_next_image_info(0, &cookie, &info) == B_OK)
+      {
+         if (info.type == B_APP_IMAGE)
+            return strlcpy(s, info.name, len);
+      }
+#elif defined(__QNX__)
+      char *buff  = (char*)malloc(len);
+      size_t _len = 0;
+      if (_cmdname(buff))
+         _len = strlcpy(s, buff, len);
+      free(buff);
+      return _len;
+#else
+      size_t i;
       static const char *exts[] = { "exe", "file", "path/a.out" };
       char link_path[255];
+      pid_t pid   = getpid();
+      size_t _len = snprintf(link_path, sizeof(link_path), "/proc/%u/",
+            (unsigned)pid);
 
-      link_path[0] = *s = '\0';
-      pid       = getpid();
+      *s           = '\0';
 
       /* Linux, BSD and Solaris paths. Not standardized. */
       for (i = 0; i < ARRAY_SIZE(exts); i++)
       {
          ssize_t ret;
+         strlcpy(link_path + _len, exts[i], sizeof(link_path) - _len);
 
-         snprintf(link_path, sizeof(link_path), "/proc/%u/%s",
-               (unsigned)pid, exts[i]);
-         ret = readlink(link_path, s, len - 1);
-
-         if (ret >= 0)
+         if ((ret = readlink(link_path, s, len - 1)) >= 0)
          {
             s[ret] = '\0';
-            return;
+            return ret;
          }
       }
-   }
 #endif
+   }
+   return 0;
 }
 
-void fill_pathname_application_dir(char *s, size_t len)
+size_t fill_pathname_application_dir(char *s, size_t len)
 {
 #ifdef __WINRT__
-   strlcpy(s, uwp_dir_install, len);
+   return strlcpy(s, uwp_dir_install, len);
 #else
    fill_pathname_application_path(s, len);
-   path_basedir_wrapper(s);
+   return path_basedir(s);
 #endif
 }
 
-void fill_pathname_home_dir(char *s, size_t len)
+size_t fill_pathname_home_dir(char *s, size_t len)
 {
 #ifdef __WINRT__
-   strlcpy(s, uwp_dir_data, len);
+   const char *home = uwp_dir_data;
 #else
    const char *home = getenv("HOME");
-   if (home)
-      strlcpy(s, home, len);
-   else
-      *s = 0;
 #endif
+   if (home)
+      return strlcpy(s, home, len);
+   *s = 0;
+   return 0;
 }
 #endif
 
 bool is_path_accessible_using_standard_io(const char *path)
 {
 #ifdef __WINRT__
-   bool result;
-   size_t         path_sizeof = PATH_MAX_LENGTH * sizeof(char);
-   char *relative_path_abbrev = (char*)malloc(path_sizeof);
-   fill_pathname_abbreviate_special(relative_path_abbrev, path, path_sizeof);
-
-   result = strlen(relative_path_abbrev) >= 2 && (relative_path_abbrev[0] == ':' || relative_path_abbrev[0] == '~') && path_char_is_slash(relative_path_abbrev[1]);
-
-   free(relative_path_abbrev);
-   return result;
+   return GetFileAttributesA(path) != INVALID_FILE_ATTRIBUTES;
 #else
    return true;
 #endif

--- a/core/deps/libretro-common/file/file_path_io.c
+++ b/core/deps/libretro-common/file/file_path_io.c
@@ -1,0 +1,149 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (file_path_io.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <sys/stat.h>
+
+#include <boolean.h>
+#include <file/file_path.h>
+#include <compat/strl.h>
+#include <compat/posix_string.h>
+#include <retro_miscellaneous.h>
+#include <string/stdstring.h>
+#define VFS_FRONTEND
+#include <vfs/vfs_implementation.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <unistd.h> /* stat() is defined here */
+#endif
+
+/* TODO/FIXME - globals */
+static retro_vfs_stat_t path_stat_cb   = retro_vfs_stat_impl;
+static retro_vfs_mkdir_t path_mkdir_cb = retro_vfs_mkdir_impl;
+
+void path_vfs_init(const struct retro_vfs_interface_info* vfs_info)
+{
+   const struct retro_vfs_interface* 
+      vfs_iface           = vfs_info->iface;
+
+   path_stat_cb           = retro_vfs_stat_impl;
+   path_mkdir_cb          = retro_vfs_mkdir_impl;
+
+   if (vfs_info->required_interface_version < PATH_REQUIRED_VFS_VERSION || !vfs_iface)
+      return;
+
+   path_stat_cb           = vfs_iface->stat;
+   path_mkdir_cb          = vfs_iface->mkdir;
+}
+
+int path_stat(const char *path)
+{
+   return path_stat_cb(path, NULL);
+}
+
+/**
+ * path_is_directory:
+ * @path               : path
+ *
+ * Checks if path is a directory.
+ *
+ * @return true if path is a directory, otherwise false.
+ */
+bool path_is_directory(const char *path)
+{
+   return (path_stat_cb(path, NULL) & RETRO_VFS_STAT_IS_DIRECTORY) != 0;
+}
+
+bool path_is_character_special(const char *path)
+{
+   return (path_stat_cb(path, NULL) & RETRO_VFS_STAT_IS_CHARACTER_SPECIAL) != 0;
+}
+
+bool path_is_valid(const char *path)
+{
+   return (path_stat_cb(path, NULL) & RETRO_VFS_STAT_IS_VALID) != 0;
+}
+
+int32_t path_get_size(const char *path)
+{
+   int32_t filesize = 0;
+   if (path_stat_cb(path, &filesize) != 0)
+      return filesize;
+
+   return -1;
+}
+
+/**
+ * path_mkdir:
+ * @dir                : directory
+ *
+ * Create directory on filesystem.
+ * 
+ * Recursive function.
+ *
+ * @return true if directory could be created, otherwise false.
+ **/
+bool path_mkdir(const char *dir)
+{
+   bool norecurse     = false;
+   char     *basedir  = NULL;
+
+   if (!(dir && *dir))
+      return false;
+
+   /* Use heap. Real chance of stack 
+    * overflow if we recurse too hard. */
+   if (!(basedir = strdup(dir)))
+      return false;
+
+   path_parent_dir(basedir, strlen(basedir));
+
+   if (!*basedir || !strcmp(basedir, dir))
+   {
+      free(basedir);
+      return false;
+   }
+
+   if (     path_is_directory(basedir)
+         || path_mkdir(basedir))
+      norecurse = true;
+
+   free(basedir);
+
+   if (norecurse)
+   {
+      int ret = path_mkdir_cb(dir);
+
+      /* Don't treat this as an error. */
+      if (ret == -2 && path_is_directory(dir))
+         return true;
+      else if (ret == 0)
+         return true;
+   }
+   return false;
+}

--- a/core/deps/libretro-common/include/file/file_path.h
+++ b/core/deps/libretro-common/include/file/file_path.h
@@ -1,4 +1,4 @@
-/* Copyright  (C) 2010-2019 The RetroArch team
+/* Copyright  (C) 2010-2020 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this file (file_path.h).
@@ -51,6 +51,28 @@ enum
    RARCH_FILE_UNSUPPORTED
 };
 
+struct path_linked_list
+{
+   char *path;
+   struct path_linked_list *next;
+};
+
+/**
+ * Create a new linked list with one item in it
+ * The path on this item will be set to NULL
+**/
+struct path_linked_list* path_linked_list_new(void);
+
+/* Free the entire linked list */
+void path_linked_list_free(struct path_linked_list *in_path_linked_list);
+
+/**
+ * Add a node to the linked list with this path
+ * If the first node's path if it's not yet set,
+ * set this instead
+**/
+void path_linked_list_add_path(struct path_linked_list *in_path_linked_list, char *path);
+
 /**
  * path_is_compressed_file:
  * @path               : path
@@ -81,12 +103,12 @@ bool path_is_compressed_file(const char *path);
  * path_get_archive_delim:
  * @path               : path
  *
- * Gets delimiter of an archive file. Only the first '#'
+ * Find delimiter of an archive file. Only the first '#'
  * after a compression extension is considered.
  *
- * Returns: pointer to the delimiter in the path if it contains
- * a compressed file, otherwise NULL.
- */
+ * @return pointer to the delimiter in the path if it contains
+ * a path inside a compressed file, otherwise NULL.
+ **/
 const char *path_get_archive_delim(const char *path);
 
 /**
@@ -96,9 +118,27 @@ const char *path_get_archive_delim(const char *path);
  * Gets extension of file. Only '.'s
  * after the last slash are considered.
  *
- * Returns: extension part from the path.
- */
+ * Hidden non-leaf function cost:
+ * - calls string_is_empty()
+ * - calls strrchr
+ *
+ * @return extension part from the path.
+ **/
 const char *path_get_extension(const char *path);
+
+/**
+ * path_get_extension_mutable:
+ * @path               : path
+ *
+ * Specialized version of path_get_extension(). Return
+ * value is mutable.
+ *
+ * Gets extension of file. Only '.'s
+ * after the last slash are considered.
+ *
+ * @return extension part from the path.
+ **/
+char *path_get_extension_mutable(const char *path);
 
 /**
  * path_remove_extension:
@@ -108,7 +148,10 @@ const char *path_get_extension(const char *path);
  * text after and including the last '.'.
  * Only '.'s after the last slash are considered.
  *
- * Returns:
+ * Hidden non-leaf function cost:
+ * - calls strrchr
+ *
+ * @return
  * 1) If path has an extension, returns path with the
  *    extension removed.
  * 2) If there is no extension, returns NULL.
@@ -122,9 +165,23 @@ char *path_remove_extension(char *path);
  *
  * Get basename from @path.
  *
- * Returns: basename from path.
+ * Hidden non-leaf function cost:
+ * - Calls path_get_archive_delim()
+ *
+ * @return basename from path.
  **/
 const char *path_basename(const char *path);
+
+/**
+ * path_basename_nocompression:
+ * @path               : path
+ *
+ * Specialized version of path_basename().
+ * Get basename from @path.
+ *
+ * @return basename from path.
+ **/
+const char *path_basename_nocompression(const char *path);
 
 /**
  * path_basedir:
@@ -133,44 +190,56 @@ const char *path_basename(const char *path);
  * Extracts base directory by mutating path.
  * Keeps trailing '/'.
  **/
-void path_basedir(char *path);
+size_t path_basedir(char *path);
 
 /**
  * path_parent_dir:
- * @path               : path
+ * @s                  : path
+ * @len                : size of buffer
  *
  * Extracts parent directory by mutating path.
  * Assumes that path is a directory. Keeps trailing '/'.
  * If the path was already at the root directory, returns empty string
  **/
-void path_parent_dir(char *path);
+size_t path_parent_dir(char *s, size_t len);
 
 /**
  * path_resolve_realpath:
- * @buf                : buffer for path
+ * @s                  : input and output buffer for path
  * @size               : size of buffer
+ * @resolve_symlinks   : whether to resolve symlinks or not
  *
- * Turns relative paths into absolute paths and
- * resolves use of "." and ".." in absolute paths.
- * If relative, rebases on current working dir.
+ * Resolves use of ".", "..", multiple slashes etc in absolute paths.
+ *
+ * Relative paths are rebased on the current working dir.
+ *
+ * @return @s if successful, NULL otherwise.
+ * Note: Not implemented on consoles
+ * Note: Symlinks are only resolved on Unix-likes
+ * Note: The current working dir might not be what you expect,
+ *       e.g. on Android it is "/"
+ *       Use of fill_pathname_resolve_relative() should be preferred
  **/
-void path_resolve_realpath(char *buf, size_t size);
+char *path_resolve_realpath(char *s, size_t len, bool resolve_symlinks);
 
 /**
  * path_relative_to:
- * @out                : buffer to write the relative path to
+ * @s                  : buffer to write the relative path to
  * @path               : path to be expressed relatively
  * @base               : relative to this
- * @size               : size of output buffer
+ * @len                : size of output buffer
  *
- * Turns @path into a path relative to @base and writes it to @out.
+ * Turns @path into a path relative to @base and writes it to @s.
  *
  * @base is assumed to be a base directory, i.e. a path ending with '/' or '\'.
  * Both @path and @base are assumed to be absolute paths without "." or "..".
  *
  * E.g. path /a/b/e/f.cgp with base /a/b/c/d/ turns into ../../e/f.cgp
+ *
+ * @return Length of the string copied into @s
  **/
-void path_relative_to(char *out, const char *path, const char *base, size_t size);
+size_t path_relative_to(char *s, const char *path, const char *base,
+      size_t len);
 
 /**
  * path_is_absolute:
@@ -178,261 +247,339 @@ void path_relative_to(char *out, const char *path, const char *base, size_t size
  *
  * Checks if @path is an absolute path or a relative path.
  *
- * Returns: true if path is absolute, false if path is relative.
+ * @return true if path is absolute, false if path is relative.
  **/
 bool path_is_absolute(const char *path);
 
 /**
  * fill_pathname:
- * @out_path           : output path
+ * @s                  : output path
  * @in_path            : input  path
  * @replace            : what to replace
- * @size               : buffer size of output path
+ * @len                : buffer size of output path
  *
  * FIXME: Verify
  *
- * Replaces filename extension with 'replace' and outputs result to out_path.
+ * Replaces filename extension with 'replace' and outputs result to s.
  * The extension here is considered to be the string from the last '.'
  * to the end.
  *
  * Only '.'s after the last slash are considered as extensions.
  * If no '.' is present, in_path and replace will simply be concatenated.
- * 'size' is buffer size of 'out_path'.
+ * 'len' is buffer size of 's'.
  * E.g.: in_path = "/foo/bar/baz/boo.c", replace = ".asm" =>
- * out_path = "/foo/bar/baz/boo.asm"
+ * s = "/foo/bar/baz/boo.asm"
  * E.g.: in_path = "/foo/bar/baz/boo.c", replace = ""     =>
- * out_path = "/foo/bar/baz/boo"
+ * s = "/foo/bar/baz/boo"
+ *
+ * Hidden non-leaf function cost:
+ * - calls strlcpy 2x
+ * - calls strrchr
+ * - calls strlcat
+ *
+ * @return Length of the string copied into @s
  */
-void fill_pathname(char *out_path, const char *in_path,
-      const char *replace, size_t size);
+size_t fill_pathname(char *s, const char *in_path,
+      const char *replace, size_t len);
 
 /**
  * fill_dated_filename:
- * @out_filename       : output filename
+ * @s                  : output filename
  * @ext                : extension of output filename
- * @size               : buffer size of output filename
+ * @len                : buffer size of output filename
  *
  * Creates a 'dated' filename prefixed by 'RetroArch', and
  * concatenates extension (@ext) to it.
  *
  * E.g.:
- * out_filename = "RetroArch-{month}{day}-{Hours}{Minutes}.{@ext}"
+ * s = "RetroArch-{month}{day}-{Hours}{Minutes}.{@ext}"
+ *
+ * Hidden non-leaf function cost:
+ * - Calls rtime_localtime()
+ * - Calls strftime
+ * - Calls strlcat
+ *
  **/
-void fill_dated_filename(char *out_filename,
-      const char *ext, size_t size);
+size_t fill_dated_filename(char *s, const char *ext, size_t len);
 
 /**
  * fill_str_dated_filename:
- * @out_filename       : output filename
+ * @s                  : output filename
  * @in_str             : input string
  * @ext                : extension of output filename
- * @size               : buffer size of output filename
+ * @len                : buffer size of output filename
  *
  * Creates a 'dated' filename prefixed by the string @in_str, and
  * concatenates extension (@ext) to it.
  *
  * E.g.:
- * out_filename = "RetroArch-{year}{month}{day}-{Hour}{Minute}{Second}.{@ext}"
+ * s = "RetroArch-{year}{month}{day}-{Hour}{Minute}{Second}.{@ext}"
+ *
+ * Hidden non-leaf function cost:
+ * - Calls time
+ * - Calls rtime_localtime()
+ * - Calls strlcpy 2x
+ * - Calls string_is_empty()
+ * - Calls strftime
+ * - Calls strlcat
+ *
+ * @return Length of the string copied into @s
  **/
-void fill_str_dated_filename(char *out_filename,
-      const char *in_str, const char *ext, size_t size);
-
-/**
- * fill_pathname_noext:
- * @out_path           : output path
- * @in_path            : input  path
- * @replace            : what to replace
- * @size               : buffer size of output path
- *
- * Appends a filename extension 'replace' to 'in_path', and outputs
- * result in 'out_path'.
- *
- * Assumes in_path has no extension. If an extension is still
- * present in 'in_path', it will be ignored.
- *
- */
-void fill_pathname_noext(char *out_path, const char *in_path,
-      const char *replace, size_t size);
+size_t fill_str_dated_filename(char *s, const char *in_str, const char *ext, size_t len);
 
 /**
  * find_last_slash:
- * @str : input path
+ * @str                : path
  *
- * Gets a pointer to the last slash in the input path.
+ * Find last slash in path. Tries to find
+ * a backslash on Windows too which takes precedence
+ * over regular slash.
  *
- * Returns: a pointer to the last slash in the input path.
+ * Leaf function.
+ *
+ * @return pointer to last slash/backslash found in @str.
  **/
 char *find_last_slash(const char *str);
 
 /**
  * fill_pathname_dir:
- * @in_dir             : input directory path
- * @in_basename        : input basename to be appended to @in_dir
+ * @s                  : input directory path
+ * @in_basename        : input basename to be appended to @s
  * @replace            : replacement to be appended to @in_basename
- * @size               : size of buffer
+ * @len                : size of buffer
  *
- * Appends basename of 'in_basename', to 'in_dir', along with 'replace'.
+ * Appends basename of 'in_basename', to 's', along with 'replace'.
  * Basename of in_basename is the string after the last '/' or '\\',
  * i.e the filename without directories.
  *
  * If in_basename has no '/' or '\\', the whole 'in_basename' will be used.
- * 'size' is buffer size of 'in_dir'.
+ * 'len' is buffer size of 's'.
  *
- * E.g..: in_dir = "/tmp/some_dir", in_basename = "/some_content/foo.c",
- * replace = ".asm" => in_dir = "/tmp/some_dir/foo.c.asm"
+ * E.g..: s = "/tmp/some_dir", in_basename = "/some_content/foo.c",
+ * replace = ".asm" => s = "/tmp/some_dir/foo.c.asm"
+ *
+ * Hidden non-leaf function cost:
+ * - Calls fill_pathname_slash()
+ * - Calls path_basename()
+ * - Calls strlcpy 2x
  **/
-void fill_pathname_dir(char *in_dir, const char *in_basename,
-      const char *replace, size_t size);
+size_t fill_pathname_dir(char *s, const char *in_basename,
+      const char *replace, size_t len);
 
 /**
  * fill_pathname_base:
- * @out                : output path
+ * @s                  : output path
  * @in_path            : input path
- * @size               : size of output path
+ * @len                : size of output path
  *
- * Copies basename of @in_path into @out_path.
+ * Copies basename of @in_path into @s.
+ *
+ * Hidden non-leaf function cost:
+ * - Calls path_basename()
+ * - Calls strlcpy
+ *
+ * @return length of the string copied into @s
  **/
-void fill_pathname_base(char *out_path, const char *in_path, size_t size);
-
-void fill_pathname_base_noext(char *out_dir,
-      const char *in_path, size_t size);
-
-void fill_pathname_base_ext(char *out,
-      const char *in_path, const char *ext,
-      size_t size);
+size_t fill_pathname_base(char *s, const char *in_path, size_t len);
 
 /**
  * fill_pathname_basedir:
- * @out_dir            : output directory
+ * @s                  : output directory
  * @in_path            : input path
- * @size               : size of output directory
+ * @len                : size of output directory
  *
- * Copies base directory of @in_path into @out_path.
+ * Copies base directory of @in_path into @s.
  * If in_path is a path without any slashes (relative current directory),
- * @out_path will get path "./".
+ * @s will get path "./".
+ *
+ * Hidden non-leaf function cost:
+ * - Calls strlcpy
+ * - Calls path_basedir()
  **/
-void fill_pathname_basedir(char *out_path, const char *in_path, size_t size);
-
-void fill_pathname_basedir_noext(char *out_dir,
-      const char *in_path, size_t size);
+size_t fill_pathname_basedir(char *s, const char *in_path, size_t len);
 
 /**
  * fill_pathname_parent_dir_name:
- * @out_dir            : output directory
+ * @s                  : output string
  * @in_dir             : input directory
- * @size               : size of output directory
+ * @len                : size of @s
  *
- * Copies only the parent directory name of @in_dir into @out_dir.
+ * Copies only the parent directory name of @in_dir into @s.
  * The two buffers must not overlap. Removes trailing '/'.
- * Returns true on success, false if a slash was not found in the path.
+ *
+ * Hidden non-leaf function cost:
+ * - Calls strdup
+ * - Can call strlcpy
+ *
+ * @return Length of the string copied into @s
  **/
-bool fill_pathname_parent_dir_name(char *out_dir,
-      const char *in_dir, size_t size);
+size_t fill_pathname_parent_dir_name(char *s,
+      const char *in_dir, size_t len);
 
 /**
  * fill_pathname_parent_dir:
- * @out_dir            : output directory
+ * @s                  : output directory
  * @in_dir             : input directory
- * @size               : size of output directory
+ * @len                : size of output directory
  *
- * Copies parent directory of @in_dir into @out_dir.
+ * Copies parent directory of @in_dir into @s.
  * Assumes @in_dir is a directory. Keeps trailing '/'.
- * If the path was already at the root directory, @out_dir will be an empty string.
+ * If the path was already at the root directory, @s will be an empty string.
+ *
+ * Hidden non-leaf function cost:
+ * - Can call strlcpy if (@s!= @in_dir)
+ * - Calls strlen if (@s == @in_dir)
+ * - Calls path_parent_dir()
+ *
+ * @return Length of the string copied into @s
  **/
-void fill_pathname_parent_dir(char *out_dir,
-      const char *in_dir, size_t size);
+size_t fill_pathname_parent_dir(char *s,
+      const char *in_dir, size_t len);
 
 /**
  * fill_pathname_resolve_relative:
- * @out_path           : output path
+ * @s                  : output path
  * @in_refpath         : input reference path
  * @in_path            : input path
- * @size               : size of @out_path
+ * @len                : size of @s
  *
  * Joins basedir of @in_refpath together with @in_path.
- * If @in_path is an absolute path, out_path = in_path.
+ * If @in_path is an absolute path, s = in_path.
  * E.g.: in_refpath = "/foo/bar/baz.a", in_path = "foobar.cg",
- * out_path = "/foo/bar/foobar.cg".
+ * s = "/foo/bar/foobar.cg".
  **/
-void fill_pathname_resolve_relative(char *out_path, const char *in_refpath,
-      const char *in_path, size_t size);
+void fill_pathname_resolve_relative(char *s, const char *in_refpath,
+      const char *in_path, size_t len);
 
 /**
  * fill_pathname_join:
- * @out_path           : output path
+ * @s                  : output path
  * @dir                : directory
  * @path               : path
- * @size               : size of output path
+ * @len                : size of output path
  *
  * Joins a directory (@dir) and path (@path) together.
- * Makes sure not to get  two consecutive slashes
+ * Makes sure not to get two consecutive slashes
  * between directory and path.
+ *
+ * Hidden non-leaf function cost:
+ * - calls strlcpy at least once
+ * - calls fill_pathname_slash()
+ *
+ * Deprecated. Use fill_pathname_join_special() instead
+ * if you can ensure @dir != @s
+ *
+ * @return Length of the string copied into @s
  **/
-void fill_pathname_join(char *out_path, const char *dir,
-      const char *path, size_t size);
+size_t fill_pathname_join(char *s, const char *dir,
+      const char *path, size_t len);
 
-void fill_pathname_join_special_ext(char *out_path,
+/**
+ * fill_pathname_join_special:
+ * @s                  : output path
+ * @dir                : directory. Cannot be identical to @s
+ * @path               : path
+ * @len                : size of output path
+ *
+ *
+ * Specialized version of fill_pathname_join.
+ * Unlike fill_pathname_join(),
+ * @dir and @s CANNOT be identical.
+ *
+ * Joins a directory (@dir) and path (@path) together.
+ * Makes sure not to get two consecutive slashes
+ * between directory and path.
+ *
+ * Hidden non-leaf function cost:
+ * - calls strlcpy 2x
+ *
+ * @return Length of the string copied into @s
+ **/
+size_t fill_pathname_join_special(char *s,
+      const char *dir, const char *path, size_t len);
+
+size_t fill_pathname_join_special_ext(char *s,
       const char *dir,  const char *path,
       const char *last, const char *ext,
-      size_t size);
-
-void fill_pathname_join_concat_noext(char *out_path,
-      const char *dir, const char *path,
-      const char *concat,
-      size_t size);
-
-void fill_pathname_join_concat(char *out_path,
-      const char *dir, const char *path,
-      const char *concat,
-      size_t size);
-
-void fill_pathname_join_noext(char *out_path,
-      const char *dir, const char *path, size_t size);
+      size_t len);
 
 /**
  * fill_pathname_join_delim:
- * @out_path           : output path
+ * @s                  : output path
  * @dir                : directory
  * @path               : path
  * @delim              : delimiter
- * @size               : size of output path
+ * @len                : size of output path
  *
  * Joins a directory (@dir) and path (@path) together
  * using the given delimiter (@delim).
+ *
+ * Hidden non-leaf function cost:
+ * - can call strlen
+ * - can call strlcpy
+ * - can call strlcat
  **/
-void fill_pathname_join_delim(char *out_path, const char *dir,
-      const char *path, const char delim, size_t size);
+size_t fill_pathname_join_delim(char *s, const char *dir,
+      const char *path, const char delim, size_t len);
 
-void fill_pathname_join_delim_concat(char *out_path, const char *dir,
-      const char *path, const char delim, const char *concat,
-      size_t size);
+size_t fill_pathname_expand_special(char *s,
+      const char *in_path, size_t len);
+
+size_t fill_pathname_abbreviate_special(char *s,
+      const char *in_path, size_t len);
 
 /**
- * fill_short_pathname_representation:
- * @out_rep            : output representation
- * @in_path            : input path
- * @size               : size of output representation
+ * fill_pathname_abbreviated_or_relative:
  *
- * Generates a short representation of path. It should only
- * be used for displaying the result; the output representation is not
- * binding in any meaningful way (for a normal path, this is the same as basename)
- * In case of more complex URLs, this should cut everything except for
- * the main image file.
+ * Fills the supplied path with either the abbreviated path or
+ * the relative path, which ever one has less depth / number of slashes
  *
- * E.g.: "/path/to/game.img" -> game.img
- *       "/path/to/myarchive.7z#folder/to/game.img" -> game.img
- */
-void fill_short_pathname_representation(char* out_rep,
-      const char *in_path, size_t size);
+ * If lengths of abbreviated and relative paths are the same,
+ * the relative path will be used
+ * @in_path can be an absolute, relative or abbreviated path
+ *
+ * @return Length of the string copied into @s
+ **/
+size_t fill_pathname_abbreviated_or_relative(char *s,
+		const char *in_refpath, const char *in_path, size_t len);
 
-void fill_short_pathname_representation_noext(char* out_rep,
-      const char *in_path, size_t size);
+/**
+ * sanitize_path_part:
+ *
+ * @path_part          : directory or filename
+ * @len                : length of path_part
+ *
+ * Takes single part of a path eg. single filename
+ * or directory, and removes any special chars that are
+ * unavailable.
+ *
+ * @returns newly allocated string that has been sanitized.
+ * Caller is responsible for freeing the returned string.
+ **/
+char *sanitize_path_part(const char *path_part, size_t len);
 
-void fill_pathname_expand_special(char *out_path,
-      const char *in_path, size_t size);
+/**
+ * pathname_conform_slashes_to_os:
+ *
+ * @path               : path
+ *
+ * Leaf function.
+ *
+ * Changes the slashes to the correct kind for the os
+ * So forward slash on linux and backslash on Windows
+ **/
+void pathname_conform_slashes_to_os(char *s);
 
-void fill_pathname_abbreviate_special(char *out_path,
-      const char *in_path, size_t size);
+/**
+ * pathname_make_slashes_portable:
+ * @path               : path
+ *
+ * Leaf function.
+ *
+ * Change all slashes to forward so they are more
+ * portable between Windows and Linux
+ **/
+void pathname_make_slashes_portable(char *s);
 
 /**
  * path_basedir:
@@ -441,7 +588,7 @@ void fill_pathname_abbreviate_special(char *out_path,
  * Extracts base directory by mutating path.
  * Keeps trailing '/'.
  **/
-void path_basedir_wrapper(char *path);
+void path_basedir_wrapper(char *s);
 
 /**
  * path_char_is_slash:
@@ -449,12 +596,12 @@ void path_basedir_wrapper(char *path);
  *
  * Checks if character (@c) is a slash.
  *
- * Returns: true (1) if character is a slash, otherwise false (0).
- */
+ * @return true if character is a slash, otherwise false.
+ **/
 #ifdef _WIN32
-#define path_char_is_slash(c) (((c) == '/') || ((c) == '\\'))
+#define PATH_CHAR_IS_SLASH(c) (((c) == '/') || ((c) == '\\'))
 #else
-#define path_char_is_slash(c) ((c) == '/')
+#define PATH_CHAR_IS_SLASH(c) ((c) == '/')
 #endif
 
 /**
@@ -462,30 +609,34 @@ void path_basedir_wrapper(char *path);
  *
  * Gets the default slash separator.
  *
- * Returns: default slash separator.
- */
+ * @return default slash separator.
+ **/
 #ifdef _WIN32
-#define path_default_slash() "\\"
-#define path_default_slash_c() '\\'
+#define PATH_DEFAULT_SLASH() "\\"
+#define PATH_DEFAULT_SLASH_C() '\\'
 #else
-#define path_default_slash() "/"
-#define path_default_slash_c() '/'
+#define PATH_DEFAULT_SLASH() "/"
+#define PATH_DEFAULT_SLASH_C() '/'
 #endif
 
 /**
  * fill_pathname_slash:
- * @path               : path
- * @size               : size of path
+ * @s                  : path
+ * @len                : size of path
  *
  * Assumes path is a directory. Appends a slash
  * if not already there.
+
+ * Hidden non-leaf function cost:
+ * - can call strlcat once if it returns false
+ * - calls strlen
  **/
-void fill_pathname_slash(char *path, size_t size);
+size_t fill_pathname_slash(char *s, size_t len);
 
 #if !defined(RARCH_CONSOLE) && defined(RARCH_INTERNAL)
-void fill_pathname_application_path(char *buf, size_t size);
-void fill_pathname_application_dir(char *buf, size_t size);
-void fill_pathname_home_dir(char *buf, size_t size);
+size_t fill_pathname_application_path(char *s, size_t len);
+size_t fill_pathname_application_dir(char *s, size_t len);
+size_t fill_pathname_home_dir(char *s, size_t len);
 #endif
 
 /**
@@ -494,7 +645,16 @@ void fill_pathname_home_dir(char *buf, size_t size);
  *
  * Create directory on filesystem.
  *
- * Returns: true (1) if directory could be created, otherwise false (0).
+ * Recursive function.
+ *
+ * Hidden non-leaf function cost:
+ * - Calls strdup
+ * - Calls path_parent_dir()
+ * - Calls strcmp
+ * - Calls path_is_directory()
+ * - Calls path_mkdir()
+ *
+ * @return true if directory could be created, otherwise false.
  **/
 bool path_mkdir(const char *dir);
 
@@ -504,9 +664,16 @@ bool path_mkdir(const char *dir);
  *
  * Checks if path is a directory.
  *
- * Returns: true (1) if path is a directory, otherwise false (0).
+ * @return true if path is a directory, otherwise false.
  */
 bool path_is_directory(const char *path);
+
+/* Time format strings with AM-PM designation require special
+ * handling due to platform dependence
+ * @return Length of the string written to @s
+ */
+size_t strftime_am_pm(char *s, size_t len, const char* format,
+      const void* timeptr);
 
 bool path_is_character_special(const char *path);
 

--- a/core/deps/libretro-common/include/streams/file_stream.h
+++ b/core/deps/libretro-common/include/streams/file_stream.h
@@ -1,0 +1,434 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (file_stream.h).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __LIBRETRO_SDK_FILE_STREAM_H
+#define __LIBRETRO_SDK_FILE_STREAM_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stddef.h>
+
+#include <sys/types.h>
+
+#include <libretro.h>
+#include <retro_common_api.h>
+#include <retro_inline.h>
+#include <boolean.h>
+
+#include <stdarg.h>
+#include <vfs/vfs_implementation.h>
+
+/** @defgroup file_stream File Streams
+ *
+ * All functions in this header will use the VFS interface set in \ref filestream_vfs_init if possible,
+ * or else they will fall back to built-in equivalents.
+ *
+ * @note These functions are modeled after those in the C standard library
+ * (and may even use them internally),
+ * but identical behavior is not guaranteed.
+ *
+ * @{
+ */
+
+/**
+ * The minimum version of the VFS interface required by the \c filestream functions.
+ */
+#define FILESTREAM_REQUIRED_VFS_VERSION 2
+
+RETRO_BEGIN_DECLS
+
+/**
+ * Opaque handle to a file stream.
+ * @warning This is not interchangeable with \c FILE* or \c retro_vfs_file_handle.
+ */
+typedef struct RFILE RFILE;
+
+#define FILESTREAM_REQUIRED_VFS_VERSION 2
+
+/**
+ * Initializes the \c filestream functions to use the VFS interface provided by the frontend.
+ * Optional; if not called, all \c filestream functions
+ * will use libretro-common's built-in implementations.
+ *
+ * @param vfs_info The VFS interface returned by the frontend.
+ * If \c vfs_info::iface (but \em not \c vfs_info itself) is \c NULL,
+ * then libretro-common's built-in VFS implementation will be used.
+ */
+void filestream_vfs_init(const struct retro_vfs_interface_info* vfs_info);
+
+/**
+ * Returns the size of the given file, in bytes.
+ *
+ * @param stream The open file to query.
+ * @return The size of \c stream in bytes,
+ * or -1 if there was an error.
+ * @see retro_vfs_size_t
+ */
+int64_t filestream_get_size(RFILE *stream);
+
+/**
+ * Sets the size of the given file,
+ * truncating or extending it as necessary.
+ *
+ * @param stream The file to resize.
+ * @param length The new size of \c stream, in bytes.
+ * @return 0 if the resize was successful,
+ * or -1 if there was an error.
+ * @see retro_vfs_truncate_t
+ */
+int64_t filestream_truncate(RFILE *stream, int64_t length);
+
+/**
+ * Opens a file for reading or writing.
+ *
+ * @param path Path to the file to open.
+ * Should be in the format described in \ref GET_VFS_INTERFACE.
+ * @param mode The mode to open the file in.
+ * Should be one or more of the flags in \refitem RETRO_VFS_FILE_ACCESS OR'd together,
+ * and \c RETRO_VFS_FILE_ACCESS_READ or \c RETRO_VFS_FILE_ACCESS_WRITE
+ * (or both) must be included.
+ * @param hints Optional hints to pass to the frontend.
+ *
+ * @return The opened file, or \c NULL if there was an error.
+ * Must be cleaned up with \c filestream_close when no longer needed.
+ * @see retro_vfs_open_t
+ */
+RFILE* filestream_open(const char *path, unsigned mode, unsigned hints);
+
+/**
+ * Sets the current position of the file stream.
+ * Use this to read specific sections of a file.
+ *
+ * @param stream The file to set the stream position of.
+ * @param offset The new stream position, in bytes.
+ * @param seek_position The position to seek from.
+ * Should be one of the values in \refitem RETRO_VFS_SEEK_POSITION.
+ * @return The new stream position in bytes relative to the beginning,
+ * or -1 if there was an error.
+ * @see RETRO_VFS_SEEK_POSITION
+ * @see retro_vfs_seek_t
+ */
+int64_t filestream_seek(RFILE *stream, int64_t offset, int seek_position);
+
+/**
+ * Reads data from the given file into a buffer.
+ * If the read is successful,
+ * the file's stream position will advance by the number of bytes read.
+ *
+ * @param stream The file to read from.
+ * @param data The buffer in which to store the read data.
+ * @param len The size of \c data, in bytes.
+ * @return The number of bytes read,
+ * or -1 if there was an error.
+ * May be less than \c len, but never more.
+ * @see retro_vfs_read_t
+ */
+int64_t filestream_read(RFILE *stream, void *data, int64_t len);
+
+/**
+ * Writes data from a buffer to the given file.
+ * If the write is successful,
+ * the file's stream position will advance by the number of bytes written.
+ *
+ * @param stream The file to write to.
+ * @param data The buffer containing the data to write.
+ * @param len The size of \c data, in bytes.
+ * @return The number of bytes written,
+ * or -1 if there was an error.
+ * May be less than \c len, but never more.
+ * @see retro_vfs_write_t
+ */
+int64_t filestream_write(RFILE *stream, const void *data, int64_t len);
+
+/**
+ * Returns the current position of the given file in bytes.
+ *
+ * @param stream The file to return the stream position for.
+ * @return The current stream position in bytes relative to the beginning,
+ * or -1 if there was an error.
+ * @see retro_vfs_tell_t
+ */
+int64_t filestream_tell(RFILE *stream);
+
+/**
+ * Rewinds the given file to the beginning.
+ * Equivalent to <tt>filestream_seek(stream, 0, RETRO_VFS_SEEK_POSITION_START)</tt>.
+
+ * @param stream The file to rewind.
+ * May be \c NULL, in which case this function does nothing.
+ */
+void filestream_rewind(RFILE *stream);
+
+/**
+ * Closes the given file.
+ *
+ * @param stream The file to close.
+ * This should have been created with \c filestream_open.
+ * Behavior is undefined if \c NULL.
+ * @return 0 if the file was closed successfully,
+ * or -1 if there was an error.
+ * @post \c stream is no longer valid and should not be used,
+ * even if this function fails.
+ * @see retro_vfs_close_t
+ */
+int filestream_close(RFILE *stream);
+
+/**
+ * Opens a file, reads its contents into a newly-allocated buffer,
+ * then closes it.
+ *
+ * @param path[in] Path to the file to read.
+ * Should be in the format described in \ref GET_VFS_INTERFACE.
+ * @param buf[out] A pointer to the address of the newly-allocated buffer.
+ * The buffer will contain the entirety of the file at \c path.
+ * Will be allocated with \c malloc and must be freed with \c free.
+ * @param len[out] Pointer to the size of the buffer in bytes.
+ * May be \c NULL, in which case the length is not written.
+ * Value is unspecified if this function fails.
+ * @return 1 if the file was read successfully,
+ * 0 if there was an error.
+ * @see filestream_write_file
+ */
+int64_t filestream_read_file(const char *path, void **buf, int64_t *len);
+
+/**
+ * Reads a line of text from the given file,
+ * up to a given length.
+ *
+ * Will read to the next newline or until the buffer is full,
+ * whichever comes first.
+ *
+ * @param stream The file to read from.
+ * @param s The buffer to write the retrieved line to.
+ * Will contain at most \c len - 1 characters
+ * plus a null terminator.
+ * The newline character (if any) will not be included.
+ * The line delimiter must be Unix-style (\c '\n').
+ * Carriage returns (\c '\r') will not be treated specially.
+ * @param len The length of the buffer \c s, in bytes.
+ * @return \s if successful, \c NULL if there was an error.
+ */
+char* filestream_gets(RFILE *stream, char *s, size_t len);
+
+/**
+ * Reads a single character from the given file.
+ *
+ * @param stream The file to read from.
+ * @return The character read, or -1 upon reaching the end of the file.
+ */
+int filestream_getc(RFILE *stream);
+
+/**
+ * Reads formatted text from the given file,
+ * with arguments provided as a standard \c va_list.
+ *
+ * @param stream The file to read from.
+ * @param format The string to write, possibly including scanf-compatible format specifiers.
+ * @param args Argument list with zero or more elements
+ * whose values will be updated according to the semantics of \c format.
+ * @return The number of arguments in \c args that were successfully assigned,
+ * or -1 if there was an error.
+ * @see https://en.cppreference.com/w/c/io/fscanf
+ * @see https://en.cppreference.com/w/c/variadic
+ */
+int filestream_vscanf(RFILE *stream, const char* format, va_list *args);
+
+/**
+ * Reads formatted text from the given file.
+ *
+ * @param stream The file to read from.
+ * @param format The string to write, possibly including scanf-compatible format specifiers.
+ * @param ... Zero or more arguments that will be updated according to the semantics of \c format.
+ * @return The number of arguments in \c ... that were successfully assigned,
+ * or -1 if there was an error.
+ * @see https://en.cppreference.com/w/c/io/fscanf
+ */
+int filestream_scanf(RFILE *stream, const char* format, ...);
+
+/**
+ * Determines if there's any more data left to read from this file.
+ *
+ * @param stream The file to check the position of.
+ * @return -1 if this stream has reached the end of the file,
+ * 0 if not.
+ */
+int filestream_eof(RFILE *stream);
+
+/**
+ * Writes the entirety of a given buffer to a file at a given path.
+ * Any file that already exists will be overwritten.
+ *
+ * @param path Path to the file that will be written to.
+ * @param data The buffer to write to \c path.
+ * @param size The size of \c data, in bytes.
+ * @return \c true if the file was written successfully,
+ * \c false if there was an error.
+ */
+bool filestream_write_file(const char *path, const void *data, int64_t size);
+
+/**
+ * Writes a single character to the given file.
+ *
+ * @param stream The file to write to.
+ * @param c The character to write.
+ * @return The character written,
+ * or -1 if there was an error.
+ * Will return -1 if \c stream is \c NULL.
+ */
+int filestream_putc(RFILE *stream, int c);
+
+/**
+ * Writes formatted text to the given file,
+ * with arguments provided as a standard \c va_list.
+ *
+ * @param stream The file to write to.
+ * @param format The string to write, possibly including printf-compatible format specifiers.
+ * @param args A list of arguments to be formatted and inserted in the resulting string.
+ * @return The number of characters written,
+ * or -1 if there was an error.
+ * @see https://en.cppreference.com/w/c/io/vfprintf
+ * @see https://en.cppreference.com/w/c/variadic
+ */
+int filestream_vprintf(RFILE *stream, const char* format, va_list args);
+
+/**
+ * Writes formatted text to the given file.
+ *
+ * @param stream The file to write to.
+ * @param format The string to write, possibly including printf-compatible format specifiers.
+ * @param ... Zero or more arguments to be formatted and inserted into the resulting string.
+ * @return The number of characters written,
+ * or -1 if there was an error.
+ * @see https://en.cppreference.com/w/c/io/printf
+ */
+int filestream_printf(RFILE *stream, const char* format, ...);
+
+/**
+ * Checks if there was an error in using the given file stream.
+ *
+ * @param stream The file stream to check for errors.
+ * @return \c true if there was an error in using this stream,
+ * \c false if not or if \c stream is \c NULL.
+ */
+int filestream_error(RFILE *stream);
+
+/**
+ * Flushes pending writes to the operating system's file layer.
+ * There is no guarantee that pending writes will be written to disk immediately.
+ *
+ * @param stream The file to flush.
+ * @return 0 if the flush was successful,
+ * or -1 if there was an error.
+ * @see retro_vfs_flush_t
+ */
+int filestream_flush(RFILE *stream);
+
+/**
+ * Deletes the file at the given path.
+ * If the file is open by any process,
+ * the behavior is platform-specific.
+ *
+ * @note This function might or might not delete directories recursively,
+ * depending on the platform and the underlying VFS implementation.
+ *
+ * @param path The file to delete.
+ * @return 0 if the file was deleted successfully,
+ * or -1 if there was an error.
+ * @see retro_vfs_remove_t
+ */
+int filestream_delete(const char *path);
+
+/**
+ * Moves a file to a new location, with a new name.
+ *
+ * @param old_path Path to the file to rename.
+ * @param new_path The target name and location of the file.
+ * @return 0 if the file was renamed successfully,
+ * or -1 if there was an error.
+ * @see retro_vfs_rename_t
+ */
+int filestream_rename(const char *old_path, const char *new_path);
+
+/**
+ * Copies a file to a new location.
+ *
+ * @param src_path Path to the file to rename.
+ * @param dst_path The target name and location of the file.
+ * @return 0 if the file was copied successfully,
+ * or -1 if there was an error.
+ */
+int filestream_copy(const char *src_path, const char *dst_path);
+
+/**
+ * Compares and verifies files.
+ *
+ * @param src_path Path to the file.
+ * @param dst_path Path to the other file.
+ * @return 0 if the files are equal,
+ * or -1 if there was an error.
+ */
+int filestream_cmp(const char *src_path, const char *dst_path);
+
+/**
+ * Get the path that was used to open a file.
+ *
+ * @param stream The file to get the path of.
+ * @return The path that was used to open \c stream,
+ * or \c NULL if there was an error.
+ * The string is owned by \c stream and must not be modified or freed by the caller.
+ */
+const char* filestream_get_path(RFILE *stream);
+
+/**
+ * Determines if a file exists at the given path.
+ *
+ * @param path The path to check for existence.
+ * @return \c true if a file exists at \c path,
+ * \c false if not or if \c path is \c NULL or empty.
+ */
+bool filestream_exists(const char *path);
+
+/**
+ * Reads a line from the given file into a newly-allocated buffer.
+ *
+ * @param stream The file to read from.
+ * @return Pointer to the line read from \c stream,
+ * or \c NULL if there was an error.
+ * Must be freed with \c free when no longer needed.
+ */
+char* filestream_getline(RFILE *stream);
+
+/**
+ * Returns the open file handle
+ * that was originally returned by the VFS interface.
+ *
+ * @param stream File handle returned by \c filestream_open.
+ * @return The file handle returned by the underlying VFS implementation.
+ */
+libretro_vfs_implementation_file* filestream_get_vfs_handle(RFILE *stream);
+
+RETRO_END_DECLS
+
+/** @} */
+
+#endif

--- a/core/deps/libretro-common/include/string/stdstring.h
+++ b/core/deps/libretro-common/include/string/stdstring.h
@@ -1,4 +1,4 @@
-/* Copyright  (C) 2010-2019 The RetroArch team
+/* Copyright  (C) 2010-2020 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this file (stdstring.h).
@@ -35,6 +35,28 @@
 
 RETRO_BEGIN_DECLS
 
+#define STRLEN_CONST(x)                   ((sizeof((x))-1))
+
+#define string_is_not_equal(a, b)         !string_is_equal((a), (b))
+
+#define TOLOWER(c)   ((c) |  (lr_char_props[(unsigned char)(c)] & 0x20))
+#define TOUPPER(c)   ((c) & ~(lr_char_props[(unsigned char)(c)] & 0x20))
+
+/* C standard says \f \v are space, but this one disagrees */
+#define ISSPACE(c)   (lr_char_props[(unsigned char)(c)] & 0x80)
+
+#define ISDIGIT(c)   (lr_char_props[(unsigned char)(c)] & 0x40)
+#define ISALPHA(c)   (lr_char_props[(unsigned char)(c)] & 0x20)
+#define ISLOWER(c)   (lr_char_props[(unsigned char)(c)] & 0x04)
+#define ISUPPER(c)   (lr_char_props[(unsigned char)(c)] & 0x02)
+#define ISALNUM(c)   (lr_char_props[(unsigned char)(c)] & 0x60)
+#define ISUALPHA(c)  (lr_char_props[(unsigned char)(c)] & 0x28)
+#define ISUALNUM(c)  (lr_char_props[(unsigned char)(c)] & 0x68)
+#define IS_XDIGIT(c) (lr_char_props[(unsigned char)(c)] & 0x01)
+
+/* Deprecated alias, all callers should use string_is_equal_case_insensitive instead */
+#define string_is_equal_noncase string_is_equal_case_insensitive
+
 static INLINE bool string_is_empty(const char *data)
 {
    return !data || (*data == '\0');
@@ -45,30 +67,48 @@ static INLINE bool string_is_equal(const char *a, const char *b)
    return (a && b) ? !strcmp(a, b) : false;
 }
 
-#define STRLEN_CONST(x)                   ((sizeof((x))-1))
-
-#define string_is_not_equal(a, b)         !string_is_equal((a), (b))
-
-#define string_add_pair_open(s, size)     strlcat((s), " (", (size))
-#define string_add_pair_close(s, size)    strlcat((s), ")",  (size))
-#define string_add_bracket_open(s, size)  strlcat((s), "{",  (size))
-#define string_add_bracket_close(s, size) strlcat((s), "}",  (size))
-#define string_add_single_quote(s, size)  strlcat((s), "'",  (size))
-#define string_add_quote(s, size)         strlcat((s), "\"",  (size))
-#define string_add_colon(s, size)         strlcat((s), ":",  (size))
-#define string_add_glob_open(s, size)     strlcat((s), "glob('*",  (size))
-#define string_add_glob_close(s, size)    strlcat((s), "*')",  (size))
-
-#define string_is_not_equal_fast(a, b, size) (memcmp(a, b, size) != 0)
-#define string_is_equal_fast(a, b, size)     (memcmp(a, b, size) == 0)
-
-static INLINE void string_add_between_pairs(char *s, const char *str,
-      size_t size)
+static INLINE bool string_starts_with_size(const char *str, const char *prefix,
+      size_t len)
 {
-   string_add_pair_open(s, size);
-   strlcat(s, str,  size);
-   string_add_pair_close(s, size);
+   return (str && prefix) ? !strncmp(prefix, str, len) : false;
 }
+
+static INLINE bool string_starts_with(const char *str, const char *prefix)
+{
+   return (str && prefix) ? !strncmp(prefix, str, strlen(prefix)) : false;
+}
+
+static INLINE bool string_ends_with_size(const char *s, const char *suffix,
+      size_t len, size_t suffix_len)
+{
+   return (len < suffix_len) ? false :
+         !memcmp(suffix, s + (len - suffix_len), suffix_len);
+}
+
+static INLINE bool string_ends_with(const char *s, const char *suffix)
+{
+   return s && suffix && string_ends_with_size(s, suffix, strlen(s), strlen(suffix));
+}
+
+/**
+ * strlen_size:
+ *
+ * Leaf function.
+ *
+ * @return the length of 'str' (c.f. strlen()), but only
+ * checks the first 'size' characters
+ * - If 'str' is NULL, returns 0
+ * - If 'str' is not NULL and no '\0' character is found
+ *   in the first 'size' characters, returns 'size'
+ **/
+static INLINE size_t strlen_size(const char *str, size_t len)
+{
+   size_t i = 0;
+   if (str)
+      while (i < len && str[i]) i++;
+   return i;
+}
+
 
 static INLINE bool string_is_equal_case_insensitive(const char *a,
       const char *b)
@@ -89,22 +129,23 @@ static INLINE bool string_is_equal_case_insensitive(const char *a,
    return (result == 0);
 }
 
-static INLINE bool string_is_equal_noncase(const char *a, const char *b)
+static INLINE bool string_starts_with_case_insensitive(const char *str,
+      const char *prefix)
 {
    int result              = 0;
-   const unsigned char *p1 = (const unsigned char*)a;
-   const unsigned char *p2 = (const unsigned char*)b;
+   const unsigned char *p1 = (const unsigned char*)str;
+   const unsigned char *p2 = (const unsigned char*)prefix;
 
-   if (!a || !b)
+   if (!str || !prefix)
       return false;
    if (p1 == p2)
-      return false;
+      return true;
 
-   while ((result = tolower (*p1) - tolower (*p2++)) == 0)
-      if (*p1++ == '\0')
+   while ((result = tolower (*p1++) - tolower (*p2)) == 0)
+      if (*p2++ == '\0')
          break;
 
-   return (result == 0);
+   return (result == 0 || *p2 == '\0');
 }
 
 char *string_to_upper(char *s);
@@ -113,21 +154,225 @@ char *string_to_lower(char *s);
 
 char *string_ucwords(char *s);
 
-char *string_replace_substring(const char *in, const char *pattern,
-      const char *by);
+char *string_replace_substring(
+      const char *in,          size_t in_len,
+      const char *pattern,     size_t pattern_len,
+      const char *replacement, size_t replacement_len);
 
-/* Remove leading whitespaces */
+/**
+ * string_trim_whitespace_left:
+ *
+ * Remove leading whitespaces
+ **/
 char *string_trim_whitespace_left(char *const s);
 
-/* Remove trailing whitespaces */
+/**
+ * string_trim_whitespace_right:
+ *
+ * Remove trailing whitespaces
+ **/
 char *string_trim_whitespace_right(char *const s);
 
-/* Remove leading and trailing whitespaces */
+/**
+ * string_trim_whitespace:
+ *
+ * Remove leading and trailing whitespaces
+ **/
 char *string_trim_whitespace(char *const s);
 
-/* max_lines == 0 means no limit */
-char *word_wrap(char *buffer, const char *string,
-      int line_width, bool unicode, unsigned max_lines);
+/**
+ * word_wrap:
+ * @dst                : pointer to destination buffer.
+ * @dst_size           : size of destination buffer.
+ * @src                : pointer to input string.
+ * @src_len            : length of @src
+ * @line_width         : max number of characters per line.
+ * @wideglyph_width    : not used, but is necessary to keep
+ *                       compatibility with word_wrap_wideglyph().
+ * @max_lines          : max lines of destination string.
+ *                       0 means no limit.
+ *
+ * Wraps string specified by 'src' to destination buffer
+ * specified by 'dst' and 'dst_size'.
+ * This function assumes that all glyphs in the string
+ * have an on-screen pixel width similar to that of
+ * regular Latin characters - i.e. it will not wrap
+ * correctly any text containing so-called 'wide' Unicode
+ * characters (e.g. CJK languages, emojis, etc.).
+ **/
+size_t word_wrap(char *dst, size_t dst_size, const char *src, size_t src_len,
+      int line_width, int wideglyph_width, unsigned max_lines);
+
+/**
+ * word_wrap_wideglyph:
+ * @dst                : pointer to destination buffer.
+ * @dst_size           : size of destination buffer.
+ * @src                : pointer to input string.
+ * @src_len            : length of @src
+ * @line_width         : max number of characters per line.
+ * @wideglyph_width    : effective width of 'wide' Unicode glyphs.
+ *                       the value here is normalised relative to the
+ *                       typical on-screen pixel width of a regular
+ *                       Latin character:
+ *                       - a regular Latin character is defined to
+ *                         have an effective width of 100
+ *                       - wideglyph_width = 100 * (wide_character_pixel_width / latin_character_pixel_width)
+ *                       - e.g. if 'wide' Unicode characters in 'src'
+ *                         have an on-screen pixel width twice that of
+ *                         regular Latin characters, wideglyph_width
+ *                         would be 200
+ * @max_lines          : max lines of destination string.
+ *                       0 means no limit.
+ *
+ * Wraps string specified by @src to destination buffer
+ * specified by @dst and @dst_size.
+ * This function assumes that all glyphs in the string
+ * are:
+ * - EITHER 'non-wide' Unicode glyphs, with an on-screen
+ *   pixel width similar to that of regular Latin characters
+ * - OR 'wide' Unicode glyphs (e.g. CJK languages, emojis, etc.)
+ *   with an on-screen pixel width defined by @wideglyph_width
+ * Note that wrapping may occur in inappropriate locations
+ * if @src string contains 'wide' Unicode characters whose
+ * on-screen pixel width deviates greatly from the set
+ * @wideglyph_width value.
+ **/
+size_t word_wrap_wideglyph(
+      char *dst, size_t dst_size,
+      const char *src, size_t src_len,
+      int line_width, int wideglyph_width,
+      unsigned max_lines);
+
+/**
+ * string_tokenize:
+ *
+ * Splits string into tokens separated by @delim
+ * > Returned token string must be free()'d
+ * > Returns NULL if token is not found
+ * > After each call, @str is set to the position after the
+ *   last found token
+ * > Tokens *include* empty strings
+ * Usage example:
+ *    char *str      = "1,2,3,4,5,6,7,,,10,";
+ *    char **str_ptr = &str;
+ *    char *token    = NULL;
+ *    while ((token = string_tokenize(str_ptr, ",")))
+ *    {
+ *        printf("%s\n", token);
+ *        free(token);
+ *        token = NULL;
+ *    }
+ **/
+char* string_tokenize(char **str, const char *delim);
+
+/**
+ * string_remove_all_chars:
+ * @str                : input string (must be non-NULL, otherwise UB)
+ *
+ * Leaf function.
+ *
+ * Removes every instance of character @c from @str
+ **/
+void string_remove_all_chars(char *str, char c);
+
+/**
+ * string_replace_all_chars:
+ * @str                : input string (must be non-NULL, otherwise UB)
+ * @find               : character to find
+ * @replace            : character to replace @find with
+ *
+ * Hidden non-leaf function cost:
+ * - Calls strchr (in a loop)
+ *
+ * Replaces every instance of character @find in @str
+ * with character @replace
+ **/
+void string_replace_all_chars(char *str, char find, char replace);
+
+/**
+ * string_to_unsigned:
+ * @str                : input string
+ *
+ * Converts string to unsigned integer.
+ *
+ * @return 0 if string is invalid, otherwise > 0
+ **/
+unsigned string_to_unsigned(const char *str);
+
+/**
+ * string_hex_to_unsigned:
+ * @str                : input string (must be non-NULL, otherwise UB)
+ *
+ * Converts hexadecimal string to unsigned integer.
+ * Handles optional leading '0x'.
+ *
+ * @return 0 if string is invalid, otherwise > 0
+ **/
+unsigned string_hex_to_unsigned(const char *str);
+
+/**
+ * string_count_occurrences_single_character:
+ *
+ * Leaf function.
+ *
+ * Get the total number of occurrences of character @c in @str.
+ *
+ * @return Total number of occurrences of character @c
+ */
+int string_count_occurrences_single_character(const char *str, char c);
+
+/**
+ * string_replace_whitespace_with_single_character:
+ *
+ * Leaf function.
+ *
+ * Replaces all spaces with given character @c.
+ **/
+void string_replace_whitespace_with_single_character(char *str, char c);
+
+/**
+ * string_replace_multi_space_with_single_space:
+ *
+ * Leaf function.
+ *
+ * Replaces multiple spaces with a single space in a string.
+ **/
+void string_replace_multi_space_with_single_space(char *str);
+
+/**
+ * string_remove_all_whitespace:
+ *
+ * Leaf function.
+ *
+ * Remove all spaces from the given string.
+ **/
+void string_remove_all_whitespace(char *str_trimmed, const char *str);
+
+/* Retrieve the last occurance of the given character in a string. */
+int string_index_last_occurance(const char *str, char c);
+
+/**
+ * string_find_index_substring_string:
+ * @str                : input string (must be non-NULL, otherwise UB)
+ * @substr             : substring to find in @str
+ *
+ * Hidden non-leaf function cost:
+ * - Calls strstr
+ *
+ * Find the position of substring @substr in string @str.
+ **/
+int string_find_index_substring_string(const char *str, const char *substr);
+
+/**
+ * string_copy_only_ascii:
+ *
+ * Leaf function.
+ *
+ * Strips non-ASCII characters from a string.
+ **/
+void string_copy_only_ascii(char *str_stripped, const char *str);
+
+extern const unsigned char lr_char_props[256];
 
 RETRO_END_DECLS
 

--- a/core/deps/libretro-common/include/time/rtime.h
+++ b/core/deps/libretro-common/include/time/rtime.h
@@ -1,0 +1,63 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (rtime.h).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __LIBRETRO_SDK_RTIME_H__
+#define __LIBRETRO_SDK_RTIME_H__
+
+#include <retro_common_api.h>
+
+#include <stdint.h>
+#include <stddef.h>
+#include <time.h>
+
+RETRO_BEGIN_DECLS
+
+/* TODO/FIXME: Move all generic time handling functions
+ * to this file */
+
+/**
+ * Must be called before using \c rtime_localtime().
+ * May be called multiple times without ill effects,
+ * but must only be called from the main thread.
+ */
+void rtime_init(void);
+
+/**
+ * Must be called upon program or core termination.
+ * May be called multiple times without ill effects,
+ * but must only be called from the main thread.
+ */
+void rtime_deinit(void);
+
+/**
+ * Thread-safe wrapper around standard \c localtime(),
+ * which by itself is not guaranteed to be thread-safe.
+ * @param timep Pointer to a time_t object to convert.
+ * @param result Pointer to a tm object to store the result in.
+ * @return \c result.
+ * @see https://en.cppreference.com/w/c/chrono/localtime
+ */
+struct tm *rtime_localtime(const time_t *timep, struct tm *result);
+
+RETRO_END_DECLS
+
+#endif

--- a/core/deps/libretro-common/streams/file_stream.c
+++ b/core/deps/libretro-common/streams/file_stream.c
@@ -1,0 +1,700 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (file_stream.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <ctype.h>
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifdef _MSC_VER
+#include <compat/msvc.h>
+#endif
+
+#include <retro_miscellaneous.h>
+#include <file/file_path.h>
+#include <string/stdstring.h>
+#include <streams/file_stream.h>
+#define VFS_FRONTEND
+#include <vfs/vfs_implementation.h>
+
+#define VFS_ERROR_RETURN_VALUE -1
+
+struct RFILE
+{
+   struct retro_vfs_file_handle *hfile;
+   bool err_flag;
+};
+
+static retro_vfs_get_path_t filestream_get_path_cb = NULL;
+static retro_vfs_open_t filestream_open_cb         = NULL;
+static retro_vfs_close_t filestream_close_cb       = NULL;
+static retro_vfs_size_t filestream_size_cb         = NULL;
+static retro_vfs_truncate_t filestream_truncate_cb = NULL;
+static retro_vfs_tell_t filestream_tell_cb         = NULL;
+static retro_vfs_seek_t filestream_seek_cb         = NULL;
+static retro_vfs_read_t filestream_read_cb         = NULL;
+static retro_vfs_write_t filestream_write_cb       = NULL;
+static retro_vfs_flush_t filestream_flush_cb       = NULL;
+static retro_vfs_remove_t filestream_remove_cb     = NULL;
+static retro_vfs_rename_t filestream_rename_cb     = NULL;
+
+/* VFS Initialization */
+
+void filestream_vfs_init(const struct retro_vfs_interface_info* vfs_info)
+{
+   const struct retro_vfs_interface *
+      vfs_iface           = vfs_info->iface;
+
+   filestream_get_path_cb = NULL;
+   filestream_open_cb     = NULL;
+   filestream_close_cb    = NULL;
+   filestream_tell_cb     = NULL;
+   filestream_size_cb     = NULL;
+   filestream_truncate_cb = NULL;
+   filestream_seek_cb     = NULL;
+   filestream_read_cb     = NULL;
+   filestream_write_cb    = NULL;
+   filestream_flush_cb    = NULL;
+   filestream_remove_cb   = NULL;
+   filestream_rename_cb   = NULL;
+
+   if (
+             (vfs_info->required_interface_version <
+             FILESTREAM_REQUIRED_VFS_VERSION)
+         || !vfs_iface)
+      return;
+
+   filestream_get_path_cb = vfs_iface->get_path;
+   filestream_open_cb     = vfs_iface->open;
+   filestream_close_cb    = vfs_iface->close;
+   filestream_size_cb     = vfs_iface->size;
+   filestream_truncate_cb = vfs_iface->truncate;
+   filestream_tell_cb     = vfs_iface->tell;
+   filestream_seek_cb     = vfs_iface->seek;
+   filestream_read_cb     = vfs_iface->read;
+   filestream_write_cb    = vfs_iface->write;
+   filestream_flush_cb    = vfs_iface->flush;
+   filestream_remove_cb   = vfs_iface->remove;
+   filestream_rename_cb   = vfs_iface->rename;
+}
+
+/* Callback wrappers */
+bool filestream_exists(const char *path)
+{
+   RFILE *dummy           = NULL;
+
+   if (!path || !*path)
+      return false;
+   if (!(dummy = filestream_open(
+         path,
+         RETRO_VFS_FILE_ACCESS_READ,
+         RETRO_VFS_FILE_ACCESS_HINT_NONE)))
+      return false;
+
+   if (filestream_close(dummy) != 0)
+      free(dummy);
+
+   dummy = NULL;
+   return true;
+}
+
+int64_t filestream_get_size(RFILE *stream)
+{
+   int64_t output;
+
+   if (filestream_size_cb)
+      output = filestream_size_cb(stream->hfile);
+   else
+      output = retro_vfs_file_size_impl(
+            (libretro_vfs_implementation_file*)stream->hfile);
+
+   if (output == VFS_ERROR_RETURN_VALUE)
+      stream->err_flag = true;
+
+   return output;
+}
+
+int64_t filestream_truncate(RFILE *stream, int64_t length)
+{
+   int64_t output;
+
+   if (filestream_truncate_cb)
+      output = filestream_truncate_cb(stream->hfile, length);
+   else
+      output = retro_vfs_file_truncate_impl(
+            (libretro_vfs_implementation_file*)stream->hfile, length);
+
+   if (output == VFS_ERROR_RETURN_VALUE)
+      stream->err_flag = true;
+
+   return output;
+}
+
+RFILE* filestream_open(const char *path, unsigned mode, unsigned hints)
+{
+   struct retro_vfs_file_handle  *fp = NULL;
+   RFILE* output                     = (RFILE*)malloc(sizeof(RFILE));
+
+   if (!output)
+      return NULL;
+
+   if (filestream_open_cb)
+      fp = (struct retro_vfs_file_handle*)
+         filestream_open_cb(path, mode, hints);
+   else
+      fp = (struct retro_vfs_file_handle*)
+         retro_vfs_file_open_impl(path, mode, hints);
+
+   if (!fp)
+   {
+      free(output);
+      return NULL;
+   }
+
+   output->err_flag = false;
+   output->hfile    = fp;
+   return output;
+}
+
+char* filestream_gets(RFILE *stream, char *s, size_t len)
+{
+   int c   = 0;
+   char *p = s;
+   if (!stream)
+      return NULL;
+
+   /* get max bytes or up to a newline */
+
+   for (len--; len > 0; len--)
+   {
+      if ((c = filestream_getc(stream)) == EOF)
+         break;
+      *p++ = c;
+      if (c == '\n')
+         break;
+   }
+   *p = 0;
+
+   if (p == s && c == EOF)
+      return NULL;
+   return (s);
+}
+
+int filestream_getc(RFILE *stream)
+{
+   char c = 0;
+   if (stream && filestream_read(stream, &c, 1) == 1)
+      return (int)(unsigned char)c;
+   return EOF;
+}
+
+int filestream_vscanf(RFILE *stream, const char* format, va_list *args)
+{
+   char buf[4096];
+   char subfmt[64];
+   va_list args_copy;
+   const char *bufiter  = buf;
+   int        ret       = 0;
+   int64_t startpos     = filestream_tell(stream);
+   int64_t maxlen       = filestream_read(stream, buf, sizeof(buf)-1);
+
+   if (maxlen <= 0)
+      return EOF;
+
+   buf[maxlen] = '\0';
+
+   /* Have to copy the input va_list here
+    * > Calling va_arg() on 'args' directly would
+    *   cause the va_list to have an indeterminate value
+    *   in the function calling filestream_vscanf(),
+    *   leading to unexpected behaviour */
+#ifdef __va_copy
+   __va_copy(args_copy, *args);
+#else
+   va_copy(args_copy, *args);
+#endif
+
+   while (*format)
+   {
+      if (*format == '%')
+      {
+         int sublen       = 0;
+         char* subfmtiter = subfmt;
+         bool asterisk    = false;
+
+         *subfmtiter++    = *format++; /* '%' */
+
+         /* %[*][width][length]specifier */
+
+         if (*format == '*')
+         {
+            asterisk      = true;
+            *subfmtiter++ = *format++;
+         }
+
+         while (ISDIGIT((unsigned char)*format))
+            *subfmtiter++ = *format++; /* width */
+
+         /* length */
+         if (*format == 'h' || *format == 'l')
+         {
+            if (format[1] == format[0])
+               *subfmtiter++ = *format++;
+            *subfmtiter++    = *format++;
+         }
+         else if (
+               *format == 'j' ||
+               *format == 'z' ||
+               *format == 't' ||
+               *format == 'L')
+         {
+            *subfmtiter++ = *format++;
+         }
+
+         /* specifier - always a single character (except ]) */
+         if (*format == '[')
+         {
+            while (*format != ']')
+               *subfmtiter++ = *format++;
+            *subfmtiter++    = *format++;
+         }
+         else
+            *subfmtiter++    = *format++;
+
+         *subfmtiter++       = '%';
+         *subfmtiter++       = 'n';
+         *subfmtiter++       = '\0';
+
+         if (sizeof(void*) != sizeof(long*))
+            abort(); /* all pointers must have the same size */
+
+         if (asterisk)
+         {
+            int v = sscanf(bufiter, subfmt, &sublen);
+            if (v == EOF)
+               return EOF;
+            if (v != 0)
+               break;
+         }
+         else
+         {
+            int v = sscanf(bufiter, subfmt, va_arg(args_copy, void*), &sublen);
+            if (v == EOF)
+               return EOF;
+            if (v != 1)
+               break;
+         }
+
+         ret++;
+         bufiter += sublen;
+      }
+      else if (isspace((unsigned char)*format))
+      {
+         while (isspace((unsigned char)*bufiter))
+            bufiter++;
+         format++;
+      }
+      else
+      {
+         if (*bufiter != *format)
+            break;
+         bufiter++;
+         format++;
+      }
+   }
+
+   va_end(args_copy);
+   filestream_seek(stream, startpos + (bufiter - buf),
+         RETRO_VFS_SEEK_POSITION_START);
+
+   return ret;
+}
+
+int filestream_scanf(RFILE *stream, const char* format, ...)
+{
+   int ret;
+   va_list vl;
+   va_start(vl, format);
+   ret = filestream_vscanf(stream, format, &vl);
+   va_end(vl);
+   return ret;
+}
+
+int64_t filestream_seek(RFILE *stream, int64_t offset, int seek_position)
+{
+   int64_t output;
+
+   if (filestream_seek_cb)
+      output = filestream_seek_cb(stream->hfile, offset, seek_position);
+   else
+      output = retro_vfs_file_seek_impl(
+            (libretro_vfs_implementation_file*)stream->hfile,
+            offset, seek_position);
+
+   if (output == VFS_ERROR_RETURN_VALUE)
+      stream->err_flag = true;
+
+   return output;
+}
+
+int filestream_eof(RFILE *stream)
+{
+   return filestream_tell(stream) == filestream_get_size(stream) ? EOF : 0;
+}
+
+int64_t filestream_tell(RFILE *stream)
+{
+   int64_t output;
+
+   if (filestream_size_cb)
+      output = filestream_tell_cb(stream->hfile);
+   else
+      output = retro_vfs_file_tell_impl(
+            (libretro_vfs_implementation_file*)stream->hfile);
+
+   if (output == VFS_ERROR_RETURN_VALUE)
+      stream->err_flag = true;
+
+   return output;
+}
+
+void filestream_rewind(RFILE *stream)
+{
+   if (!stream)
+      return;
+   filestream_seek(stream, 0L, RETRO_VFS_SEEK_POSITION_START);
+   stream->err_flag = false;
+}
+
+int64_t filestream_read(RFILE *stream, void *s, int64_t len)
+{
+   int64_t output;
+
+   if (filestream_read_cb)
+      output = filestream_read_cb(stream->hfile, s, len);
+   else
+      output = retro_vfs_file_read_impl(
+            (libretro_vfs_implementation_file*)stream->hfile, s, len);
+
+   if (output == VFS_ERROR_RETURN_VALUE)
+      stream->err_flag = true;
+
+   return output;
+}
+
+int filestream_flush(RFILE *stream)
+{
+   int output;
+
+   if (filestream_flush_cb)
+      output = filestream_flush_cb(stream->hfile);
+   else
+      output = retro_vfs_file_flush_impl(
+            (libretro_vfs_implementation_file*)stream->hfile);
+
+   if (output == VFS_ERROR_RETURN_VALUE)
+      stream->err_flag = true;
+
+   return output;
+}
+
+int filestream_delete(const char *path)
+{
+   if (filestream_remove_cb)
+      return filestream_remove_cb(path);
+
+   return retro_vfs_file_remove_impl(path);
+}
+
+int filestream_rename(const char *old_path, const char *new_path)
+{
+   if (filestream_rename_cb)
+      return filestream_rename_cb(old_path, new_path);
+
+   return retro_vfs_file_rename_impl(old_path, new_path);
+}
+
+int filestream_copy(const char *src, const char *dst)
+{
+   char buf[256] = {0};
+   int64_t n     = 0;
+   int ret       = 0;
+   char path_dst[PATH_MAX_LENGTH] = {0};
+
+   RFILE *fp_src = filestream_open(src, RETRO_VFS_FILE_ACCESS_READ, RETRO_VFS_FILE_ACCESS_HINT_NONE);
+   RFILE *fp_dst = filestream_open(dst, RETRO_VFS_FILE_ACCESS_WRITE, RETRO_VFS_FILE_ACCESS_HINT_NONE);
+
+   if (!fp_src || !fp_dst)
+      ret = -1;
+
+   if (ret < 0)
+      goto close;
+
+   snprintf(path_dst, sizeof(path_dst), "%s", dst);
+   path_basedir(path_dst);
+
+   if (!path_is_directory(path_dst))
+      path_mkdir(path_dst);
+
+   while ((n = filestream_read(fp_src, buf, sizeof(buf))) > 0 && ret == 0)
+   {
+      if (filestream_write(fp_dst, buf, n) != n)
+         ret = -1;
+   }
+
+close:
+   if (fp_src)
+      filestream_close(fp_src);
+   if (fp_dst)
+      filestream_close(fp_dst);
+   return ret;
+}
+
+int filestream_cmp(const char *src, const char *dst)
+{
+   int ret           = 0;
+   RFILE *fp_src     = filestream_open(src, RETRO_VFS_FILE_ACCESS_READ,
+         RETRO_VFS_FILE_ACCESS_HINT_NONE);
+   RFILE *fp_dst     = filestream_open(dst, RETRO_VFS_FILE_ACCESS_READ,
+         RETRO_VFS_FILE_ACCESS_HINT_NONE);
+
+   if (!fp_src || !fp_dst || filestream_get_size(fp_src) != filestream_get_size(fp_dst))
+      ret = -1;
+
+   if (ret >= 0)
+   {
+      char buf_src[256] = {0};
+      char buf_dst[256] = {0};
+      while ((filestream_read(fp_src, buf_src, sizeof(buf_src))) > 0 && ret == 0)
+      {
+         filestream_read(fp_dst, buf_dst, sizeof(buf_dst));
+         ret = memcmp(buf_src, buf_dst, sizeof(buf_src));
+      }
+   }
+
+   if (fp_src)
+   {
+      filestream_close(fp_src);
+      fp_src = NULL;
+   }
+   if (fp_dst)
+   {
+      filestream_close(fp_dst);
+      fp_dst = NULL;
+   }
+   return ret;
+}
+
+const char* filestream_get_path(RFILE *stream)
+{
+   if (filestream_get_path_cb)
+      return filestream_get_path_cb(stream->hfile);
+
+   return retro_vfs_file_get_path_impl(
+         (libretro_vfs_implementation_file*)stream->hfile);
+}
+
+int64_t filestream_write(RFILE *stream, const void *s, int64_t len)
+{
+   int64_t output;
+
+   if (filestream_write_cb)
+      output = filestream_write_cb(stream->hfile, s, len);
+   else
+      output = retro_vfs_file_write_impl(
+            (libretro_vfs_implementation_file*)stream->hfile, s, len);
+
+   if (output == VFS_ERROR_RETURN_VALUE)
+      stream->err_flag = true;
+
+   return output;
+}
+
+int filestream_putc(RFILE *stream, int c)
+{
+   char c_char = (char)c;
+   if (!stream)
+      return EOF;
+   return filestream_write(stream, &c_char, 1) == 1
+      ? (int)(unsigned char)c
+      : EOF;
+}
+
+int filestream_vprintf(RFILE *stream, const char* format, va_list args)
+{
+   static char buffer[8 * 1024];
+   int _len = vsnprintf(buffer, sizeof(buffer),
+         format, args);
+   if (_len < 0)
+      return -1;
+   else if (_len == 0)
+      return 0;
+   return (int)filestream_write(stream, buffer, _len);
+}
+
+int filestream_printf(RFILE *stream, const char* format, ...)
+{
+   va_list vl;
+   int ret;
+   va_start(vl, format);
+   ret = filestream_vprintf(stream, format, vl);
+   va_end(vl);
+   return ret;
+}
+
+int filestream_error(RFILE *stream)
+{
+   return (stream && stream->err_flag);
+}
+
+int filestream_close(RFILE *stream)
+{
+   int output;
+   struct retro_vfs_file_handle* fp = stream->hfile;
+
+   if (filestream_close_cb)
+      output = filestream_close_cb(fp);
+   else
+      output = retro_vfs_file_close_impl(
+            (libretro_vfs_implementation_file*)fp);
+
+   if (output == 0)
+      free(stream);
+
+   return output;
+}
+
+int64_t filestream_read_file(const char *path, void **buf, int64_t *len)
+{
+   int64_t ret              = 0;
+   int64_t content_buf_size = 0;
+   void *content_buf        = NULL;
+   RFILE *file              = filestream_open(path,
+         RETRO_VFS_FILE_ACCESS_READ,
+         RETRO_VFS_FILE_ACCESS_HINT_NONE);
+
+   if (!file)
+   {
+      *buf = NULL;
+      return 0;
+   }
+
+   if ((content_buf_size = filestream_get_size(file)) < 0)
+      goto error;
+
+   if (!(content_buf = malloc((size_t)(content_buf_size + 1))))
+      goto error;
+   if ((int64_t)(uint64_t)(content_buf_size + 1) != (content_buf_size + 1))
+      goto error;
+
+   if ((ret = filestream_read(file, content_buf, (int64_t)content_buf_size)) <
+         0)
+      goto error;
+
+   if (filestream_close(file) != 0)
+      free(file);
+
+   *buf    = content_buf;
+
+   /* Allow for easy reading of strings to be safe.
+    * Will only work with sane character formatting (Unix). */
+   ((char*)content_buf)[ret] = '\0';
+
+   if (len)
+      *len = ret;
+
+   return 1;
+
+error:
+   if (filestream_close(file) != 0)
+      free(file);
+   if (content_buf)
+      free(content_buf);
+   if (len)
+      *len = -1;
+   *buf = NULL;
+   return 0;
+}
+
+bool filestream_write_file(const char *path, const void *data, int64_t size)
+{
+   int64_t ret   = 0;
+   RFILE *file   = filestream_open(path,
+         RETRO_VFS_FILE_ACCESS_WRITE,
+         RETRO_VFS_FILE_ACCESS_HINT_NONE);
+   if (!file)
+      return false;
+   ret = filestream_write(file, data, size);
+   if (filestream_close(file) != 0)
+      free(file);
+   return (ret == size);
+}
+
+char *filestream_getline(RFILE *stream)
+{
+   char *newline_tmp  = NULL;
+   size_t cur_size    = 8;
+   size_t idx         = 0;
+   int in             = 0;
+   char *newline      = (char*)malloc(9);
+
+   if (!stream || !newline)
+   {
+      if (newline)
+         free(newline);
+      return NULL;
+   }
+
+   in = filestream_getc(stream);
+
+   while (in != EOF && in != '\n')
+   {
+      if (idx == cur_size)
+      {
+         cur_size    *= 2;
+
+         if (!(newline_tmp = (char*)realloc(newline, cur_size + 1)))
+         {
+            free(newline);
+            return NULL;
+         }
+
+         newline     = newline_tmp;
+      }
+
+      newline[idx++] = in;
+      in             = filestream_getc(stream);
+   }
+
+   newline[idx]      = '\0';
+   return newline;
+}
+
+libretro_vfs_implementation_file* filestream_get_vfs_handle(RFILE *stream)
+{
+   return (libretro_vfs_implementation_file*)stream->hfile;
+}

--- a/core/deps/libretro-common/string/stdstring.c
+++ b/core/deps/libretro-common/string/stdstring.c
@@ -1,4 +1,4 @@
-/* Copyright  (C) 2010-2018 The RetroArch team
+/* Copyright  (C) 2010-2020 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this file (stdstring.c).
@@ -22,9 +22,31 @@
 
 #include <stdint.h>
 #include <ctype.h>
+#include <string.h>
 
+#include <compat/strl.h>
 #include <string/stdstring.h>
 #include <encodings/utf.h>
+
+const uint8_t lr_char_props[256] = {
+	/*x0   x1   x2   x3   x4   x5   x6   x7   x8   x9   xA   xB   xC   xD   xE   xF */
+	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x80,0x80,0x00,0x00,0x80,0x00,0x00, /* 0x                  */
+	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, /* 1x                  */
+	0x80,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, /* 2x  !"#$%&'()*+,-./ */
+	0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x00,0x00,0x00,0x00,0x00,0x00, /* 3x 0123456789:;<=>? */
+	0x00,0x23,0x23,0x23,0x23,0x23,0x23,0x22,0x22,0x22,0x22,0x22,0x22,0x22,0x22,0x22, /* 4x @ABCDEFGHIJKLMNO */
+	0x22,0x22,0x22,0x22,0x22,0x22,0x22,0x22,0x22,0x22,0x22,0x00,0x00,0x00,0x00,0x08, /* 5x PQRSTUVWXYZ[\]^_ */
+	0x00,0x25,0x25,0x25,0x25,0x25,0x25,0x24,0x24,0x24,0x24,0x24,0x24,0x24,0x24,0x24, /* 6x `abcdefghijklmno */
+	0x24,0x24,0x24,0x24,0x24,0x24,0x24,0x24,0x24,0x24,0x24,0x00,0x00,0x00,0x00,0x00, /* 7x pqrstuvwxyz{|}~  */
+	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, /* 8x                  */
+	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, /* 9x                  */
+	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, /* Ax                  */
+	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, /* Bx                  */
+	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, /* Cx                  */
+	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, /* Dx                  */
+	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, /* Ex                  */
+	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, /* Fx                  */
+};
 
 char *string_to_upper(char *s)
 {
@@ -45,9 +67,13 @@ char *string_to_lower(char *s)
 char *string_ucwords(char *s)
 {
    char *cs = (char *)s;
+
+   if (!s || *s == '\0')
+      return s;
+
    for ( ; *cs != '\0'; cs++)
    {
-      if (*cs == ' ')
+      if (*cs == ' ' && *(cs + 1) != '\0')
          *(cs+1) = toupper((unsigned char)*(cs+1));
    }
 
@@ -55,10 +81,13 @@ char *string_ucwords(char *s)
    return s;
 }
 
-char *string_replace_substring(const char *in,
-      const char *pattern, const char *replacement)
+char *string_replace_substring(
+      const char *in,          size_t in_len,
+      const char *pattern,     size_t pattern_len,
+      const char *replacement, size_t replacement_len)
 {
-   size_t numhits, pattern_len, replacement_len, outlen;
+   size_t _len;
+   size_t numhits     = 0;
    const char *inat   = NULL;
    const char *inprev = NULL;
    char          *out = NULL;
@@ -69,9 +98,6 @@ char *string_replace_substring(const char *in,
    if (!pattern || !replacement)
       return strdup(in);
 
-   pattern_len     = strlen(pattern);
-   replacement_len = strlen(replacement);
-   numhits         = 0;
    inat            = in;
 
    while ((inat = strstr(inat, pattern)))
@@ -80,10 +106,9 @@ char *string_replace_substring(const char *in,
       numhits++;
    }
 
-   outlen          = strlen(in) - pattern_len*numhits + replacement_len*numhits;
-   out             = (char *)malloc(outlen+1);
+   _len = in_len - pattern_len * numhits + replacement_len*numhits;
 
-   if (!out)
+   if (!(out = (char *)malloc(_len + 1)))
       return NULL;
 
    outat           = out;
@@ -96,56 +121,69 @@ char *string_replace_substring(const char *in,
       outat += inat-inprev;
       memcpy(outat, replacement, replacement_len);
       outat += replacement_len;
-      inat += pattern_len;
+      inat  += pattern_len;
       inprev = inat;
    }
-   strcpy(outat, inprev);
+
+   _len = (in + in_len) - inprev;
+   strlcpy(outat, inprev, _len + 1);
 
    return out;
 }
 
-/* Remove leading whitespaces */
+/**
+ * string_trim_whitespace_left:
+ *
+ * Remove leading whitespaces
+ **/
 char *string_trim_whitespace_left(char *const s)
 {
-   if(s && *s)
+   if (s && *s)
    {
-      size_t len     = strlen(s);
       char *current  = s;
 
-      while(*current && isspace((unsigned char)*current))
-      {
+      while (*current && ISSPACE((unsigned char)*current))
          ++current;
-         --len;
-      }
 
-      if(s != current)
-         memmove(s, current, len + 1);
+      if (s != current)
+      {
+         size_t _len = strlen(current);
+         memmove(s, current, _len + 1);
+      }
    }
 
    return s;
 }
 
-/* Remove trailing whitespaces */
+/**
+ * string_trim_whitespace_right:
+ *
+ * Remove trailing whitespaces
+ **/
 char *string_trim_whitespace_right(char *const s)
 {
-   if(s && *s)
+   if (s && *s)
    {
-      size_t len     = strlen(s);
-      char  *current = s + len - 1;
+      size_t _len    = strlen(s);
+      char  *current = s + _len - 1;
 
-      while(current != s && isspace((unsigned char)*current))
+      while (current != s && ISSPACE((unsigned char)*current))
       {
          --current;
-         --len;
+         --_len;
       }
 
-      current[isspace((unsigned char)*current) ? 0 : 1] = '\0';
+      current[ISSPACE((unsigned char)*current) ? 0 : 1] = '\0';
    }
 
    return s;
 }
 
-/* Remove leading and trailing whitespaces */
+/**
+ * string_trim_whitespace:
+ *
+ * Remove leading and trailing whitespaces
+ **/
 char *string_trim_whitespace(char *const s)
 {
    string_trim_whitespace_right(s);  /* order matters */
@@ -154,86 +192,534 @@ char *string_trim_whitespace(char *const s)
    return s;
 }
 
-char *word_wrap(char* buffer, const char *string, int line_width, bool unicode, unsigned max_lines)
+/**
+ * word_wrap:
+ * @s                  : pointer to destination buffer.
+ * @len                : size of destination buffer.
+ * @src                : pointer to input string.
+ * @line_width         : max number of characters per line.
+ * @wideglyph_width    : not used, but is necessary to keep
+ *                       compatibility with word_wrap_wideglyph().
+ * @max_lines          : max lines of destination string.
+ *                       0 means no limit.
+ *
+ * Wraps string specified by @src to destination buffer
+ * specified by @s and @len.
+ * This function assumes that all glyphs in the string
+ * have an on-screen pixel width similar to that of
+ * regular Latin characters - i.e. it will not wrap
+ * correctly any text containing so-called 'wide' Unicode
+ * characters (e.g. CJK languages, emojis, etc.).
+ **/
+size_t word_wrap(
+      char *s,         size_t len,
+      const char *src, size_t src_len,
+      int line_width,  int wideglyph_width, unsigned max_lines)
 {
-   unsigned i     = 0;
-   unsigned len   = (unsigned)strlen(string);
-   unsigned lines = 1;
+   char *last_space    = NULL;
+   unsigned counter    = 0;
+   unsigned lines      = 1;
+   const char *src_end = src + src_len;
+   char *s_start       = s;
+   size_t _len         = len;
 
-   while (i < len)
+   /* Prevent buffer overflow */
+   if (len < src_len + 1)
+      return 0;
+
+   /* Early return if src string length is less
+    * than line width */
+   if (src_len < (size_t)line_width)
+      return strlcpy(s, src, len);
+
+   while (*src != '\0')
    {
-      unsigned counter;
-      int pos = (int)(&buffer[i] - buffer);
+      unsigned char_len = (unsigned)(utf8skip(src, 1) - src);
+      counter++;
 
-      /* copy string until the end of the line is reached */
-      for (counter = 1; counter <= (unsigned)line_width; counter++)
+      if (*src == ' ')
+         last_space = s; /* Remember the location of the whitespace */
+      else if (*src == '\n')
       {
-         const char *character;
-         unsigned char_len;
-         unsigned j = i;
+         /* If newlines embedded in the input,
+          * reset the index */
+         lines++;
+         counter   = 0;
 
-         /* check if end of string reached */
-         if (i == len)
+         /* Early return if remaining src string
+          * length is less than line width */
+         if (src_end - src <= line_width)
          {
-            buffer[i] = 0;
-            return buffer;
-         }
-
-         character = utf8skip(&string[i], 1);
-         char_len  = (unsigned)(character - &string[i]);
-
-         if (!unicode)
-            counter += char_len - 1;
-
-         do
-         {
-            buffer[i] = string[i];
-            char_len--;
-            i++;
-         } while(char_len);
-
-         /* check for newlines embedded in the original input
-          * and reset the index */
-         if (buffer[j] == '\n')
-         {
-            lines++;
-            counter = 1;
+            _len = len - (size_t)(s - s_start);
+            return strlcpy(s, src, _len);
          }
       }
 
-      /* check for whitespace */
-      if (string[i] == ' ')
+      while (char_len--)
+         *s++ = *src++;
+
+      if (counter >= (unsigned)line_width)
       {
-         if ((max_lines == 0 || lines < max_lines))
+         counter = 0;
+
+         if (last_space && (max_lines == 0 || lines < max_lines))
          {
-            buffer[i] = '\n';
-            i++;
+            /* Replace nearest (previous) whitespace
+             * with newline character */
+            *last_space = '\n';
             lines++;
+
+            src        -= s - last_space - 1;
+            s           = last_space + 1;
+            last_space  = NULL;
+
+            /* Early return if remaining src string
+             * length is less than line width */
+            if (src_end - src < line_width)
+            {
+               _len = len - (size_t)(s - s_start);
+               return strlcpy(s, src, _len);
+            }
          }
-      }
-      else
-      {
-         int k;
-
-         /* check for nearest whitespace back in string */
-         for (k = i; k > 0; k--)
-         {
-            if (string[k] != ' ' || (max_lines != 0 && lines >= max_lines))
-               continue;
-
-            buffer[k] = '\n';
-            /* set string index back to character after this one */
-            i         = k + 1;
-            lines++;
-            break;
-         }
-
-         if (&buffer[i] - buffer == pos)
-            return buffer;
       }
    }
 
-   buffer[i] = 0;
+   *s = '\0';
+   return 0;
+}
 
-   return buffer;
+/**
+ * word_wrap_wideglyph:
+ * @dst                : pointer to destination buffer.
+ * @len                : size of destination buffer.
+ * @src                : pointer to input string.
+ * @line_width         : max number of characters per line.
+ * @wideglyph_width    : effective width of 'wide' Unicode glyphs.
+ *                       the value here is normalised relative to the
+ *                       typical on-screen pixel width of a regular
+ *                       Latin character:
+ *                       - a regular Latin character is defined to
+ *                         have an effective width of 100
+ *                       - wideglyph_width = 100 * (wide_character_pixel_width / latin_character_pixel_width)
+ *                       - e.g. if 'wide' Unicode characters in 'src'
+ *                         have an on-screen pixel width twice that of
+ *                         regular Latin characters, wideglyph_width
+ *                         would be 200
+ * @max_lines          : max lines of destination string.
+ *                       0 means no limit.
+ *
+ * Wraps string specified by @src to destination buffer
+ * specified by @dst and @len.
+ * This function assumes that all glyphs in the string
+ * are:
+ * - EITHER 'non-wide' Unicode glyphs, with an on-screen
+ *   pixel width similar to that of regular Latin characters
+ * - OR 'wide' Unicode glyphs (e.g. CJK languages, emojis, etc.)
+ *   with an on-screen pixel width defined by @wideglyph_width
+ * Note that wrapping may occur in inappropriate locations
+ * if @src string contains 'wide' Unicode characters whose
+ * on-screen pixel width deviates greatly from the set
+ * @wideglyph_width value.
+ **/
+size_t word_wrap_wideglyph(char *s, size_t len,
+      const char *src, size_t src_len, int line_width,
+      int wideglyph_width, unsigned max_lines)
+{
+   char *lastspace                   = NULL;
+   char *lastwideglyph               = NULL;
+   const char *src_end               = src + src_len;
+   char *s_start                     = s;
+   unsigned lines                    = 1;
+   /* 'line_width' means max numbers of characters per line,
+    * but this metric is only meaningful when dealing with
+    * 'regular' glyphs that have an on-screen pixel width
+    * similar to that of regular Latin characters.
+    * When handing so-called 'wide' Unicode glyphs, it is
+    * necessary to consider the actual on-screen pixel width
+    * of each character.
+    * In order to do this, we create a distinction between
+    * regular Latin 'non-wide' glyphs and 'wide' glyphs, and
+    * normalise all values relative to the on-screen pixel
+    * width of regular Latin characters:
+    * - Regular 'non-wide' glyphs have a normalised width of 100
+    * - 'line_width' is therefore normalised to 100 * (width_in_characters)
+    * - 'wide' glyphs have a normalised width of
+    *   100 * (wide_character_pixel_width / latin_character_pixel_width)
+    * - When a character is detected, the position in the current
+    *   line is incremented by the regular normalised width of 100
+    * - If that character is then determined to be a 'wide'
+    *   glyph, the position in the current line is further incremented
+    *   by the difference between the normalised 'wide' and 'non-wide'
+    *   width values */
+   unsigned counter_normalized       = 0;
+   int line_width_normalized         = line_width * 100;
+   int additional_counter_normalized = wideglyph_width - 100;
+
+   /* Early return if src string length is less
+    * than line width */
+   if (src_end - src < line_width)
+      return strlcpy(s, src, len);
+
+   while (*src != '\0')
+   {
+      size_t remaining;
+      unsigned char_len   = (unsigned)(utf8skip(src, 1) - src);
+      counter_normalized += 100;
+
+      /* Prevent buffer overflow */
+      if (char_len >= len)
+         break;
+
+      if (*src == ' ')
+         lastspace          = s; /* Remember the location of the whitespace */
+      else if (*src == '\n')
+      {
+         /* If newlines embedded in the input,
+          * reset the index */
+         lines++;
+         counter_normalized = 0;
+
+         /* Early return if remaining src string
+          * length is less than line width */
+         if (src_end - src <= line_width)
+         {
+            remaining = len - (size_t)(s - s_start);
+            return strlcpy(s, src, remaining);
+         }
+      }
+      else if (char_len >= 3)
+      {
+         /* Remember the location of the first byte
+          * whose length as UTF-8 >= 3*/
+         lastwideglyph       = s;
+         counter_normalized += additional_counter_normalized;
+      }
+
+      len -= char_len;
+      while (char_len--)
+         *s++ = *src++;
+
+      if (counter_normalized >= (unsigned)line_width_normalized)
+      {
+         counter_normalized = 0;
+
+         if (max_lines != 0 && lines >= max_lines)
+            continue;
+         else if (lastwideglyph 
+              && (!lastspace || lastwideglyph > lastspace))
+         {
+            /* Insert newline character */
+            *lastwideglyph = '\n';
+            lines++;
+            src           -= s - lastwideglyph;
+            s              = lastwideglyph + 1;
+            lastwideglyph  = NULL;
+
+            /* Early return if remaining src string
+             * length is less than line width */
+            if (src_end - src <= line_width)
+            {
+               remaining = len - (size_t)(s - s_start);
+               return strlcpy(s, src, remaining);
+            }
+         }
+         else if (lastspace)
+         {
+            /* Replace nearest (previous) whitespace
+             * with newline character */
+            *lastspace = '\n';
+            lines++;
+            src       -= s - lastspace - 1;
+            s          = lastspace + 1;
+            lastspace  = NULL;
+
+            /* Early return if remaining src string
+             * length is less than line width */
+            if (src_end - src < line_width)
+            {
+               remaining = len - (size_t)(s - s_start);
+               return strlcpy(s, src, remaining);
+            }
+         }
+      }
+   }
+
+   *s = '\0';
+   return 0;
+}
+
+/**
+ * string_tokenize:
+ *
+ * Splits string into tokens separated by @delim
+ * > Returned token string must be free()'d
+ * > Returns NULL if token is not found
+ * > After each call, @str is set to the position after the
+ *   last found token
+ * > Tokens *include* empty strings
+ * Usage example:
+ *    char *str      = "1,2,3,4,5,6,7,,,10,";
+ *    char **str_ptr = &str;
+ *    char *token    = NULL;
+ *    while ((token = string_tokenize(str_ptr, ",")))
+ *    {
+ *        printf("%s\n", token);
+ *        free(token);
+ *        token = NULL;
+ *    }
+ **/
+char* string_tokenize(char **str, const char *delim)
+{
+   /* Taken from https://codereview.stackexchange.com/questions/216956/strtok-function-thread-safe-supports-empty-tokens-doesnt-change-string# */
+   char *str_ptr    = NULL;
+   char *delim_ptr  = NULL;
+   char *token      = NULL;
+   size_t _len      = 0;
+   size_t delim_len = 0;
+
+   /* Sanity checks */
+   if (!str || string_is_empty(delim))
+      return NULL;
+
+   /* Note: we don't check string_is_empty() here,
+    * empty strings are valid */
+   if (!(str_ptr = *str))
+      return NULL;
+
+   delim_len = strlen(delim);
+
+   /* Search for delimiter */
+   if ((delim_ptr = strstr(str_ptr, delim)))
+      _len = delim_ptr - str_ptr;
+   else
+      _len = strlen(str_ptr);
+
+   /* Allocate token string */
+   if (!(token = (char *)malloc((_len + 1) * sizeof(char))))
+      return NULL;
+
+   /* Copy token */
+   strlcpy(token, str_ptr, (_len + 1) * sizeof(char));
+   token[_len] = '\0';
+   /* Update input string pointer */
+   *str = delim_ptr ? delim_ptr + delim_len : NULL;
+   return token;
+}
+
+/**
+ * string_remove_all_chars:
+ * @s                 : input string (must be non-NULL, otherwise UB)
+ *
+ * Leaf function.
+ *
+ * Removes every instance of character @c from @s
+ **/
+void string_remove_all_chars(char *s, char c)
+{
+   char *read_ptr  = s;
+   char *write_ptr = s;
+
+   while (*read_ptr != '\0')
+   {
+      /* Only write if the character is not the one to remove */
+      if (*read_ptr != c)
+         *write_ptr++ = *read_ptr;
+      read_ptr++;
+   }
+
+   *write_ptr = '\0';
+}
+
+/**
+ * string_replace_all_chars:
+ * @s                  : input string (must be non-NULL, otherwise UB)
+ * @find               : character to find
+ * @replace            : character to replace @find with
+ *
+ * Replaces every instance of character @find in @s
+ * with character @replace
+ **/
+void string_replace_all_chars(char *s, char find, char replace)
+{
+   char *str_ptr = s;
+   while ((str_ptr = strchr(str_ptr, find)))
+      *str_ptr++ = replace;
+}
+
+/**
+ * string_to_unsigned:
+ * @str                : input string
+ *
+ * Converts string to unsigned integer.
+ *
+ * @return 0 if string is invalid, otherwise > 0
+ **/
+unsigned string_to_unsigned(const char *str)
+{
+   const char *ptr = NULL;
+
+   if (string_is_empty(str))
+      return 0;
+
+   for (ptr = str; *ptr != '\0'; ptr++)
+   {
+      if (!ISDIGIT((unsigned char)*ptr))
+         return 0;
+   }
+
+   return (unsigned)strtoul(str, NULL, 10);
+}
+
+/**
+ * string_hex_to_unsigned:
+ * @str                : input string (must be non-NULL, otherwise UB)
+ *
+ * Converts hexadecimal string to unsigned integer.
+ * Handles optional leading '0x'.
+ *
+ * @return 0 if string is invalid, otherwise > 0
+ **/
+unsigned string_hex_to_unsigned(const char *str)
+{
+   const char *hex_str = str;
+   const char *ptr     = NULL;
+
+   if (string_is_empty(str))
+      return 0;
+
+   /* Remove leading '0x', if present */
+   if (   str[0] == '0'
+       && (str[1] == 'x' || str[1] == 'X'))
+   {
+      hex_str = str + 2;
+      if (string_is_empty(hex_str))
+         return 0;
+   }
+
+   /* Check for valid characters */
+   for (ptr = hex_str; *ptr != '\0'; ptr++)
+   {
+      if (!isxdigit((unsigned char)*ptr))
+         return 0;
+   }
+
+   return (unsigned)strtoul(hex_str, NULL, 16);
+}
+
+/**
+ * string_count_occurrences_single_character:
+ *
+ * Leaf function.
+ *
+ * Get the total number of occurrences of character @c in @str.
+ *
+ * @return Total number of occurrences of character @c
+ */
+int string_count_occurrences_single_character(const char *str, char c)
+{
+   int count = 0;
+
+   for (; *str; str++)
+      if (*str == c)
+         count++;
+
+   return count;
+}
+
+/**
+ * string_replace_whitespace_with_single_character:
+ *
+ * Leaf function.
+ *
+ * Replaces all spaces with given character @c.
+ **/
+/* FIX: Added unsigned char cast to ISSPACE argument for
+ * correct behaviour with high-byte / signed char inputs. */
+void string_replace_whitespace_with_single_character(char *s, char c)
+{
+   for (; *s; s++)
+      if (ISSPACE((unsigned char)*s))
+         *s = c;
+}
+
+/**
+ * string_replace_multi_space_with_single_space:
+ *
+ * Leaf function.
+ *
+ * Replaces multiple spaces with a single space in a string.
+ **/
+/* FIX: Added unsigned char cast to ISSPACE arguments. */
+void string_replace_multi_space_with_single_space(char *s)
+{
+   char *str_trimmed  = s;
+   bool prev_is_space = false;
+   bool curr_is_space = false;
+
+   for (; *s; s++)
+   {
+      curr_is_space  = ISSPACE((unsigned char)*s);
+      if (prev_is_space && curr_is_space)
+         continue;
+      *str_trimmed++ = *s;
+      prev_is_space  = curr_is_space;
+   }
+   *str_trimmed = '\0';
+}
+
+/**
+ * string_remove_all_whitespace:
+ *
+ * Leaf function.
+ *
+ * Remove all spaces from the given string.
+ **/
+/* FIX: Added unsigned char cast to ISSPACE argument. */
+void string_remove_all_whitespace(char *s, const char *str)
+{
+   for (; *str; str++)
+      if (!ISSPACE((unsigned char)*str))
+         *s++ = *str;
+   *s = '\0';
+}
+
+/**
+ * Retrieve the last occurrence of the given character in a string.
+ */
+int string_index_last_occurance(const char *str, char c)
+{
+   const char *pos = strrchr(str, c);
+   if (pos)
+      return (int)(pos - str);
+   return -1;
+}
+
+/**
+ * string_find_index_substring_string:
+ * @str                : input string (must be non-NULL, otherwise UB)
+ * @substr             : substring to find in @str
+ *
+ * Find the position of substring @substr in string @str.
+ **/
+int string_find_index_substring_string(const char *str, const char *substr)
+{
+   const char *pos = strstr(str, substr);
+   if (pos)
+      return (int)(pos - str);
+   return -1;
+}
+
+/**
+ * string_copy_only_ascii:
+ *
+ * Leaf function.
+ *
+ * Strips non-ASCII characters from a string.
+ **/
+void string_copy_only_ascii(char *s, const char *str)
+{
+   for (; *str; str++)
+      if (*str > 0x1F && *str < 0x7F)
+         *s++ = *str;
+   *s = '\0';
 }

--- a/core/deps/libretro-common/time/rtime.c
+++ b/core/deps/libretro-common/time/rtime.c
@@ -1,0 +1,78 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (rtime.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifdef HAVE_THREADS
+#include <rthreads/rthreads.h>
+#include <stdlib.h>
+#endif
+
+#include <string.h>
+#include <time/rtime.h>
+
+#ifdef HAVE_THREADS
+/* TODO/FIXME - global */
+slock_t *rtime_localtime_lock = NULL;
+#endif
+
+/* Must be called before using rtime_localtime() */
+void rtime_init(void)
+{
+   rtime_deinit();
+#ifdef HAVE_THREADS
+   if (!rtime_localtime_lock)
+      rtime_localtime_lock = slock_new();
+#endif
+}
+
+/* Must be called upon program termination */
+void rtime_deinit(void)
+{
+#ifdef HAVE_THREADS
+   if (rtime_localtime_lock)
+   {
+      slock_free(rtime_localtime_lock);
+      rtime_localtime_lock = NULL;
+   }
+#endif
+}
+
+/* Thread-safe wrapper for localtime() */
+struct tm *rtime_localtime(const time_t *timep, struct tm *result)
+{
+   struct tm *time_info = NULL;
+
+   /* Lock mutex */
+#ifdef HAVE_THREADS
+   slock_lock(rtime_localtime_lock);
+#endif
+
+   time_info = localtime(timep);
+   if (time_info)
+      memcpy(result, time_info, sizeof(struct tm));
+
+   /* Unlock mutex */
+#ifdef HAVE_THREADS
+   slock_unlock(rtime_localtime_lock);
+#endif
+
+   return result;
+}

--- a/core/hw/flashrom/flashrom.cpp
+++ b/core/hw/flashrom/flashrom.cpp
@@ -21,11 +21,11 @@
 
 bool MemChip::Load(const std::string& file)
 {
-	FILE *f = hostfs::storage().openFile(file, "rb");
+	hostfs::File *f = hostfs::storage().openFile(file, "rb");
 	if (f)
 	{
-		bool rv = std::fread(data + write_protect_size, 1, size - write_protect_size, f) == size - write_protect_size;
-		std::fclose(f);
+		bool rv = f->read(data + write_protect_size, 1, size - write_protect_size) == size - write_protect_size;
+		delete f;
 		if (rv)
 			this->load_filename = file;
 

--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -435,16 +435,16 @@ struct maple_sega_vmu: maple_base
 
         // Load existing vmu file if found
         std::string rpath = hostfs::getVmuPath(logical_port, false);
-		// this might be a storage url
-		FILE *rfile = hostfs::storage().openFile(rpath, "rb");
+        // this might be a storage url
+        hostfs::File *rfile = hostfs::storage().openFile(rpath, "rb");
         if (rfile == nullptr) {
             INFO_LOG(MAPLE, "Unable to open VMU file \"%s\", creating new file", rpath.c_str());
         }
         else
         {
-            if (std::fread(flash_data, sizeof(flash_data), 1, rfile) != 1)
+            if (rfile->read(flash_data, sizeof(flash_data), 1) != 1)
                 WARN_LOG(MAPLE, "Failed to read the VMU file \"%s\" from disk", rpath.c_str());
-            std::fclose(rfile);
+            delete rfile;
         }
         // Open or create the vmu file to save to
         std::string wpath = hostfs::getVmuPath(logical_port, true);

--- a/core/hw/naomi/naomi_cart.cpp
+++ b/core/hw/naomi/naomi_cart.cpp
@@ -495,16 +495,16 @@ static void loadDecryptedRom(const std::string& path, const std::string& fileNam
 	if (extension == "lst")
 	{
 		// LST file
-		FILE *fl = hostfs::storage().openFile(path, "r");
+		hostfs::File *fl = hostfs::storage().openFile(path, "r");
 		if (!fl)
 			throw FlycastException(strprintf(T("Error: can't open %s"), path.c_str()));
 		folder = hostfs::storage().getParentPath(path);
 
 		char t[512];
-		char* line = std::fgets(t, sizeof(t), fl);
+		char* line = fl->gets(t, sizeof(t));
 		if (!line)
 		{
-			std::fclose(fl);
+			delete fl;
 			throw FlycastException(Ts("Error: Invalid LST file"));
 		}
 
@@ -517,10 +517,10 @@ static void loadDecryptedRom(const std::string& path, const std::string& fileNam
 			DEBUG_LOG(NAOMI, "+Loading naomi rom : %s", line);
 		}
 
-		line = std::fgets(t, sizeof(t), fl);
+		line = fl->gets(t, sizeof(t));
 		if (!line)
 		{
-			std::fclose(fl);
+			delete fl;
 			throw FlycastException(Ts("Error: Invalid LST file"));
 		}
 
@@ -538,20 +538,20 @@ static void loadDecryptedRom(const std::string& path, const std::string& fileNam
 			else if (line[0] != 0 && line[0] != '\n' && line[0] != '\r')
 				WARN_LOG(NAOMI, "Warning: invalid line in .lst file: %s", line);
 
-			line = std::fgets(t, sizeof(t), fl);
+			line = fl->gets(t, sizeof(t));
 		}
-		std::fclose(fl);
+		delete fl;
 	}
 	else
 	{
 		// BIN loading
-		FILE* fp = hostfs::storage().openFile(path, "rb");
+		hostfs::File* fp = hostfs::storage().openFile(path, "rb");
 		if (fp == nullptr)
 			throw FlycastException(strprintf(T("Error: can't open %s"), path.c_str()));
 
-		std::fseek(fp, 0, SEEK_END);
-		u32 file_size = (u32)std::ftell(fp);
-		std::fclose(fp);
+		fp->seek(0, SEEK_END);
+		u32 file_size = (u32)fp->tell();
+		delete fp;
 		files.emplace_back(path);
 		fstart.push_back(0);
 		fsize.push_back(file_size);
@@ -573,7 +573,7 @@ static void loadDecryptedRom(const std::string& path, const std::string& fileNam
 
 	for (size_t i = 0; i<files.size(); i++)
 	{
-		FILE *fp = nullptr;
+		hostfs::File *fp = nullptr;
 
 		if (files[i] != "null")
 		{
@@ -601,10 +601,10 @@ static void loadDecryptedRom(const std::string& path, const std::string& fileNam
 		else
 		{
 			//printf("-Mapping \"%s\" at 0x%08X, size 0x%08X\n", files[i].c_str(), fstart[i], fsize[i]);
-			bool mapped = fread(romDest, 1, fsize[i], fp) == fsize[i];
+			bool mapped = fp->read(romDest, 1, fsize[i]) == fsize[i];
 			if (config::GGPOEnable)
 				md5.add(fp);
-			fclose(fp);
+			delete fp;
 			if (!mapped)
 			{
 				ERROR_LOG(NAOMI, "Unable to read file %s @ %08x size %x", files[i].c_str(),

--- a/core/hw/naomi/systemsp.cpp
+++ b/core/hw/naomi/systemsp.cpp
@@ -1925,7 +1925,7 @@ SystemSpCart::~SystemSpCart()
 
 chd_file *SystemSpCart::openChd(const std::string path)
 {
-	FILE *chdFile = hostfs::storage().openFile(path, "rb");
+	hostfs::File *chdFile = hostfs::storage().openFile(path, "rb");
 	if (chdFile == nullptr)
 	{
 		WARN_LOG(NAOMI, "Cannot open file '%s' errno %d", path.c_str(), errno);
@@ -1938,7 +1938,7 @@ chd_file *SystemSpCart::openChd(const std::string path)
 	if (err != CHDERR_NONE)
 	{
 		WARN_LOG(NAOMI, "Invalid CHD file %s", path.c_str());
-		fclose(chdFile);
+		delete chdFile;
 		return nullptr;
 	}
 	INFO_LOG(NAOMI, "compact flash: parsing file %s", path.c_str());

--- a/core/hw/naomi/systemsp.cpp
+++ b/core/hw/naomi/systemsp.cpp
@@ -1919,28 +1919,26 @@ SystemSpCart::~SystemSpCart()
 	EventManager::unlisten(Event::Pause, handleEvent, this);
 	if (chd != nullptr)
 		chd_close(chd);
-	if (chdFile != nullptr)
-		fclose(chdFile);
 	sh4_sched_unregister(schedId);
 	Instance = nullptr;
 }
 
 chd_file *SystemSpCart::openChd(const std::string path)
 {
-	chdFile = hostfs::storage().openFile(path, "rb");
+	FILE *chdFile = hostfs::storage().openFile(path, "rb");
 	if (chdFile == nullptr)
 	{
 		WARN_LOG(NAOMI, "Cannot open file '%s' errno %d", path.c_str(), errno);
 		return nullptr;
 	}
+
 	chd_file *chd;
-	chd_error err = chd_open_file(chdFile, CHD_OPEN_READ, 0, &chd);
+	chd_error err = chd_open_file(chdFile, CHD_OPEN_READ, nullptr, &chd);
 
 	if (err != CHDERR_NONE)
 	{
 		WARN_LOG(NAOMI, "Invalid CHD file %s", path.c_str());
 		fclose(chdFile);
-		chdFile = nullptr;
 		return nullptr;
 	}
 	INFO_LOG(NAOMI, "compact flash: parsing file %s", path.c_str());

--- a/core/hw/naomi/systemsp.h
+++ b/core/hw/naomi/systemsp.h
@@ -18,6 +18,7 @@
  */
 #pragma once
 #include "types.h"
+#include "chd.h"
 #include "emulator.h"
 #include "hw/hwreg.h"
 #include "hw/naomi/m4cartridge.h"
@@ -25,7 +26,6 @@
 #include "serialize.h"
 #include "network/net_platform.h"
 #include <memory>
-#include <libchdr/chd.h>
 
 namespace systemsp
 {
@@ -210,7 +210,6 @@ private:
 	int schedId;
 	const char *mediaName = nullptr;
 	const char *parentName = nullptr;
-	FILE *chdFile = nullptr;
 	chd_file *chd = nullptr;
 	u32 hunkbytes = 0;
 	std::unique_ptr<u8[]> hunkmem;

--- a/core/imgread/cdi.cpp
+++ b/core/imgread/cdi.cpp
@@ -9,7 +9,7 @@ Disc* cdi_parse(const char* file, std::vector<u8> *digest)
 	if (get_file_extension(file) != "cdi")
 		return nullptr;
 
-	FILE *fsource = hostfs::storage().openFile(file, "rb");
+	hostfs::File *fsource = hostfs::storage().openFile(file, "rb");
 
 	if (fsource == nullptr)
 	{
@@ -49,7 +49,7 @@ Disc* cdi_parse(const char* file, std::vector<u8> *digest)
 				throw FlycastException(i18n::Ts("Invalid CDI image"));
 			}
 
-			image.header_position = std::ftell(fsource);
+			image.header_position = fsource->tell();
 
 			if (image.tracks == 0)
 				INFO_LOG(GDROM, "Open session");
@@ -78,7 +78,7 @@ Disc* cdi_parse(const char* file, std::vector<u8> *digest)
 						throw FlycastException(i18n::Ts("Invalid CDI sector size"));
 					}
 
-					image.header_position = std::ftell(fsource);
+					image.header_position = fsource->tell();
 
 					// Show info
 #if 0
@@ -120,7 +120,7 @@ Disc* cdi_parse(const char* file, std::vector<u8> *digest)
 					t.CTRL=track.mode==0?0:4;
 					t.StartFAD=track.start_lba+track.pregap_length;
 					t.EndFAD=t.StartFAD+track.length-1;
-					FILE *trackFile = hostfs::storage().openFile(file, "rb");
+					hostfs::File *trackFile = hostfs::storage().openFile(file, "rb");
 					if (trackFile == nullptr) {
 						WARN_LOG(GDROM, "Cannot re-open file '%s' errno %d", file, errno);
 						throw FlycastException(i18n::Ts("Cannot re-open CDI file"));
@@ -132,21 +132,21 @@ Disc* cdi_parse(const char* file, std::vector<u8> *digest)
 					if (track.length < 0)
 						WARN_LOG(GDROM, "Negative track size found. You must extract image with /pregap option");
 
-					std::fseek(fsource, track.position, SEEK_SET);
+					fsource->seek(track.position, SEEK_SET);
 					if (track.total_length < track.length + track.pregap_length)
 					{
 						WARN_LOG(GDROM, "This track seems truncated. Skipping...");
 						// FIXME that can't be right
-						std::fseek(fsource, track.total_length, SEEK_CUR);
+						fsource->seek(track.total_length, SEEK_CUR);
 					}
 					else
 					{
-						std::fseek(fsource, track.total_length * track.sector_size, SEEK_CUR);
+						fsource->seek(track.total_length * track.sector_size, SEEK_CUR);
 						rv->EndFAD = track.start_lba + track.total_length - 1;
 					}
-					track.position = std::ftell(fsource);
+					track.position = fsource->tell();
 
-					std::fseek(fsource, image.header_position, SEEK_SET);
+					fsource->seek(image.header_position, SEEK_SET);
 
 					image.remaining_tracks--;
 				}
@@ -158,7 +158,7 @@ Disc* cdi_parse(const char* file, std::vector<u8> *digest)
 		}
 		if (digest != nullptr)
 			*digest = MD5Sum().add(fsource).getDigest();
-		std::fclose(fsource);
+		delete fsource;
 
 		rv->type=GuessDiscType(CD_M1,CD_M2,CD_DA);
 
@@ -168,7 +168,7 @@ Disc* cdi_parse(const char* file, std::vector<u8> *digest)
 
 		return rv.release();
 	} catch (...) {
-		std::fclose(fsource);
+		delete fsource;
 		throw;
 	}
 }

--- a/core/imgread/chd.cpp
+++ b/core/imgread/chd.cpp
@@ -2,7 +2,7 @@
 #include "stdclass.h"
 #include "oslib/storage.h"
 #include "oslib/i18n.h"
-#include <libchdr/chd.h>
+#include "chd.h"
 
 struct CHDDisc : Disc
 {
@@ -12,7 +12,6 @@ struct CHDDisc : Disc
 	static constexpr u32 SESSION_GAP = 11400;
 
 	chd_file *chd = nullptr;
-	FILE *fp = nullptr;
 	u8* hunk_mem = nullptr;
 	u32 old_hunk = 0;
 
@@ -27,8 +26,6 @@ struct CHDDisc : Disc
 
 		if (chd)
 			chd_close(chd);
-		if (fp)
-			std::fclose(fp);
 	}
 };
 
@@ -111,17 +108,20 @@ static u32 getSectorSize(const std::string& type)
 
 void CHDDisc::tryOpen(const char* file)
 {
-	fp = hostfs::storage().openFile(file, "rb");
+	FILE *fp = hostfs::storage().openFile(file, "rb");
 	if (fp == nullptr)
 	{
 		WARN_LOG(COMMON, "Cannot open file '%s' errno %d", file, errno);
 		throw FlycastException(strprintf(i18n::T("Cannot open CHD file %s"), file));
 	}
 
-	chd_error err = chd_open_file(fp, CHD_OPEN_READ, 0, &chd);
+	chd_error err = chd_open_file(fp, CHD_OPEN_READ, nullptr, &chd);
 
 	if (err != CHDERR_NONE)
+	{
+		std::fclose(fp);
 		throw FlycastException(strprintf(i18n::T("Invalid CHD file %s"), file));
+	}
 
 	INFO_LOG(GDROM, "chd: parsing file %s", file);
 

--- a/core/imgread/chd.cpp
+++ b/core/imgread/chd.cpp
@@ -108,7 +108,7 @@ static u32 getSectorSize(const std::string& type)
 
 void CHDDisc::tryOpen(const char* file)
 {
-	FILE *fp = hostfs::storage().openFile(file, "rb");
+	hostfs::File *fp = hostfs::storage().openFile(file, "rb");
 	if (fp == nullptr)
 	{
 		WARN_LOG(COMMON, "Cannot open file '%s' errno %d", file, errno);
@@ -119,7 +119,7 @@ void CHDDisc::tryOpen(const char* file)
 
 	if (err != CHDERR_NONE)
 	{
-		std::fclose(fp);
+		delete fp;
 		throw FlycastException(strprintf(i18n::T("Invalid CHD file %s"), file));
 	}
 

--- a/core/imgread/common.h
+++ b/core/imgread/common.h
@@ -4,6 +4,7 @@
 
 #include "emulator.h"
 #include "hw/gdrom/gdrom_if.h"
+#include "oslib/storage.h"
 
 /*
 Mode2 Subheader:
@@ -214,11 +215,11 @@ Disc* OpenDisc(const std::string& path, std::vector<u8> *digest = nullptr);
 
 struct RawTrackFile : TrackFile
 {
-	FILE *file;
+	hostfs::File *file;
 	s32 offset;
 	u32 fmt;
 
-	RawTrackFile(FILE *file, u32 file_offs, u32 first_fad, u32 secfmt)
+	RawTrackFile(hostfs::File *file, u32 file_offs, u32 first_fad, u32 secfmt)
 	{
 		verify(file != nullptr);
 		this->file = file;
@@ -243,8 +244,8 @@ struct RawTrackFile : TrackFile
 			return false;
 		}
 
-		std::fseek(file, offset + FAD * fmt, SEEK_SET);
-		if (std::fread(dst, 1, fmt, file) != fmt)
+		file->seek(offset + FAD * fmt, SEEK_SET);
+		if (file->read(dst, 1, fmt) != fmt)
 		{
 			WARN_LOG(GDROM, "Failed or truncated GD-Rom read");
 			return false;
@@ -254,7 +255,7 @@ struct RawTrackFile : TrackFile
 
 	~RawTrackFile() override
 	{
-		std::fclose(file);
+		delete file;
 	}
 };
 

--- a/core/imgread/cue.cpp
+++ b/core/imgread/cue.cpp
@@ -49,7 +49,7 @@ Disc* cue_parse(const char* file, std::vector<u8> *digest)
 	if (get_file_extension(file) != "cue")
 		return nullptr;
 
-	FILE *fsource = hostfs::storage().openFile(file, "rb");
+	hostfs::File *fsource = hostfs::storage().openFile(file, "rb");
 
 	if (fsource == nullptr)
 	{
@@ -64,13 +64,13 @@ Disc* cue_parse(const char* file, std::vector<u8> *digest)
 
 	if (cue_len >= sizeof(cue_data))
 	{
-		std::fclose(fsource);
+		delete fsource;
 		throw FlycastException(i18n::Ts("CUE parse error: CUE file too big"));
 	}
 
-	if (std::fread(cue_data, 1, cue_len, fsource) != cue_len)
+	if (fsource->read(cue_data, 1, cue_len) != cue_len)
 		WARN_LOG(GDROM, "Failed or truncated read of cue file '%s'", file);
-	std::fclose(fsource);
+	delete fsource;
 
 	std::istringstream istream(cue_data);
 	istream.imbue(std::locale::classic());
@@ -179,12 +179,12 @@ Disc* cue_parse(const char* file, std::vector<u8> *digest)
 				throw FlycastException(i18n::T("Invalid CUE file"));
 			}
 			track_filename = hostfs::storage().getSubPath(basepath, track_filename);
-			FILE *track_file = hostfs::storage().openFile(track_filename, "rb");
+			hostfs::File *track_file = hostfs::storage().openFile(track_filename, "rb");
 			if (track_file == nullptr)
 				throw FlycastException(strprintf(i18n::T("CUE file: cannot open track %s"), track_filename.c_str()));
 			if (digest != nullptr)
 				md5.add(track_file);
-			std::fclose(track_file);
+			delete track_file;
 			fileInfo = hostfs::storage().getFileInfo(track_filename);
 			fileStartFAD = currentFAD;
 			// Clear track context
@@ -234,7 +234,7 @@ Disc* cue_parse(const char* file, std::vector<u8> *digest)
 				t.isrc = track_isrc;
 				DEBUG_LOG(GDROM, "file[%zd] \"%s\": session %d type %s FAD:%d -> %d %s", disc->tracks.size() + 1, track_filename.c_str(),
 						session_number, track_type.c_str(), t.StartFAD, t.EndFAD, t.isrc.empty() ? "" : ("ISRC " + t.isrc).c_str());
-				FILE *track_file = hostfs::storage().openFile(track_filename, "rb");
+				hostfs::File *track_file = hostfs::storage().openFile(track_filename, "rb");
 				t.file = new RawTrackFile(track_file, indexFAD * track_secsize, t.StartFAD, track_secsize);
 				disc->tracks.push_back(t);
 				if (disc->tracks.size() >= 2) {

--- a/core/imgread/gdi.cpp
+++ b/core/imgread/gdi.cpp
@@ -6,7 +6,7 @@
 
 static Disc* load_gdi(const char* file, std::vector<u8> *digest)
 {
-	FILE *t = hostfs::storage().openFile(file, "rb");
+	hostfs::File *t = hostfs::storage().openFile(file, "rb");
 	if (t == nullptr)
 	{
 		WARN_LOG(COMMON, "Cannot open file '%s' errno %d", file, errno);
@@ -20,13 +20,13 @@ static Disc* load_gdi(const char* file, std::vector<u8> *digest)
 
 	if (gdi_len >= sizeof(gdi_data))
 	{
-		std::fclose(t);
+		delete t;
 		throw FlycastException(i18n::Ts("GDI file too big"));
 	}
 
-	if (std::fread(gdi_data, 1, gdi_len, t) != gdi_len)
+	if (t->read(gdi_data, 1, gdi_len) != gdi_len)
 		WARN_LOG(GDROM, "Failed or truncated read of gdi file '%s'", file);
-	std::fclose(t);
+	delete t;
 
 	std::istringstream gdi(gdi_data);
 	gdi.imbue(std::locale::classic());
@@ -127,7 +127,7 @@ static Disc* load_gdi(const char* file, std::vector<u8> *digest)
 		t.CTRL = CTRL;
 
 		std::string path = hostfs::storage().getSubPath(basepath, track_filename);
-		FILE *file = hostfs::storage().openFile(path, "rb");
+		hostfs::File *file = hostfs::storage().openFile(path, "rb");
 		if (file == nullptr)
 			throw FlycastException(strprintf(i18n::T("GDI file: Cannot open track %s"), path.c_str()));
 		if (digest != nullptr)

--- a/core/input/mapping.cpp
+++ b/core/input/mapping.cpp
@@ -441,7 +441,7 @@ static DreamcastKey getKeyId(const std::string& name)
 	return EMU_BTN_NONE;
 }
 
-void InputMapping::load(FILE* fp)
+void InputMapping::load(hostfs::File* fp)
 {
 	IniFile mf;
 	mf.load(fp);
@@ -833,7 +833,7 @@ std::shared_ptr<InputMapping> InputMapping::LoadMapping(const std::string& name)
 		return it->second;
 
 	std::string path;
-	FILE *fp = nullptr;
+	hostfs::File *fp = nullptr;
 	// Try user-defined mapping folders first
 	for (const auto& base : config::MappingsPath.get())
 	{
@@ -857,37 +857,37 @@ std::shared_ptr<InputMapping> InputMapping::LoadMapping(const std::string& name)
 	if (fp == nullptr)
 	{
 		path = get_readonly_config_path(std::string("mappings/") + name);
-		fp = nowide::fopen(path.c_str(), "r");
+		fp = hostfs::storage().openFile(path.c_str(), "r");
 		if (fp == NULL)
 			return NULL;
 	}
 	std::shared_ptr<InputMapping> mapping = std::make_shared<InputMapping>();
 	mapping->load(fp);
-	std::fclose(fp);
+	delete fp;
 	loaded_mappings[name] = mapping;
 
 	if (mapping->is_dirty())
 	{
 		// Make a backup of the current mapping file
-		FILE *out = nowide::fopen((path + ".save").c_str(), "w");
+		hostfs::File *out = hostfs::storage().openFile((path + ".save").c_str(), "w");
 		if (out == nullptr)
 			WARN_LOG(INPUT, "Can't backup controller mapping file %s", path.c_str());
 		else
 		{
-			fp = nowide::fopen(path.c_str(), "r");
+			fp = hostfs::storage().openFile(path.c_str(), "r");
 			if (fp != nullptr)
 			{
 				u8 buf[4096];
 				while (true)
 				{
-					size_t n = fread(buf, 1, sizeof(buf), fp);
+					size_t n = fp->read(buf, 1, sizeof(buf));
 					if (n <= 0)
 						break;
-					fwrite(buf, 1, n, out);
+					fp->write(buf, 1, n);
 				}
-				std::fclose(fp);
+				delete fp;
 			}
-			std::fclose(out);
+			delete out;
 		}
 	}
 
@@ -931,7 +931,7 @@ bool InputMapping::save(const std::string& name)
 		make_directory(base);
 		path = get_writable_config_path(std::string("mappings/") + name);
 	}
-	FILE *fp = nowide::fopen(path.c_str(), "w");
+	hostfs::File *fp = hostfs::storage().openFile(path.c_str(), "w");
 	if (fp == NULL)
 	{
 		WARN_LOG(INPUT, "Cannot save controller mappings into %s", path.c_str());
@@ -1029,7 +1029,7 @@ bool InputMapping::save(const std::string& name)
 	mf.set("emulator", "triggers", triggerString);
 	mf.save(fp);
 	dirty = false;
-	std::fclose(fp);
+	delete fp;
 
 	return true;
 }

--- a/core/input/mapping.h
+++ b/core/input/mapping.h
@@ -20,6 +20,7 @@
 
 #include "types.h"
 #include "gamepad.h"
+#include "oslib/storage.h"
 
 #include <map>
 #include <memory>
@@ -249,7 +250,7 @@ public:
 		return triggers;
 	}
 
-	void load(FILE* fp);
+	void load(hostfs::File* fp);
 	bool save(const std::string& name);
 
 	void set_dirty();

--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -199,21 +199,21 @@ void dc_savestate(int index, const u8 *pngData, u32 pngSize)
 	ser = Serializer(data, ser.size());
 	dc_serialize(ser);
 
-	FILE *f = nullptr;
+	hostfs::File *f = nullptr;
 	std::string filename = "";
 #ifdef HAS_FMEMOPEN
 	if (index == -2)
 	{
 		// in-ram savestate
 		filename = "RAM";
-		f = fmemopen(quicksave_buf, QUICKSAVE_DEFAULT_SIZE, "wb");
+		f = new hostfs::StdFile(fmemopen(quicksave_buf, QUICKSAVE_DEFAULT_SIZE, "wb"));
 	}
 	else
 #endif
 	{
 		// regular file savestate
 		filename = hostfs::getSavestatePath(index, true);
-		f = nowide::fopen(filename.c_str(), "wb");
+		f = hostfs::storage().openFile(filename.c_str(), "wb");
 	}
 	
 	if (f == nullptr)
@@ -228,15 +228,15 @@ void dc_savestate(int index, const u8 *pngData, u32 pngSize)
 	SavestateHeader header;
 	header.init();
 	header.pngSize = pngSize;
-	if (std::fwrite(&header, sizeof(header), 1, f) != 1)
+	if (f->write(&header, sizeof(header), 1) != 1)
 		goto fail;
-	if (pngSize > 0 && std::fwrite(pngData, 1, pngSize, f) != pngSize)
+	if (pngSize > 0 && f->write(pngData, 1, pngSize) != pngSize)
 		goto fail;
 
 #if 0
 	// Uncompressed savestate
-	std::fwrite(data, 1, ser.size(), f);
-	std::fclose(f);
+	f->write(data, 1, ser.size());
+	delete f;
 #else
 	if (!zipFile.Open(f, true))
 		goto fail;
@@ -256,7 +256,7 @@ fail:
 	if (zipFile.rawFile() != nullptr)
 		zipFile.Close();
 	else
-		std::fclose(f);
+		delete f;
 	free(data);
 	// delete failed savestate?
 }
@@ -267,14 +267,14 @@ void dc_loadstate(int index)
 		return;
 	u32 total_size = 0;
 
-	FILE *f = nullptr;
+	hostfs::File *f = nullptr;
 	std::string filename = "";
 #ifdef HAS_FMEMOPEN
 	if (index == -2)
 	{
 		// in-ram savestate
 		filename = "RAM";
-		f = fmemopen(quicksave_buf, QUICKSAVE_DEFAULT_SIZE, "rb");
+		f = new hostfs::StdFile(fmemopen(quicksave_buf, QUICKSAVE_DEFAULT_SIZE, "rb"));
 	}
 	else
 #endif
@@ -291,26 +291,26 @@ void dc_loadstate(int index)
 		return;
 	}
 	SavestateHeader header;
-	if (std::fread(&header, sizeof(header), 1, f) == 1)
+	if (f->read(&header, sizeof(header), 1) == 1)
 	{
 		if (!header.isValid())
 			// seek to beginning of file if this isn't a valid header (legacy savestate)
-			std::fseek(f, 0, SEEK_SET);
+			f->seek(0, SEEK_SET);
 		else
 			// skip png data
-			std::fseek(f, header.pngSize, SEEK_CUR);
+			f->seek(header.pngSize, SEEK_CUR);
 	}
 	else {
 		// probably not a valid savestate but we'll fail later
-		std::fseek(f, 0, SEEK_SET);
+		f->seek(0, SEEK_SET);
 	}
 
 	if (index == -1 && config::GGPOEnable)
 	{
-		long pos = std::ftell(f);
+		long pos = f->tell();
 		MD5Sum().add(f)
 				.getDigest(settings.network.md5.savestate);
-		std::fseek(f, pos, SEEK_SET);
+		f->seek(pos, SEEK_SET);
 	}
 	RZipFile zipFile;
 	if (zipFile.Open(f, false)) {
@@ -318,10 +318,10 @@ void dc_loadstate(int index)
 	}
 	else
 	{
-		long pos = std::ftell(f);
-		std::fseek(f, 0, SEEK_END);
-		total_size = (u32)std::ftell(f) - pos;
-		std::fseek(f, pos, SEEK_SET);
+		long pos = f->tell();
+		f->seek(0, SEEK_END);
+		total_size = (u32)f->tell() - pos;
+		f->seek(pos, SEEK_SET);
 	}
 	void *data = malloc(total_size);
 	if (data == nullptr)
@@ -329,7 +329,7 @@ void dc_loadstate(int index)
 		WARN_LOG(SAVESTATE, "Failed to load state - could not malloc %d bytes", total_size);
 		os_notify(i18n::T("Failed to load state"), 5000, i18n::T("Not enough memory"));
 		if (zipFile.rawFile() == nullptr)
-			std::fclose(f);
+			delete f;
 		else
 			zipFile.Close();
 		return;
@@ -343,8 +343,8 @@ void dc_loadstate(int index)
 	}
 	else
 	{
-		read_size = std::fread(data, 1, total_size, f);
-		std::fclose(f);
+		read_size = f->read(data, 1, total_size);
+		delete f;
 	}
 	if (read_size != total_size)
 	{
@@ -375,15 +375,15 @@ time_t dc_getStateCreationDate(int index)
 	if (filename != lastStateFile)
 	{
 		lastStateFile = filename;
-		FILE *f = hostfs::storage().openFile(filename, "rb");
+		hostfs::File *f = hostfs::storage().openFile(filename, "rb");
 		if (f == nullptr)
 			lastStateTime = 0;
 		else
 		{
 			SavestateHeader header;
-			if (std::fread(&header, sizeof(header), 1, f) != 1 || !header.isValid())
+			if (f->read(&header, sizeof(header), 1) != 1 || !header.isValid())
 			{
-				std::fclose(f);
+				delete f;
 				try {
 					hostfs::FileInfo fileInfo = hostfs::storage().getFileInfo(filename);
 					lastStateTime = fileInfo.updateTime;
@@ -392,7 +392,7 @@ time_t dc_getStateCreationDate(int index)
 				}
 			}
 			else {
-				std::fclose(f);
+				delete f;
 				lastStateTime = (time_t)header.creationDate;
 			}
 		}
@@ -404,17 +404,17 @@ void dc_getStateScreenshot(int index, std::vector<u8>& pngData)
 {
 	pngData.clear();
 	std::string filename = hostfs::getSavestatePath(index, false);
-	FILE *f = hostfs::storage().openFile(filename, "rb");
+	hostfs::File *f = hostfs::storage().openFile(filename, "rb");
 	if (f == nullptr)
 		return;
 	SavestateHeader header;
-	if (std::fread(&header, sizeof(header), 1, f) == 1 && header.isValid() && header.pngSize != 0)
+	if (f->read(&header, sizeof(header), 1) == 1 && header.isValid() && header.pngSize != 0)
 	{
 		pngData.resize(header.pngSize);
-		if (std::fread(pngData.data(), 1, pngData.size(), f) != pngData.size())
+		if (f->read(pngData.data(), 1, pngData.size()) != pngData.size())
 			pngData.clear();
 	}
-	std::fclose(f);
+	delete f;
 }
 
 #endif

--- a/core/oslib/storage.cpp
+++ b/core/oslib/storage.cpp
@@ -28,9 +28,7 @@ std::string os_PrecomposedString(std::string string);
 namespace hostfs
 {
 
-CustomStorage& customStorage();
-
-#if !defined(__ANDROID__) || defined(LIBRETRO)
+#if !defined(__ANDROID__) && !defined(LIBRETRO)
 CustomStorage& customStorage()
 {
 	class NullStorage : public CustomStorage

--- a/core/oslib/storage.cpp
+++ b/core/oslib/storage.cpp
@@ -38,7 +38,7 @@ CustomStorage& customStorage()
 	public:
 		bool isKnownPath(const std::string& path) override { return false; }
 		std::vector<FileInfo> listContent(const std::string& path) override { return std::vector<FileInfo>(); }
-		FILE *openFile(const std::string& path, const std::string& mode) override { die("Not implemented"); }
+		File *openFile(const std::string& path, const std::string& mode) override { die("Not implemented"); }
 		std::string getParentPath(const std::string& path) override { die("Not implemented"); }
 		std::string getSubPath(const std::string& reference, const std::string& relative) override { die("Not implemented"); }
 		FileInfo getFileInfo(const std::string& path) override { die("Not implemented"); }
@@ -156,9 +156,14 @@ public:
 		return entries;
 	}
 
-	FILE *openFile(const std::string& path, const std::string& mode) override
+	File *openFile(const std::string& path, const std::string& mode) override
 	{
-		return nowide::fopen(path.c_str(), mode.c_str());
+		FILE *file = nowide::fopen(path.c_str(), mode.c_str());
+
+		if (file == nullptr)
+			return nullptr;
+
+		return new StdFile(file);
 	}
 
 	std::string getParentPath(const std::string& path) override
@@ -357,7 +362,7 @@ std::vector<FileInfo> AllStorage::listContent(const std::string& path)
 		return stdStorage.listContent(path);
 }
 
-FILE *AllStorage::openFile(const std::string& path, const std::string& mode)
+File *AllStorage::openFile(const std::string& path, const std::string& mode)
 {
 	if (customStorage().isKnownPath(path))
 		return customStorage().openFile(path, mode);

--- a/core/oslib/storage.h
+++ b/core/oslib/storage.h
@@ -257,4 +257,6 @@ private:
 	const std::string& root;
 };
 
+CustomStorage& customStorage();
+
 }	// namespace hostfs

--- a/core/oslib/storage.h
+++ b/core/oslib/storage.h
@@ -41,6 +41,82 @@ struct FileInfo
 	u64 updateTime = 0;
 };
 
+class File
+{
+public:
+	virtual ~File() {}
+
+	virtual size_t read(void* buffer, size_t size, size_t count) = 0;
+	virtual size_t write(const void* buffer, size_t size, size_t count) = 0;
+	virtual s64 tell() = 0;
+	virtual int seek(s64 offset, int whence) = 0;
+	virtual char* gets(char* str, int count) = 0;
+	virtual s64 size() = 0;
+	virtual int eof() = 0;
+	virtual int error() = 0;
+};
+
+class StdFile : public File
+{
+protected:
+	FILE* const file;
+
+public:
+	StdFile(FILE* file)
+		: file(file)
+	{}
+
+	~StdFile() override
+	{
+		std::fclose(file);
+	}
+
+	size_t read(void* buffer, size_t size, size_t count) override
+	{
+		return std::fread(buffer, size, count, file);
+	}
+
+	size_t write(const void* buffer, size_t size, size_t count) override
+	{
+		return std::fwrite(buffer, size, count, file);
+	}
+
+	s64 tell() override
+	{
+		return std::ftell(file);
+	}
+
+	int seek(s64 offset, int whence) override
+	{
+		return std::fseek(file, offset, whence);
+	}
+
+	char* gets(char* str, int count) override
+	{
+		return std::fgets(str, count, file);
+	}
+
+	s64 size() override
+	{
+		std::fpos_t position;
+		std::fgetpos(file, &position);
+		std::fseek(file, 0, SEEK_END);
+		s64 size = tell();
+		std::fsetpos(file, &position);
+		return size;
+	}
+
+	int eof() override
+	{
+		return std::feof(file);
+	}
+
+	int error() override
+	{
+		return std::ferror(file);
+	}
+};
+
 class StorageException : public FlycastException
 {
 public:
@@ -52,7 +128,7 @@ class Storage
 public:
 	virtual bool isKnownPath(const std::string& path) = 0;
 	virtual std::vector<FileInfo> listContent(const std::string& path) = 0;
-	virtual FILE *openFile(const std::string& path, const std::string& mode) = 0;
+	virtual File *openFile(const std::string& path, const std::string& mode) = 0;
 	virtual std::string getParentPath(const std::string& path) = 0;
 	virtual std::string getSubPath(const std::string& reference, const std::string& subpath) = 0;
 	virtual FileInfo getFileInfo(const std::string& path) = 0;
@@ -74,7 +150,7 @@ public:
 	bool isKnownPath(const std::string& path) override { return true; }
 
 	std::vector<FileInfo> listContent(const std::string& path) override;
-	FILE *openFile(const std::string& path, const std::string& mode) override;
+	File *openFile(const std::string& path, const std::string& mode) override;
 	std::string getParentPath(const std::string& path) override;
 	std::string getSubPath(const std::string& reference, const std::string& subpath) override;
 	FileInfo getFileInfo(const std::string& path) override;

--- a/core/rend/CustomTexture.cpp
+++ b/core/rend/CustomTexture.cpp
@@ -122,13 +122,13 @@ u8* CustomTextureSource::loadCustomTexture(u32 hash, int& width, int& height)
 	if (it == texture_map.end())
 		return nullptr;
 
-	FILE *file = hostfs::storage().openFile(it->second, "rb");
+	hostfs::File *file = hostfs::storage().openFile(it->second, "rb");
 	if (file == nullptr)
 		return nullptr;
 	int n;
 	stbi_set_flip_vertically_on_load(1);
 	u8 *imgData = stbi_load_from_file(file, &width, &height, &n, STBI_rgb_alpha);
-	std::fclose(file);
+	delete file;
 	return imgData;
 }
 

--- a/core/rend/CustomTexture.cpp
+++ b/core/rend/CustomTexture.cpp
@@ -30,7 +30,7 @@
 #define STB_IMAGE_IMPLEMENTATION
 #define STBI_ONLY_JPEG
 #define STBI_ONLY_PNG
-#include <stb_image.h>
+#include "stbi.h"
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
 

--- a/core/rend/vulkan/adreno.cpp
+++ b/core/rend/vulkan/adreno.cpp
@@ -149,7 +149,7 @@ bool getCustomGpuDriverInfo(std::string& name, std::string& description, std::st
 
 void uploadCustomGpuDriver(const std::string& zipPath)
 {
-	FILE *zipf = hostfs::storage().openFile(zipPath, "r");
+	hostfs::File *zipf = hostfs::storage().openFile(zipPath, "r");
 	if (zipf == nullptr)
 		throw FlycastException(i18n::Ts("Can't open zip file"));
 	ZipArchive archive;

--- a/core/stbi.h
+++ b/core/stbi.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <cstdio>
 #include <utility>
 
 #include <stb_image.h>
+
+#include "oslib/storage.h"
 
 namespace STBI
 {
@@ -11,24 +12,24 @@ namespace STBI
 	inline const stbi_io_callbacks callbacks = {
 		[](void *user, char *data, int size) -> int
 		{
-			auto file = static_cast<std::FILE*>(user);
-			return std::fread(data, 1, size, file);
+			auto file = static_cast<hostfs::File*>(user);
+			return file->read(data, 1, size);
 		},
 		[](void *user, int n)
 		{
-			auto file = static_cast<std::FILE*>(user);
-			std::fseek(file, n, SEEK_CUR);
+			auto file = static_cast<hostfs::File*>(user);
+			file->seek(n, SEEK_CUR);
 		},
 		[](void *user) -> int
 		{
-			auto file = static_cast<std::FILE*>(user);
-			return std::feof(file);
+			auto file = static_cast<hostfs::File*>(user);
+			return file->eof();
 		}
 	};
 }
 
 template <typename... Ts>
-inline auto stbi_load_from_file(std::FILE *file, Ts &&...args)
+inline auto stbi_load_from_file(hostfs::File *file, Ts &&...args)
 {
 	return stbi_load_from_callbacks(&STBI::callbacks, file, std::forward<Ts>(args)...);
 }

--- a/core/stbi.h
+++ b/core/stbi.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdio>
+#include <utility>
+
+#include <stb_image.h>
+
+namespace STBI
+{
+	// Moved out here to avoid being duplicated by the template.
+	inline const stbi_io_callbacks callbacks = {
+		[](void *user, char *data, int size) -> int
+		{
+			auto file = static_cast<std::FILE*>(user);
+			return std::fread(data, 1, size, file);
+		},
+		[](void *user, int n)
+		{
+			auto file = static_cast<std::FILE*>(user);
+			std::fseek(file, n, SEEK_CUR);
+		},
+		[](void *user) -> int
+		{
+			auto file = static_cast<std::FILE*>(user);
+			return std::feof(file);
+		}
+	};
+}
+
+template <typename... Ts>
+inline auto stbi_load_from_file(std::FILE *file, Ts &&...args)
+{
+	return stbi_load_from_callbacks(&STBI::callbacks, file, std::forward<Ts>(args)...);
+}

--- a/core/ui/boxart/scraper.cpp
+++ b/core/ui/boxart/scraper.cpp
@@ -260,14 +260,14 @@ void OfflineScraper::scrape(GameBoxart& item)
 		std::string extension = get_file_extension(item.fileName);
 		if (extension != "zip" && extension != "7z" && extension != "lst")
 		{
-			FILE *file = hostfs::storage().openFile(item.gamePath, "rb");
+			hostfs::File *file = hostfs::storage().openFile(item.gamePath, "rb");
 			if (file != nullptr)
 			{
-				fseek(file, 0x30, SEEK_SET);
+				file->seek(0x30, SEEK_SET);
 				u8 buf[0x20];
-				if (fread(buf, 1, sizeof(buf), file) == sizeof(buf))
+				if (file->read(buf, 1, sizeof(buf)) == sizeof(buf))
 					item.uniqueId = trim_trailing_ws(std::string(&buf[0], &buf[0x20]));
-				fclose(file);
+				delete file;
 			}
 		}
 	}

--- a/core/ui/vgamepad.cpp
+++ b/core/ui/vgamepad.cpp
@@ -35,7 +35,7 @@
 #include "hw/naomi/naomi_cart.h"
 #include "hw/naomi/card_reader.h"
 #include "hw/maple/maple_devs.h"
-#include <stb_image.h>
+#include "stbi.h"
 
 namespace vgamepad
 {
@@ -109,7 +109,7 @@ static bool loadOSDButtons(const std::string& path)
 		return false;
 
 	stbi_set_flip_vertically_on_load(1);
-    int width, height, n;
+	int width, height, n;
 	u8 *image_data = stbi_load_from_file(file, &width, &height, &n, STBI_rgb_alpha);
 	std::fclose(file);
 	if (image_data == nullptr)

--- a/core/ui/vgamepad.cpp
+++ b/core/ui/vgamepad.cpp
@@ -104,14 +104,14 @@ static bool loadOSDButtons(const std::string& path)
 {
 	if (path.empty())
 		return false;
-	FILE *file = hostfs::storage().openFile(path, "rb");
+	hostfs::File *file = hostfs::storage().openFile(path, "rb");
 	if (file == nullptr)
 		return false;
 
 	stbi_set_flip_vertically_on_load(1);
 	int width, height, n;
 	u8 *image_data = stbi_load_from_file(file, &width, &height, &n, STBI_rgb_alpha);
-	std::fclose(file);
+	delete file;
 	if (image_data == nullptr)
 		return false;
     try {

--- a/shell/android-studio/flycast/src/main/jni/src/android_storage.h
+++ b/shell/android-studio/flycast/src/main/jni/src/android_storage.h
@@ -251,7 +251,7 @@ private:
 	void (*addStorageCallback)(bool cancelled, std::string selectedPath);
 };
 
-Storage& customStorage()
+CustomStorage& customStorage()
 {
 	static std::unique_ptr<AndroidStorage> androidStorage;
 	if (!androidStorage)

--- a/shell/android-studio/flycast/src/main/jni/src/android_storage.h
+++ b/shell/android-studio/flycast/src/main/jni/src/android_storage.h
@@ -50,7 +50,7 @@ public:
 		return path.substr(0, 10) == "content://";
 	}
 
-	FILE *openFile(const std::string& uri, const std::string& mode) override
+	File *openFile(const std::string& uri, const std::string& mode) override
 	{
 		jni::String juri(uri);
 		const char *amode;
@@ -75,7 +75,13 @@ public:
 			WARN_LOG(COMMON, "openFile failed: %s", e.what());
 			return nullptr;
 		}
-		return fdopen(fd, mode.c_str());
+
+		FILE *file = fdopen(fd, mode.c_str());
+
+		if (file == nullptr)
+			return nullptr;
+
+		return new StdFile(file);
 	}
 
 	std::vector<FileInfo> listContent(const std::string& uri) override

--- a/shell/libretro/libretro.cpp
+++ b/shell/libretro/libretro.cpp
@@ -67,8 +67,9 @@
 #include "rend/CustomTexture.h"
 #include "oslib/i18n.h"
 #include "input/dreampotato.h"
+#include "storage.h"
 
-constexpr char slash = path_default_slash_c();
+constexpr char slash = PATH_DEFAULT_SLASH_C();
 
 #define RETRO_DEVICE_TWINSTICK				RETRO_DEVICE_SUBCLASS( RETRO_DEVICE_JOYPAD, 1 )
 #define RETRO_DEVICE_TWINSTICK_SATURN		RETRO_DEVICE_SUBCLASS( RETRO_DEVICE_JOYPAD, 2 )
@@ -267,6 +268,8 @@ static void input_set_deadzone_trigger(int percent)
 void retro_set_environment(retro_environment_t cb)
 {
 	environ_cb = cb;
+
+	hostfs::LibretroStorage::initialise(cb);
 
 	// An annoyance: retro_set_environment() can be called
 	// multiple times, and depending upon the current frontend
@@ -2251,7 +2254,7 @@ bool retro_load_game(const struct retro_game_info *game)
 
 		disk_paths.push_back(game->path);
 
-		fill_short_pathname_representation(disk_label, game->path, sizeof(disk_label));
+		fill_pathname(disk_label, path_basename(game->path), "", sizeof(disk_label));
 		disk_labels.push_back(disk_label);
 
 		game_data = game->path;
@@ -3687,7 +3690,7 @@ static bool retro_replace_image_index(unsigned index, const struct retro_game_in
 
 		disk_paths[index] = info->path;
 
-		fill_short_pathname_representation(disk_label, info->path, sizeof(disk_label));
+		fill_pathname(disk_label, path_basename(info->path), "", sizeof(disk_label));
 		disk_labels[index] = disk_label;
 	}
 
@@ -3813,7 +3816,7 @@ static bool read_m3u(const char *file)
 				snprintf(name, sizeof(name), "%s%s", g_roms_dir, line);
 			disk_paths.push_back(name);
 
-			fill_short_pathname_representation(disk_label, name, sizeof(disk_label));
+			fill_pathname(disk_label, path_basename(name), "", sizeof(disk_label));
 			disk_labels.push_back(disk_label);
 
 			disk_index++;

--- a/shell/libretro/oslib.cpp
+++ b/shell/libretro/oslib.cpp
@@ -42,7 +42,7 @@ std::string getVmuPath(const std::string& port, bool save)
 	if ((per_content_vmus == 1 && port == "A1")
 			|| per_content_vmus == 2)
 	{
-		std::string vmuDir = vmu_dir_no_slash + std::string(path_default_slash());
+		std::string vmuDir = vmu_dir_no_slash + std::string(PATH_DEFAULT_SLASH());
 		if (settings.platform.isConsole() && !settings.content.gameId.empty())
 		{
 			constexpr std::string_view INVALID_CHARS { " /\\:*?|<>" };
@@ -64,7 +64,7 @@ std::string getVmuPath(const std::string& port, bool save)
 		return vmuDir + std::string(content_name) + "." + port + ".bin";
 	}
 	else {
-		return std::string(game_dir_no_slash) + std::string(path_default_slash()) + "vmu_save_" + port + ".bin";
+		return std::string(game_dir_no_slash) + std::string(PATH_DEFAULT_SLASH()) + "vmu_save_" + port + ".bin";
 	}
 }
 
@@ -112,13 +112,13 @@ std::string getFlashSavePath(const std::string& prefix, const std::string& name)
 {
    std::string root(game_dir_no_slash);
 
-	return root + path_default_slash() + prefix + name;
+	return root + PATH_DEFAULT_SLASH() + prefix + name;
 }
 
 std::string findNaomiBios(const std::string& name)
 {
 	std::string basepath(game_dir_no_slash);
-	basepath += path_default_slash() + name;
+	basepath += PATH_DEFAULT_SLASH() + name;
 	if (!file_exists(basepath))
 	{
 		// File not found in system dir, try game dir instead
@@ -137,19 +137,19 @@ std::string getSavestatePath(int index, bool writable)
 
 std::string getShaderCachePath(const std::string& filename)
 {
-	return std::string(game_dir_no_slash) + std::string(path_default_slash()) + filename;
+	return std::string(game_dir_no_slash) + std::string(PATH_DEFAULT_SLASH()) + filename;
 }
 
 std::string getTextureLoadPath(const std::string& gameId)
 {
 	return std::string(retro_get_system_directory()) + "/dc/textures/"
-						+ gameId + path_default_slash();
+						+ gameId + PATH_DEFAULT_SLASH();
 }
 
 std::string getTextureDumpPath()
 {
-	return std::string(game_dir_no_slash) + std::string(path_default_slash())
-			+ "texdump" + std::string(path_default_slash());
+	return std::string(game_dir_no_slash) + std::string(PATH_DEFAULT_SLASH())
+			+ "texdump" + std::string(PATH_DEFAULT_SLASH());
 }
 
 std::string getScreenshotsPath()

--- a/shell/libretro/storage.cpp
+++ b/shell/libretro/storage.cpp
@@ -1,0 +1,193 @@
+/*
+    This file is part of Flycast.
+
+    Flycast is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Flycast is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Flycast.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "storage.h"
+
+#include <file/file_path.h>
+
+struct retro_vfs_interface* hostfs::LibretroStorage::vfs_interface = nullptr;
+
+bool hostfs::LibretroStorage::isFileWriteable(const std::string& path)
+{
+	// Not ideal; would be nicer if the VFS API gave us a direct way of checking this.
+	RFILE* file = filestream_open(path.c_str(), RETRO_VFS_FILE_ACCESS_WRITE | RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING, RETRO_VFS_FILE_ACCESS_HINT_NONE);
+
+	if (file == nullptr)
+		return false;
+
+	filestream_close(file);
+	return true;
+}
+
+hostfs::FileInfo hostfs::LibretroStorage::makeFileInfo(std::string name, std::string path)
+{
+	const bool is_directory = path_is_directory(path.c_str());
+	const size_t size = path_get_size(path.c_str());
+	const bool is_writeable = isFileWriteable(path);
+
+	return {std::move(name), std::move(path), is_directory, size, is_writeable};
+}
+
+void hostfs::LibretroStorage::initialise(retro_environment_t environ_cb)
+{
+	retro_vfs_interface_info vfs_interface_info;
+	vfs_interface_info.required_interface_version = 3; // We really want those directory functions.
+
+	if (!environ_cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_interface_info))
+		return;
+
+	vfs_interface = vfs_interface_info.iface;
+
+	filestream_vfs_init(&vfs_interface_info);
+	path_vfs_init(&vfs_interface_info);
+}
+
+bool hostfs::LibretroStorage::isKnownPath(const std::string& path)
+{
+	return filestream_exists(path.c_str());
+}
+
+std::vector<hostfs::FileInfo> hostfs::LibretroStorage::listContent(const std::string& path)
+{
+	std::vector<FileInfo> list;
+
+	struct retro_vfs_dir_handle* dir = vfs_interface->opendir(path.c_str(), true);
+
+	if (dir == nullptr)
+		return list;
+
+	while (vfs_interface->readdir(dir))
+	{
+		const auto entry_name = vfs_interface->dirent_get_name(dir);
+		const auto entry_path = path + PATH_DEFAULT_SLASH_C() + entry_name;
+
+		list.emplace_back(makeFileInfo(entry_name, entry_path));
+	}
+
+	vfs_interface->closedir(dir);
+
+	return list;
+}
+
+hostfs::File *hostfs::LibretroStorage::openFile(const std::string& path, const std::string& mode)
+{
+	bool extended = false;
+	bool append = false;
+	unsigned int mode_bitfield = 0;
+
+	for (char character : mode)
+	{
+		switch (character)
+		{
+			case 'R':
+			case 'r':
+				if (mode_bitfield != 0)
+					return nullptr;
+
+				mode_bitfield = RETRO_VFS_FILE_ACCESS_READ;
+				break;
+
+			case 'W':
+			case 'w':
+				if (mode_bitfield != 0)
+					return nullptr;
+
+				mode_bitfield = RETRO_VFS_FILE_ACCESS_WRITE;
+				break;
+
+			case 'A':
+			case 'a':
+				if (mode_bitfield != 0)
+					return nullptr;
+
+				mode_bitfield = RETRO_VFS_FILE_ACCESS_WRITE | RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING;
+				append = true;
+				break;
+
+			case '+':
+				extended = true;
+				break;
+
+			case 'B':
+			case 'b':
+			case 'T':
+			case 't':
+				// Binary mode unfortunately just gets assumed by default...
+				// TODO: Do any of Flycast's text parsers require text mode?
+				break;
+
+			default:
+				// Unrecognised character.
+				return nullptr;
+		}
+	}
+
+	if (mode_bitfield == 0)
+		return nullptr;
+
+	if (extended)
+		mode_bitfield = RETRO_VFS_FILE_ACCESS_READ_WRITE;
+
+	RFILE *rfile = filestream_open(path.c_str(), mode_bitfield, RETRO_VFS_FILE_ACCESS_HINT_NONE);
+
+	if (rfile == nullptr)
+		return nullptr;
+
+	auto file = new LibretroFile(rfile);
+
+	if (append)
+		file->seek(0, SEEK_END);
+
+	return file;
+}
+
+std::string hostfs::LibretroStorage::getParentPath(const std::string& path)
+{
+	std::string parent_path = path;
+
+	parent_path.resize(path_parent_dir(parent_path.data(), parent_path.size()));
+
+	return parent_path;
+}
+
+std::string hostfs::LibretroStorage::getSubPath(const std::string& reference, const std::string& relative)
+{
+	return reference + PATH_DEFAULT_SLASH_C() + relative;
+}
+
+hostfs::FileInfo hostfs::LibretroStorage::getFileInfo(const std::string& path)
+{
+	return makeFileInfo(path_basename(path.c_str()), path);
+}
+
+bool hostfs::LibretroStorage::exists(const std::string& path)
+{
+	return filestream_exists(path.c_str());
+}
+
+bool hostfs::LibretroStorage::addStorage(bool isDirectory, bool writeAccess, const std::string& description,
+		void (*callback)(bool cancelled, std::string selectedPath), const std::string& mimeType)
+{
+	// TODO: Should this do anything?
+	return false;
+}
+
+hostfs::CustomStorage& hostfs::customStorage()
+{
+	static LibretroStorage storage;
+
+	return storage;
+}

--- a/shell/libretro/storage.h
+++ b/shell/libretro/storage.h
@@ -1,0 +1,110 @@
+/*
+    This file is part of Flycast.
+
+    Flycast is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Flycast is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Flycast.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <streams/file_stream.h>
+#include "../../core/oslib/storage.h"
+
+namespace hostfs {
+
+class LibretroFile : public File
+{
+protected:
+	RFILE* const file;
+
+public:
+	LibretroFile(RFILE* file)
+		: file(file)
+	{}
+
+	~LibretroFile() override
+	{
+		filestream_close(file);
+	}
+
+	size_t read(void* buffer, size_t size, size_t count) override
+	{
+		if (size == 0 || count == 0)
+			return 0;
+
+		return filestream_read(file, buffer, size * count) / size;
+	}
+
+	size_t write(const void* buffer, size_t size, size_t count) override
+	{
+		if (size == 0 || count == 0)
+			return 0;
+
+		return filestream_write(file, buffer, size * count) / size;
+	}
+
+	s64 tell() override
+	{
+		return filestream_tell(file);
+	}
+
+	int seek(s64 offset, int whence) override
+	{
+		// TODO: This needs to be changed when libretro-common is updated!
+		// See: https://github.com/libretro/RetroArch/pull/18607
+		return filestream_seek(file, offset, whence) == -1;
+	}
+
+	char* gets(char* str, int count) override
+	{
+		return filestream_gets(file, str, count);
+	}
+
+	s64 size() override
+	{
+		return filestream_get_size(file);
+	}
+
+	int eof() override
+	{
+		return filestream_eof(file);
+	}
+
+	int error() override
+	{
+		return filestream_error(file);
+	}
+};
+
+class LibretroStorage : public CustomStorage
+{
+protected:
+	static struct retro_vfs_interface* vfs_interface;
+
+	static bool isFileWriteable(const std::string& path);
+	static FileInfo makeFileInfo(std::string name, std::string path);
+
+public:
+	static void initialise(retro_environment_t environ_cb);
+
+	bool isKnownPath(const std::string& path) override;
+	std::vector<FileInfo> listContent(const std::string& path) override;
+	File *openFile(const std::string& path, const std::string& mode) override;
+	std::string getParentPath(const std::string& path) override;
+	std::string getSubPath(const std::string& reference, const std::string& relative) override;
+	FileInfo getFileInfo(const std::string& path) override;
+	bool exists(const std::string& path) override;
+	bool addStorage(bool isDirectory, bool writeAccess, const std::string& description,
+			void (*callback)(bool cancelled, std::string selectedPath), const std::string& mimeType) override;
+};
+
+}

--- a/tests/src/IniFileTest.cpp
+++ b/tests/src/IniFileTest.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 #include "cfg/ini.h"
 #include "types.h"
+#include "oslib/storage.h"
 #include <locale>
 using namespace config;
 
@@ -160,13 +161,13 @@ TEST_F(IniFileTest, loadSaveFile)
 	file.set("s1", "e1", "e1");
 	file.set("s1", "e2", true);
 	file.set("s1", "e3", 3.14f);
-	FILE *f = fopen("test.cfg", "wb");
+	auto *f = new hostfs::StdFile(fopen("test.cfg", "wb"));
 	file.save(f);
-	fclose(f);
+	delete f;
 	file = {};
-	f = fopen("test.cfg", "rb");
+	f = new hostfs::StdFile(fopen("test.cfg", "rb"));
 	file.load(f);
-	fclose(f);
+	delete f;
 	ASSERT_EQ(42, file.getInt("", "root"));
 	ASSERT_EQ("e1", file.get("s1", "e1"));
 	ASSERT_TRUE(file.getBool("s1", "e2"));


### PR DESCRIPTION
This is enough to get a CHD file of Sonic Adventure to load over SMB in RetroArch. This should allow for loading files via Android's Storage Access Framework in RetroArch as well.

**The changes to .zip, .7z, and .png loading need testing.** Are these formats only used by texture packs, or is there another way to test them?

Currently, the file indirection only covers files which are opened with `hostfs::storage().openFile`; files which are opened with `nowide::fopen` directly are unaffected. If needed, I can look into migrating the remaining file IO to this new system.

I have done what I can to keep the indirect file API similar to the standard C file API, to minimise the impact on the codebase.

In the future, this new API can be expanded upon to streamline file IO, such as closing files automatically using RAII, instead of needing to manually close them with `delete` (which is the replacement for `fclose`).

Closes #2100.