### PR TITLE
 UI: Add option to discard video and animated textures during dump

### DIFF
--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -79,6 +79,7 @@ Option<float> ExtraDepthScale("rend.ExtraDepthScale", 1.f);
 Option<bool> CustomTextures("rend.CustomTextures");
 Option<bool> PreloadCustomTextures("rend.PreloadCustomTextures");
 Option<bool> DumpTextures("rend.DumpTextures");
+Option<bool> DumpUniqueTextures("rend.DumpUniqueTextures", true);
 Option<bool> DumpReplacedTextures("rend.DumpReplacedTextures");
 Option<int> ScreenStretching("rend.ScreenStretching", 100);
 Option<bool> Fog("rend.Fog", true);

--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -79,7 +79,7 @@ Option<float> ExtraDepthScale("rend.ExtraDepthScale", 1.f);
 Option<bool> CustomTextures("rend.CustomTextures");
 Option<bool> PreloadCustomTextures("rend.PreloadCustomTextures");
 Option<bool> DumpTextures("rend.DumpTextures");
-Option<bool> DumpUniqueTextures("rend.DumpUniqueTextures",true);
+Option<bool> DumpUniqueTextures("rend.DumpUniqueTextures");
 Option<bool> DumpReplacedTextures("rend.DumpReplacedTextures");
 Option<int> ScreenStretching("rend.ScreenStretching", 100);
 Option<bool> Fog("rend.Fog", true);

--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -79,7 +79,7 @@ Option<float> ExtraDepthScale("rend.ExtraDepthScale", 1.f);
 Option<bool> CustomTextures("rend.CustomTextures");
 Option<bool> PreloadCustomTextures("rend.PreloadCustomTextures");
 Option<bool> DumpTextures("rend.DumpTextures");
-Option<bool> DumpUniqueTextures("rend.DumpUniqueTextures", true);
+Option<bool> DumpUniqueTextures("rend.DumpUniqueTextures",true);
 Option<bool> DumpReplacedTextures("rend.DumpReplacedTextures");
 Option<int> ScreenStretching("rend.ScreenStretching", 100);
 Option<bool> Fog("rend.Fog", true);

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -449,6 +449,7 @@ extern Option<float> ExtraDepthScale;
 extern Option<bool> CustomTextures;
 extern Option<bool> PreloadCustomTextures;
 extern Option<bool> DumpTextures;
+extern Option<bool> DumpUniqueTextures;
 extern Option<bool> DumpReplacedTextures;
 extern Option<int> ScreenStretching;	// in percent. 150 means stretch from 4/3 to 6/3
 extern Option<bool> Fog;

--- a/core/rend/CustomTexture.cpp
+++ b/core/rend/CustomTexture.cpp
@@ -320,6 +320,12 @@ void CustomTexture::loadCustomTextureAsync(BaseTextureCacheData *texture_data)
 
 void CustomTexture::dumpTexture(BaseTextureCacheData* texture, int w, int h, void *src_buffer)
 {
+	if (!config::DumpTextures)
+		return;
+
+	if (config::DumpUniqueTextures && (texture->Updates > 1 || texture->tcw.PixelFmt == PixelYUV))
+		return;
+
 	if (!config::DumpReplacedTextures.get() && isTextureReplaced(texture))
 		return;
 

--- a/core/ui/settings.cpp
+++ b/core/ui/settings.cpp
@@ -112,6 +112,8 @@ static void gui_settings_advanced()
 			DisabledScope scope(!config::DumpTextures.get());
 			OptionCheckbox(T("Dump Replaced Textures"), config::DumpReplacedTextures,
 					T("Always dump textures that are already replaced by custom textures"));
+			OptionCheckbox(T("Discard Video and Animated Textures"), config::DumpUniqueTextures,
+					T("Skip dumping video (YUV) and already updated textures"));
 		}
 		ImGui::Unindent();
         bool logToFile = config::loadBool("log", "LogToFile", false);

--- a/resources/i18n/flycast.pot
+++ b/resources/i18n/flycast.pot
@@ -2314,6 +2314,14 @@ msgstr ""
 msgid "Always dump textures that are already replaced by custom textures"
 msgstr ""
 
+#: core/ui/settings.cpp:115
+msgid "Discard Video and Animated Textures"
+msgstr ""
+
+#: core/ui/settings.cpp:116
+msgid "Skip dumping video (YUV) and already updated textures"
+msgstr ""
+
 #: core/ui/settings.cpp:118
 msgid "Log to File"
 msgstr ""

--- a/resources/i18n/fr.po
+++ b/resources/i18n/fr.po
@@ -2242,6 +2242,14 @@ msgstr "Sauvegarde texture remplacée"
 msgid "Always dump textures that are already replaced by custom textures"
 msgstr "Toujours sauvegarder les textures déjà remplacées"
 
+#: core/ui/settings.cpp:115
+msgid "Discard Video and Animated Textures"
+msgstr "Ignorer vidéos et textures animées"
+
+#: core/ui/settings.cpp:116
+msgid "Skip dumping video (YUV) and already updated textures"
+msgstr "Ignorer les vidéos (YUV) et les textures déjà mises à jour"
+
 #: core/ui/settings.cpp:118
 msgid "Log to File"
 msgstr "Journal dans fichier"

--- a/shell/libretro/option.cpp
+++ b/shell/libretro/option.cpp
@@ -66,6 +66,7 @@ Option<float> ExtraDepthScale("", 1.f);
 Option<bool> CustomTextures(CORE_OPTION_NAME "_custom_textures");
 Option<bool> PreloadCustomTextures(CORE_OPTION_NAME "_preload_custom_textures");
 Option<bool> DumpTextures(CORE_OPTION_NAME "_dump_textures");
+Option<bool> DumpUniqueTextures(CORE_OPTION_NAME "_dump_unique_textures");
 Option<bool> DumpReplacedTextures(CORE_OPTION_NAME "_dump_replaced_textures");
 Option<int> ScreenStretching("", 100);
 Option<bool> Fog(CORE_OPTION_NAME "_fog", true);


### PR DESCRIPTION

## Description
This PR implements a filter to prevent flooding the texture dump directory with thousands of redundant frames from FMVs or procedural effects.

## Key Changes:

* Filtered Dumping: Added logic to skip the dump process if a texture has been updated more than once (Updates > 1) or if it utilizes the YUV format.
* New UI Option: Added a toggle "Discard Video and Animated Textures" in the Advanced Settings (enabled by default).
* Localization: Updated UI, French translations, and i18n template.

## Technical Context

* I am aware of the existing PR regarding YUV filtering. This PR complements it by adding the Updates > 1 logic.
* This addition is crucial for titles like Le Mans 24 Hours, where certain procedural or animated textures don't necessarily use the YUV format but still flood the dump directory with redundant data.

## Status

* I am fully available to discuss these implementation choices.


<img width="256" height="256" alt="fed80f86" src="https://github.com/user-attachments/assets/4b4f6eb2-e50a-4c02-a19b-e17ee2f97a22" />
<img width="1024" height="512" alt="fe6d0ec3" src="https://github.com/user-attachments/assets/9a805404-7dbd-4bbc-9fad-9629360ef66b" />
<img width="256" height="256" alt="fbf12e4" src="https://github.com/user-attachments/assets/70d57d46-bafa-4b4c-8b42-338fdb96c2fd" />
