### PR TITLE
libretro: report 60.00 fps for NTSC instead of 59.94

### DIFF
--- a/shell/libretro/libretro.cpp
+++ b/shell/libretro/libretro.cpp
@@ -696,11 +696,11 @@ static void setGameGeometry(retro_game_geometry& geometry)
 bool setAVInfo(retro_system_av_info& avinfo)
 {
 	double sample_rate = 44100.0;
-	double fps = SPG_CONTROL.isPAL() ? 50.0 : 59.94;
+	double fps = SPG_CONTROL.isPAL() ? 50.0 : 60.0;
 
 	// 240p NTSC rate
 	if (framebufferHeight == 240 && !SPG_CONTROL.isNTSC() && !SPG_CONTROL.isPAL())
-		fps = 59.82366;
+		fps = 60.0;
 
 	setGameGeometry(avinfo.geometry);
 	avinfo.timing.sample_rate = sample_rate;


### PR DESCRIPTION
## Summary

Changes the NTSC framerate reported to the libretro frontend in `setAVInfo()` from `59.94` to `60.00` (and the 240p NTSC-mode special case from `59.82366` to `60.00`). PAL is unchanged.

## Motivation

On non-VRR 60 Hz displays, the 0.1% drift between the core's reported 59.94 fps and the host's 60 Hz refresh produces a periodic frame skip/duplicate roughly every 17 seconds. The hiccup is normally absorbed by frontend audio resampling and goes unnoticed, but it becomes visible when:

- **Black Frame Insertion** is enabled — the strobe pattern visibly stutters at the drift point
- **Strict V-Sync** is used without dynamic refresh-rate matching

Reporting 60.00 fps lines the core up with the typical 60 Hz monitor and removes the hiccup entirely on those setups.

## Diff

```diff
- double fps = SPG_CONTROL.isPAL() ? 50.0 : 59.94;
+ double fps = SPG_CONTROL.isPAL() ? 50.0 : 60.0;
- 	fps = 59.82366;
+ 	fps = 60.0;
```

## Trade-off

The reported rate diverges 0.1% from cycle-accurate NTSC. Audio sample rate is unchanged (44100 Hz) and the per-run sample count `sample_rate / fps` adjusts automatically, so frontend resamplers absorb the difference cleanly. Anyone needing strict NTSC timing should rely on the frontend's auto-refresh-rate features (or VRR), which is the more correct fix anyway.

If a configurable option is preferred (`force_60hz` style), happy to follow up with one — kept this PR minimal.

## Test plan

- [x] Builds cleanly on macOS arm64
- [x] RetroArch log shows `[INFO] [Core] ... FPS: 60.00` instead of `59.94`
- [x] Tested with Jazz Jackrabbit DC port and Volgarr the Viking
- [ ] Reviewers welcome to verify on Linux/Windows and additional retail titles