### PR TITLE
ios: remove [super dealloc] when using arc

### DIFF
--- a/shell/apple/emulator-ios/emulator/EmulatorView.mm
+++ b/shell/apple/emulator-ios/emulator/EmulatorView.mm
@@ -38,7 +38,6 @@
 {
 	GamepadDevice::Unregister(mouse);
 	mouse.reset();
-	[super dealloc];
 }
 
 - (void)touchLocation:(UITouch*)touch;

--- a/shell/apple/emulator-ios/emulator/PadViewController.mm
+++ b/shell/apple/emulator-ios/emulator/PadViewController.mm
@@ -49,7 +49,6 @@
 {
 	GamepadDevice::Unregister(virtualGamepad);
 	virtualGamepad.reset();
-	[super dealloc];
 }
 
 - (void)showController:(UIView *)parentView


### PR DESCRIPTION
> Custom dealloc methods in ARC do not require a call to [super dealloc] (it actually results in a compiler error). The chaining to super is automated and enforced by the compiler.

Source: https://developer.apple.com/library/archive/releasenotes/ObjectiveC/RN-TransitioningToARC/Introduction/Introduction.html