### PR TITLE
libretro: Revert change to reported fps

### DIFF
--- a/shell/libretro/libretro.cpp
+++ b/shell/libretro/libretro.cpp
@@ -701,11 +701,11 @@ static void setGameGeometry(retro_game_geometry& geometry)
 bool setAVInfo(retro_system_av_info& avinfo)
 {
 	double sample_rate = 44100.0;
-	double fps = SPG_CONTROL.isPAL() ? 50.0 : 60.0;
+	double fps = SPG_CONTROL.isPAL() ? 50.0 : 59.94;
 
 	// 240p NTSC rate
 	if (framebufferHeight == 240 && !SPG_CONTROL.isNTSC() && !SPG_CONTROL.isPAL())
-		fps = 60.0;
+		fps = 59.82366;
 
 	setGameGeometry(avinfo.geometry);
 	avinfo.timing.sample_rate = sample_rate;


### PR DESCRIPTION
Reverts change to reported libretro fps. (#2333)

For users who need to align exactly to a certain fps, Retroarch already has a mechanism called [Dynamic Rate Control](https://docs.libretro.com/development/cores/dynamic-rate-control/), which will adjust the emulation to run at a set refresh rate while also adjusting the pitch of the audio to compensate for the difference.  This mechanism is already used to compensate for all other cores that are not exactly 60, for example, the SNES at 60.10, the Gameboy at 59.73, the Genesis at 59.92, etc.  Further, for users who have a variable refresh monitor, Retroarch also offers a feature, Sync to Exact Content Framerate, to allow those users to sync precisely.  Applying the previous change mistimes the emulation for all configurations without the benefit of the audio compensation.

The previous PR mentions that some users may not have a VRR monitor or not want to use the DRC, but those features and technologies are supported specifically to deal with the situation where the console's framerate is different from the monitor.  By forcing the change from 59.94/59.82366 -> 60, this means that even people who do have VRR technology or who are willing to use DRC, are unable to get the raw base refresh rate to utilize those technologies and features properly.  Moreover, even 60Hz displays are not necessarily 60Hz, frequently outputting at 59.95, for example, meaning that there's now two stages of rate conversion for their devices.

The best solution is that reported fps should stay correct for the console and the frontend's additional features should be used to compensate as the user's configuration dictates.