### PR TITLE
fix: emulator not properly deinitializing and causing crashes when reinitializing

### DIFF
--- a/core/emulator.cpp
+++ b/core/emulator.cpp
@@ -493,7 +493,7 @@ static void setPlatform(int platform)
 
 void Emulator::init()
 {
-	if (state != Uninitialized)
+	if (state != Uninitialized && state != Terminated)
 	{
 		verify(state == Init);
 		return;

--- a/shell/libretro/libretro.cpp
+++ b/shell/libretro/libretro.cpp
@@ -389,12 +389,8 @@ void retro_deinit()
 		std::lock_guard<std::mutex> lock(mtx_serialization);
 	}
 	os_UninstallFaultHandler();
-	
-#if defined(__APPLE__) || (defined(__GNUC__) && defined(__linux__) && !defined(__ANDROID__))
-	addrspace::release();
-#else
 	emu.term();
-#endif
+
 	libretro_supports_bitmasks = false;
 	categoriesSupported = false;
 	platformIsDreamcast = true;


### PR DESCRIPTION
Steps to reproduce:
1. Open RetroArch
2. Load a flycast rom
3. Load a dolphin rom
4. Load a flycast rom again
5. Get crash

These was happening because `retro_deinit` wasn't destroying the emulator state, so the next time it executes, it would try to initialize with CpuRunning = true for example.

On `retro_deinit`, I believe this part of the code was causing the issue:

```c
#if defined(__APPLE__) || (defined(__GNUC__) && defined(__linux__) && !defined(__ANDROID__))
	addrspace::release();
#else
	emu.term();
#endif
```

If it's Apple or Linux, it would only release addrspace, but not call `emu.term` which terminates interpreter, recompiler, and so on. 
(`emu.term` itself calls `addrspace::release()` so thats why I didn't had to include it)

I hope my fix is in the right direction, but feel free to make any suggestions on the code and you can ask me to test anything.

I tested both the buggy and the fixed version on a clean retroarch config.
