### PR TITLE
rec-x64: check CpuRunning between translated blocks

### DIFF
--- a/core/rec-x64/rec_x64.cpp
+++ b/core/rec-x64/rec_x64.cpp
@@ -702,6 +702,14 @@ public:
 		mov(call_regs[0], dword[rax]);
 		call(bm_GetCodeByVAddr);
 		call(rax);
+
+		// Check CpuRunning between translated blocks so Stop() is observed
+		// promptly in single-threaded delayed frame-swap paths on Win64.
+		// This matches the x86 dynarec behavior more closely.
+		mov(rax, (size_t)&sh4ctx.CpuRunning);
+		cmp(dword[rax], 0);
+		je(end_run_loop);
+
 		mov(rax, (uintptr_t)&sh4ctx.cycle_counter);
 		mov(ecx, dword[rax]);
 		test(ecx, ecx);


### PR DESCRIPTION
I spent several weeks chasing this bug, and after a lot of dead ends, this seems to be the right fix.

What first looked like a renderer or Delay Frame Swapping issue actually comes from rec-x64 stop granularity in single-threaded mode. When Delay Frame Swapping is enabled, `Stop()` effectively acts as a frame-boundary signal. rec-x86 observes `CpuRunning` between translated blocks, but rec-x64 was only checking it at the start of the run loop, so it could keep running until the end of the current timeslice before reacting.

In practice, that means the delayed frame-boundary stop is handled too late on Win64, which causes the stutter / frame pacing issues seen in non-multicore mode.

This change makes rec-x64 re-check `CpuRunning` between translated blocks, which brings its behavior closer to rec-x86 in this area and fixes the issue in my testing.

I specifically verified this against the long-standing Win64 + Delay Frame Swapping + non-multicore stutter case, and this is the first change that consistently fixes it for me.

I should also mention that I eventually found the root cause with the help of ChatGPT, which helped me narrow the issue down to rec-x64 stop handling.

This solves https://github.com/flyinghead/flycast/issues/1615 and https://github.com/flyinghead/flycast/issues/2308 _(it might also solve some other single-threaded specific issues.)_