### PR TITLE
Warm up C++ exceptions on Switch startup

### DIFF
--- a/shell/switch/switch_main.cpp
+++ b/shell/switch/switch_main.cpp
@@ -25,6 +25,14 @@
 #include <vector>
 #include <string>
 
+static void warmUpSwitchExceptions()
+{
+	try {
+		throw 1;
+	} catch (...) {
+	}
+}
+
 int main(int argc, char *argv[])
 {
 	socketInitializeDefault();
@@ -45,6 +53,8 @@ int main(int argc, char *argv[])
 	add_system_data_dir("/flycast/data/");
 	add_system_data_dir("./");
 	add_system_data_dir("data/");
+
+	warmUpSwitchExceptions();
 
 	if (flycast_init(argc, argv))
 		die("Flycast initialization failed");


### PR DESCRIPTION
Add a small Switch startup exception warm-up before `flycast_init()`
This avoids a system-level crash seen when the first C++ exception is thrown later during game launch

On newer Switch firmware/Atmosphere combinations affected by the TLS ABI changes, first-use C++ exception handling appears fragile in the launch path. Warming up exception handling once at startup makes the later existing exception path stable (Mimicking the "force boxart fetching" workaround which has early exception warm up)

Closes #2196.

#2341 becomes a nice to have now