### PR TITLE
Simplify custom texture directory discovery

### DIFF
--- a/core/rend/CustomTexture.cpp
+++ b/core/rend/CustomTexture.cpp
@@ -44,15 +44,9 @@ public:
 		textures_path = hostfs::getTextureLoadPath(game_id);
 		if (!textures_path.empty())
 		{
-			try {
-				hostfs::FileInfo fileInfo = hostfs::storage().getFileInfo(textures_path);
-				if (fileInfo.isDirectory)
-				{
-					NOTICE_LOG(RENDERER, "Found custom textures directory: %s", textures_path.c_str());
-					custom_textures_available = true;
-				}
-			} catch (const FlycastException& e) {
-			}
+			custom_textures_available = hostfs::storage().exists(textures_path);
+			if (custom_textures_available)
+				NOTICE_LOG(RENDERER, "Found custom textures directory: %s", textures_path.c_str());
 		}
 	}
 	bool shouldReplace() const override { return config::CustomTextures && custom_textures_available; }


### PR DESCRIPTION
This simplifies custom texture discovery for the optional per-game texture directory:

`data/textures/<gameId>/`

The previous code used `hostfs::storage().getFileInfo()` and checked `fileInfo.isDirectory`. For this path, we only need to know whether the optional texture location exists, so `hostfs::storage().exists()` is enough and avoids using exceptions for normal control flow when the folder is absent.

This has became a small cleanup and is independent of the Switch exception warm-up fix now.


Original switch crash fixing attempt:
> This fixes a reproducible Switch launch crash in custom texture discovery.
> 
> During game load, Flycast may probe the default per-game custom texture path:
> `/flycast/data/textures/<gameId>/`
> 
> That directory is optional and often does not exist. The previous code used `hostfs::storage().getFileInfo()` to probe it.
> On Switch, that missing-directory metadata path could trigger a fatal crash.
> 
> This PR replaces that metadata probe with a directory-open check in `CustomTextureSource`
> 
> Verified working by Discord user milko0987. Closes #2196 
> 
> <hr>
> Some observation from users feedback and debugging:
> 
> > even the games that do open crash on the second attempt
> 
> > the emulator opens only once, the second time I'm opening the game, the fatal error on the console requiring restarting the atmosphere
> 
> > Launching a game with Flycast the first time works just fine #2334
> 
> 
> This problem could also be worked around without any code change by forcing boxart regeneration (for example, deleting the boxart folder before launching). This triggers both GD-ROM boxart extraction and online boxart fetch, which causes a different pattern of transient allocations before game launch.
> 
> That points to allocator/timing sensitivity around the crashing path, but the direct reproducible trigger identified here was the custom texture directory probe on a missing optional path.