### PR TITLE
vk: enable portability enumeration on Apple platforms

### DIFF
--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -44,6 +44,8 @@ VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 #include <memory>
 #include <set>
 #include <vulkan/vulkan_format_traits.hpp>
+#include <algorithm>
+#include <cstring>
 
 void ReInitOSD();
 
@@ -190,11 +192,29 @@ bool VulkanContext::InitInstance(const char** extensions, uint32_t extensions_co
 	&& (defined(VK_USE_PLATFORM_METAL_EXT) || defined(__APPLE__))
 		// MoltenVK is a portability driver. Vulkan loaders >= 1.3.216
 		// will not enumerate portability ICDs unless the application
-		// opts in via VK_KHR_portability_enumeration. Without this
-		// instance creation fails with VK_ERROR_INCOMPATIBLE_DRIVER
-		// on macOS / iOS where MoltenVK is the only available ICD.
-		vext.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
-		instanceFlags |= vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
+		// opts in via VK_KHR_portability_enumeration. Without this,
+		// instance creation fails with VK_ERROR_INCOMPATIBLE_DRIVER on
+		// macOS / iOS where MoltenVK is the only available ICD.
+		// Only opt in if the loader actually advertises the extension:
+		// older loaders that predate it would otherwise reject the
+		// instance with VK_ERROR_EXTENSION_NOT_PRESENT.
+		{
+			bool portabilityEnumSupported = false;
+			for (const auto& ext : vk::enumerateInstanceExtensionProperties())
+				if (strcmp(ext.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0) {
+					portabilityEnumSupported = true;
+					break;
+				}
+			if (portabilityEnumSupported) {
+				const bool alreadyRequested = std::any_of(vext.begin(), vext.end(),
+					[](const char *name) {
+						return strcmp(name, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0;
+					});
+				if (!alreadyRequested)
+					vext.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+				instanceFlags |= vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
+			}
+		}
 #endif
 		vk::InstanceCreateInfo instanceCreateInfo(instanceFlags, &applicationInfo, layer_names, vext);
 		// create a UniqueInstance

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -185,7 +185,18 @@ bool VulkanContext::InitInstance(const char** extensions, uint32_t extensions_co
 		layer_names.push_back("VK_LAYER_GOOGLE_unique_objects");
 #endif
 #endif
-		vk::InstanceCreateInfo instanceCreateInfo({}, &applicationInfo, layer_names, vext);
+		vk::InstanceCreateFlags instanceFlags{};
+#if defined(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) \
+	&& (defined(VK_USE_PLATFORM_METAL_EXT) || defined(__APPLE__))
+		// MoltenVK is a portability driver. Vulkan loaders >= 1.3.216
+		// will not enumerate portability ICDs unless the application
+		// opts in via VK_KHR_portability_enumeration. Without this
+		// instance creation fails with VK_ERROR_INCOMPATIBLE_DRIVER
+		// on macOS / iOS where MoltenVK is the only available ICD.
+		vext.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+		instanceFlags |= vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
+#endif
+		vk::InstanceCreateInfo instanceCreateInfo(instanceFlags, &applicationInfo, layer_names, vext);
 		// create a UniqueInstance
 		instance = vk::createInstanceUnique(instanceCreateInfo);
 


### PR DESCRIPTION
## Summary

MoltenVK is a portability driver. Starting with Vulkan loader 1.3.216 the loader no longer enumerates portability ICDs unless the application explicitly opts in via:

- `VK_KHR_portability_enumeration` instance extension
- `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` flag on `VkInstanceCreateInfo`

Without this, `vkCreateInstance` returns `VK_ERROR_INCOMPATIBLE_DRIVER` on macOS / iOS where MoltenVK is the only available ICD, and Flycast falls back / fails to start the Vulkan renderer at all on a fresh install with the current SDK.

The matching `VK_KHR_portability_subset` device extension is already enabled on device creation (under `VK_ENABLE_BETA_EXTENSIONS`), so this PR only fills in the missing instance side.

## Scope

- Gated on `defined(__APPLE__) || defined(VK_USE_PLATFORM_METAL_EXT)`, so non-portability platforms are not affected.
- Also gated on `defined(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)` so older Vulkan headers continue to compile.
- No behavior change when not using a portability ICD: the flag and extension are inert against conformant drivers.

## Test plan

- macOS / MoltenVK with current Vulkan SDK: confirm Flycast's Vulkan renderer starts cleanly (previously: `VK_ERROR_INCOMPATIBLE_DRIVER`).
- Linux + RADV / NVIDIA: confirm no regression — `vext` does not gain the portability extension and `instanceFlags` stays `{}`.
- Windows + NVIDIA: confirm no regression.


Made with [Cursor](https://cursor.com)