### PR TITLE
vk: recreate swapchain on suboptimal present result

### DIFF
--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -975,7 +975,14 @@ void VulkanContext::Present() noexcept
 		try {
 			DoSwapAutomation();
 			vk::Result res = presentQueue.presentKHR(vk::PresentInfoKHR(1, &(*renderCompleteSemaphores[currentSemaphore]), 1, &(*swapChain), &currentImage));
-			(void)res;
+			// presentKHR lists eSuboptimalKHR as a success code so it is
+			// returned rather than thrown. Treat it as a request to
+			// recreate the swapchain on the next frame; otherwise the
+			// surface can stay stuck in a sub-optimal configuration
+			// (notably across DPI / window-resize / display-mode changes
+			// and with MoltenVK on Apple platforms).
+			if (res == vk::Result::eSuboptimalKHR)
+				resized = true;
 			currentSemaphore = (currentSemaphore + 1) % renderCompleteSemaphores.size();
 
 			if (lastFrameView && IsValid() && !gui_is_open())
@@ -983,6 +990,8 @@ void VulkanContext::Present() noexcept
 				{
 					PresentFrame(vk::Image(), lastFrameView, lastFrameExtent, lastFrameAR);
 					res = presentQueue.presentKHR(vk::PresentInfoKHR(1, &(*renderCompleteSemaphores[currentSemaphore]), 1, &(*swapChain), &currentImage));
+					if (res == vk::Result::eSuboptimalKHR)
+						resized = true;
 					currentSemaphore = (currentSemaphore + 1) % renderCompleteSemaphores.size();
 				}
 		} catch (const vk::SystemError& e) {

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -990,9 +990,15 @@ void VulkanContext::Present() noexcept
 				{
 					PresentFrame(vk::Image(), lastFrameView, lastFrameExtent, lastFrameAR);
 					res = presentQueue.presentKHR(vk::PresentInfoKHR(1, &(*renderCompleteSemaphores[currentSemaphore]), 1, &(*swapChain), &currentImage));
-					if (res == vk::Result::eSuboptimalKHR)
-						resized = true;
 					currentSemaphore = (currentSemaphore + 1) % renderCompleteSemaphores.size();
+					if (res == vk::Result::eSuboptimalKHR)
+					{
+						// Stop queuing additional dupe presents into a swap
+						// chain that we are about to tear down: the extra
+						// in-flight semaphores would just delay waitIdle().
+						resized = true;
+						break;
+					}
 				}
 		} catch (const vk::SystemError& e) {
 			// Happens when resizing the window


### PR DESCRIPTION
## Summary

`vulkan-hpp` lists `eSuboptimalKHR` as a success code for `presentKHR`, so the call returns the value rather than throwing. The existing `Present()` ignores it via `(void)res` and the surface stays stuck in a sub-optimal configuration until something else triggers a resize.

This patch sets `resized` when present returns `eSuboptimalKHR`, so the swapchain is rebuilt on the next frame. This mirrors the existing out-of-date handling that already comes through `vk::SystemError`.

## Why this matters

Most desktop GPU drivers rarely return `eSuboptimalKHR` outside of explicit window resizes, so the bug is mostly invisible. It becomes visible on:

- **DPI / display-mode changes** (e.g. moving a window between monitors, fullscreen toggles) where the driver reports suboptimal but keeps presenting.
- **MoltenVK on Apple platforms**, which is more aggressive about reporting suboptimal swapchains across rotation, retina scale changes and the iOS keyboard appearing/disappearing. Without this patch the surface can stay stretched / blurry indefinitely.

## What it doesn't change

- `eErrorOutOfDateKHR` from present already throws `vk::OutOfDateKHRError` and is caught by the existing `vk::SystemError` handler — that path is untouched.
- `acquireNextImageKHR` already throws `InvalidVulkanContext` on any non-success result, and the outer catches in `RenderFrame` / `vulkan_driver` already set `resized = true`. That path is untouched.
- The change is contained to `Present()`. No new allocations, no behavior change on success or on out-of-date.

## Test plan

- Linux + RADV: launch a few games, drag the window across two monitors with different scale factors, confirm the surface immediately repaints at the new resolution rather than staying stretched until next manual resize.
- macOS / MoltenVK: rotate iPad simulator / change scene size; confirm framebuffer no longer gets stuck at a stale extent.
- Windows + NVIDIA: alt-tab in/out of fullscreen, confirm no regression and no extra log spam.


Made with [Cursor](https://cursor.com)