### PR TITLE
dx9: route renderer teardown on vsync switch through rend_term_renderer

### DIFF
--- a/core/rend/dx9/dxcontext.cpp
+++ b/core/rend/dx9/dxcontext.cpp
@@ -149,12 +149,7 @@ void DXContext::Present()
 		if (swapOnVSync != (!settings.input.fastForwardMode && config::VSync))
 		{
 			DEBUG_LOG(RENDERER, "Switch vsync %d", !swapOnVSync);
-			if (renderer != nullptr)
-			{
-				renderer->Term();
-				delete renderer;
-				renderer = nullptr;
-			}
+			rend_term_renderer();
 			term();
 			if (init(true))
 			{


### PR DESCRIPTION
## Summary

`DXContext::Present()` re-implements renderer teardown inline when the user toggles VSync: it null-checks `renderer`, calls `Term()`, deletes it and clears the pointer. `rend_term_renderer()` in `core/rend/Renderer_if.cpp` already does this exact dance and is what every other path uses (context destroy, content unload, renderer switch, etc.).

This patch deletes the inline teardown and calls `rend_term_renderer()` instead.

## Why

- **De-duplication.** The inline block and `rend_term_renderer()` have to stay in lockstep by hand today; this removes the duplication.
- **Future-proofing.** Any safety logic added to `rend_term_renderer()` (queue draining, render-thread cancellation, etc.) is automatically picked up by the DX9 vsync-switch path instead of needing a parallel patch.
- **Behavioural parity with Vulkan/GL.** Their context backends already go through `rend_term_renderer()` from the analogous code paths.

## Risk

Minimal. `rend_term_renderer()` is a strict superset of the inline block — it also has to handle the `renderer == nullptr` case, which the inline block was explicitly checking for anyway. No other behavior changes.

## Test plan

- DX9 backend on Windows: launch a game, toggle VSync option from the in-game menu while the emulator is running. Confirm:
  - Renderer is recreated cleanly (no crash, no leaked D3D resources).
  - Audio/input continue working after the switch.
  - Repeated toggles do not progressively degrade.


Made with [Cursor](https://cursor.com)