### PR TITLE
rend: rename gl.quad to gl.quadDrawer

### DIFF
--- a/core/rend/gl4/gles.cpp
+++ b/core/rend/gl4/gles.cpp
@@ -669,7 +669,7 @@ static void gl_create_resources()
 	}
 	GlVertexArray::unbind();
 
-	gl.quad = std::make_unique<GlQuadDrawer>();
+	gl.quadDrawer = std::make_unique<GlQuadDrawer>();
 	glCheck();
 }
 

--- a/core/rend/gles/gldraw.cpp
+++ b/core/rend/gles/gldraw.cpp
@@ -678,7 +678,7 @@ void OpenGLRenderer::RenderFramebuffer(const FramebufferInfo& info)
 	else
 	{
 		glcache.Disable(GL_BLEND);
-		gl.quad->draw(gl.dcfb.tex, false, false);
+		gl.quadDrawer->draw(gl.dcfb.tex, false, false);
 	}
 #ifdef LIBRETRO
 	postProcessor.render(glsm_get_current_framebuffer());
@@ -723,7 +723,7 @@ void writeFramebufferToVRAM()
 			glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 			glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 			glcache.Disable(GL_BLEND);
-			gl.quad->draw(gl.ofbo.framebuffer->getTexture(), false);
+			gl.quadDrawer->draw(gl.ofbo.framebuffer->getTexture(), false);
 		}
 		else
 		{
@@ -793,7 +793,7 @@ bool OpenGLRenderer::renderLastFrame()
 			vertices = sverts;
 		}
 		glcache.Disable(GL_BLEND);
-		gl.quad->draw(framebuffer->getTexture(), config::Rotate90, true, vertices);
+		gl.quadDrawer->draw(framebuffer->getTexture(), config::Rotate90, true, vertices);
 	}
 	else
 	{
@@ -852,7 +852,7 @@ bool OpenGLRenderer::GetLastFrame(std::vector<u8>& data, int& width, int& height
 		};
 		vertices = &rvertices[0][0];
 	}
-	gl.quad->draw(framebuffer->getTexture(), config::Rotate90, false, vertices);
+	gl.quadDrawer->draw(framebuffer->getTexture(), config::Rotate90, false, vertices);
 
 	data.resize(width * height * 3);
 	glPixelStorei(GL_PACK_ALIGNMENT, 1);
@@ -980,7 +980,7 @@ static void drawVmuTexture(u8 vmuIndex, int width, int height)
 	};
 	glcache.Enable(GL_BLEND);
 	glcache.BlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-	gl.quad->draw(vmuTextureId[vmuIndex], false, false, vertices, color);
+	gl.quadDrawer->draw(vmuTextureId[vmuIndex], false, false, vertices, color);
 }
 
 static void updateLightGunTexture()
@@ -1027,7 +1027,7 @@ static void drawGunCrosshair(u8 port, int width, int height)
 	};
 	glcache.Enable(GL_BLEND);
 	glcache.BlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-	gl.quad->draw(lightgunTextureId, false, false, vertices, color);
+	gl.quadDrawer->draw(lightgunTextureId, false, false, vertices, color);
 }
 
 void drawVmusAndCrosshairs(int width, int height)

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -461,7 +461,7 @@ void termGLCommon()
 #ifdef VIDEO_ROUTING
 	os_VideoRoutingTermGL();
 #endif
-	gl.quad.reset();
+	gl.quadDrawer.reset();
 
 	// palette, fog
 	glcache.DeleteTextures(1, &fogTextureId);
@@ -921,7 +921,7 @@ static void gl_create_resources()
 	gl.vbo.modvols = std::make_unique<GlBuffer>(GL_ARRAY_BUFFER);
 	gl.vbo.idxs = std::make_unique<GlBuffer>(GL_ELEMENT_ARRAY_BUFFER);
 
-	gl.quad = std::make_unique<GlQuadDrawer>();
+	gl.quadDrawer = std::make_unique<GlQuadDrawer>();
 }
 
 GLuint gl_CompileShader(const char* shader,GLuint type);

--- a/core/rend/gles/gles.h
+++ b/core/rend/gles/gles.h
@@ -294,7 +294,7 @@ struct gl_ctx
 		std::unique_ptr<GlFramebuffer> framebuffer;
 	} videorouting;
 
-	std::unique_ptr<GlQuadDrawer> quad;
+	std::unique_ptr<GlQuadDrawer> quadDrawer;
 	const char *gl_version;
 	const char *glsl_version_header;
 	int gl_major;

--- a/core/rend/gles/postprocess.cpp
+++ b/core/rend/gles/postprocess.cpp
@@ -304,7 +304,7 @@ void PostProcessor::render(GLuint output_fbo)
 			vertices[1] = vertices[11] = -1.f - gl.ofbo.shiftY * 2.f / framebuffer->getHeight();
 			vertices[6] = vertices[16] = vertices[1] + 2;
 			glcache.Disable(GL_BLEND);
-			gl.quad->draw(framebuffer->getTexture(), false, false, vertices);
+			gl.quadDrawer->draw(framebuffer->getTexture(), false, false, vertices);
 		}
 		else
 		{


### PR DESCRIPTION
Prevent confusion with the macro "quad" from newlib (devkitpro, vitasdk):
- https://github.com/devkitPro/newlib/blob/57bd8e1ade3cf46d2e61a72516ac8bfaf8fdfd62/newlib/libc/include/sys/types.h#L52
- https://github.com/vitasdk/newlib/blob/fbb8375870d799758e0b4358d2f1708781aa26a6/newlib/libc/include/sys/types.h#L52