### PR TITLE
vk: fix non-threaded freeze on AMD GPUs

### DIFF
--- a/core/rend/vulkan/vulkan_renderer.cpp
+++ b/core/rend/vulkan/vulkan_renderer.cpp
@@ -231,6 +231,7 @@ bool BaseVulkanRenderer::presentFramebuffer()
 		return false;
 	GetContext()->PresentFrame(fbTexture->GetImage(), fbTexture->GetImageView(), fbTexture->getSize(),
 			getDCFramebufferAspectRatio());
+	framebufferRendered = false;
 	return true;
 }
 


### PR DESCRIPTION
Reset framebufferRendered after PresentFrame() in the Vulkan framebuffer presentation path.

This fixes a standalone Vulkan freeze on AMD GPUs in non-threaded mode, where the emulator could hang after the Sega logo until an alt-tab.

Regression from this 2024 commit https://github.com/flyinghead/flycast/commit/cc56b0f

Certain games like Metal Slug 6 (Atomiswave) and South Park - Chef's Luv still hangs and need Alt-tab to continue. South Park's freeze may be because of https://github.com/flyinghead/flycast/issues/2302