### PR TITLE
docs: clarify download channels and desktop build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,22 @@ Information about configuration and supported features can be found on [**TheArc
 
 Join us on our [**Discord server**](https://discord.gg/X8YWP8w) for a chat.
 
+## Downloads ![android](https://flyinghead.github.io/flycast-builds/android.jpg) ![windows](https://flyinghead.github.io/flycast-builds/windows.png) ![linux](https://flyinghead.github.io/flycast-builds/ubuntu.png) ![apple](https://flyinghead.github.io/flycast-builds/apple.png) ![switch](https://flyinghead.github.io/flycast-builds/switch.png) ![xbox](https://flyinghead.github.io/flycast-builds/xbox.png)
+
+Get builds for your system from the [**builds page**](https://flyinghead.github.io/flycast-builds/) or [**GitHub Releases**](https://github.com/flyinghead/flycast/releases).
+
+- **Latest master builds:** regular builds from the `master` branch with recent fixes and updates.
+- **Nightly dev builds:** experimental builds with the latest features and changes.
+- **Stable tagged releases:** versioned release builds published on GitHub Releases.
+
+Automated test results are available from the builds page as well.
+
 ## Install
 
 ### Android ![android](https://flyinghead.github.io/flycast-builds/android.jpg)
+
 Install Flycast from [**Google Play**](https://play.google.com/store/apps/details?id=com.flycast.emulator).
+
 ### Flatpak (Linux ![ubuntu logo](https://flyinghead.github.io/flycast-builds/ubuntu.png))
 
 1. [Set up Flatpak](https://www.flatpak.org/setup/).
@@ -30,7 +42,7 @@ Install Flycast from [**Google Play**](https://play.google.com/store/apps/detail
 
 `flatpak run org.flycast.Flycast`
 
-### Homebrew (MacOS ![apple logo](https://flyinghead.github.io/flycast-builds/apple.png))
+### Homebrew (macOS ![apple logo](https://flyinghead.github.io/flycast-builds/apple.png))
 
 1. [Set up Homebrew](https://brew.sh).
 
@@ -40,19 +52,29 @@ Install Flycast from [**Google Play**](https://play.google.com/store/apps/detail
 
 ### iOS
 
-Due to persistent harassment from an iOS user, support for this platform has been dropped. 
+Due to persistent harassment from an iOS user, support for this platform has been dropped.
 
 ### Xbox One/Series ![xbox logo](https://flyinghead.github.io/flycast-builds/xbox.png)
 
 Grab the latest build from [**the builds page**](https://flyinghead.github.io/flycast-builds/), or the [**GitHub Actions**](https://github.com/flyinghead/flycast/actions/workflows/uwp.yml). Then install it using the **Xbox Device Portal**.
 
-### Binaries ![android](https://flyinghead.github.io/flycast-builds/android.jpg) ![windows](https://flyinghead.github.io/flycast-builds/windows.png) ![linux](https://flyinghead.github.io/flycast-builds/ubuntu.png) ![apple](https://flyinghead.github.io/flycast-builds/apple.png) ![switch](https://flyinghead.github.io/flycast-builds/switch.png) ![xbox](https://flyinghead.github.io/flycast-builds/xbox.png)
+## Build from source
 
-Get fresh builds for your system [**on the builds page**](https://flyinghead.github.io/flycast-builds/).
+### macOS
 
-**New:** Now automated test results are available as well. 
+Right-click the bootstrap script and choose **Open**:
 
-### Build requirements (Linux):
+`shell/apple/generate_xcode_project.command`
+
+### Windows
+
+Double-click the bootstrap script:
+
+`shell\windows\generate_vs_project.bat`
+
+### Linux
+
+#### Dependencies
 
 - **C/C++ compiler toolchain** (e.g. `gcc`/`g++`)
 - **CMake**
@@ -62,7 +84,8 @@ Get fresh builds for your system [**on the builds page**](https://flyinghead.git
 - **SDL2** (development headers)
 - **Graphics API**: Vulcan, OpenGL
 
-### Build instructions:
+#### Build
+
 ```
 $ git clone --recursive https://github.com/flyinghead/flycast.git
 $ cd flycast


### PR DESCRIPTION
- Increase visibility of the builds page and GitHub Releases
- Clarify the three available build channels
  - latest master builds
  - nightly dev builds
  - stable tagged releases
- Highlight the macOS and Windows bootstrap scripts (#2313 & #2316) since people are not aware of them