### PR TITLE
Android: Add RetroAchievements host override receiver

### DIFF
--- a/core/achievements/achievements.cpp
+++ b/core/achievements/achievements.cpp
@@ -63,6 +63,7 @@ public:
 	void deserialize(Deserializer& deser);
 
 	static Achievements& Instance();
+	void setHostOverride(const std::string& host);
 
 private:
 	bool createClient();
@@ -105,6 +106,7 @@ private:
 
 	rc_client_t *rc_client = nullptr;
 	bool loggedOn = false;
+	bool hostOverrideActive = false;
 	std::atomic_bool loadingGame {};
 	bool active = false;
 	bool paused = false;
@@ -154,6 +156,10 @@ std::vector<Achievement> getAchievementList() {
 
 bool canPause() {
 	return Achievements::Instance().canPause();
+}
+
+void setHostOverride(const std::string& host) {
+	Achievements::Instance().setHostOverride(host);
 }
 
 void serialize(Serializer& ser) {
@@ -243,7 +249,33 @@ bool Achievements::createClient()
 
 	rc_client_set_userdata(rc_client, this);
 
+	if (!config::AchievementsHostUrl.get().empty()) {
+		rc_client_set_host(rc_client, config::AchievementsHostUrl.get().c_str());
+		hostOverrideActive = true;
+	}
+
 	return true;
+}
+
+void Achievements::setHostOverride(const std::string& host)
+{
+	config::AchievementsHostUrl.set(host);
+	hostOverrideActive = !host.empty();
+	// rc_client_set_host sets the global URL even when rc_client is null
+	rc_client_set_host(rc_client, host.empty() ? nullptr : host.c_str());
+	if (rc_client != nullptr)
+	{
+		if (!host.empty())
+		{
+			rc_client_set_hardcore_enabled(rc_client, 0);
+		}
+		else
+		{
+			bool restoredHardcore = config::AchievementsHardcoreMode.get();
+			rc_client_set_hardcore_enabled(rc_client, (int)restoredHardcore);
+			settings.raHardcoreMode = restoredHardcore;
+		}
+	}
 }
 
 void Achievements::loadCache()
@@ -855,7 +887,9 @@ void Achievements::loadGame()
 	if (!gameHash.empty())
 	{
 		// settings.raHardcoreMode is set before enabling cheats and loading the initial savestate
-		rc_client_set_hardcore_enabled(rc_client, settings.raHardcoreMode);
+		// Hardcore is disabled when routing through a custom host (e.g. RAOfflineProxy).
+		bool effectiveHardcore = settings.raHardcoreMode && !hostOverrideActive;
+		rc_client_set_hardcore_enabled(rc_client, effectiveHardcore);
 		rc_client_begin_load_game(rc_client, gameHash.c_str(), [](int result, const char *error_message, rc_client_t *client, void *userdata) {
 				((Achievements *)userdata)->gameLoaded(result, error_message);
 			}, this);

--- a/core/achievements/achievements.h
+++ b/core/achievements/achievements.h
@@ -54,6 +54,7 @@ bool isActive();
 Game getCurrentGame();
 std::vector<Achievement> getAchievementList();
 bool canPause();
+void setHostOverride(const std::string& host);
 
 #else
 

--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -246,5 +246,6 @@ Option<bool> EnableAchievements("Enabled", false, "achievements");
 Option<bool> AchievementsHardcoreMode("HardcoreMode", false, "achievements");
 OptionString AchievementsUserName("UserName", "", "achievements");
 OptionString AchievementsToken("Token", "", "achievements");
+OptionString AchievementsHostUrl("HostUrl", "", "achievements");
 
 } // namespace config

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -573,5 +573,6 @@ extern Option<bool> EnableAchievements;
 extern Option<bool> AchievementsHardcoreMode;
 extern OptionString AchievementsUserName;
 extern OptionString AchievementsToken;
+extern OptionString AchievementsHostUrl;
 
 } // namespace config

--- a/shell/android-studio/flycast/src/main/AndroidManifest.xml
+++ b/shell/android-studio/flycast/src/main/AndroidManifest.xml
@@ -166,6 +166,15 @@
 					android:scheme="file" />
 			</intent-filter>
         </activity-alias>
+        <receiver
+            android:name="com.flycast.emulator.RetroAchievementsHostOverrideReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.flycast.emulator.action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE" />
+                <action android:name="com.flycast.emulator.action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE" />
+            </intent-filter>
+        </receiver>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.provider"

--- a/shell/android-studio/flycast/src/main/java/com/flycast/emulator/RetroAchievementsHostOverrideReceiver.java
+++ b/shell/android-studio/flycast/src/main/java/com/flycast/emulator/RetroAchievementsHostOverrideReceiver.java
@@ -1,0 +1,143 @@
+package com.flycast.emulator;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.preference.PreferenceManager;
+import android.util.Log;
+
+import com.flycast.emulator.config.Config;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Receives host override broadcasts from RAOfflineProxy (and similar tools) so they can
+ * redirect RetroAchievements API traffic to a local proxy without modifying emu.cfg manually.
+ *
+ * SET action: com.flycast.emulator.action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE
+ *   Extra "host" (String): the proxy base URL, e.g. "http://127.0.0.1:8080"
+ *
+ * CLEAR action: com.flycast.emulator.action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE
+ *   No extras required.
+ */
+public class RetroAchievementsHostOverrideReceiver extends BroadcastReceiver {
+    private static final String TAG = "flycast/RAHostOverride";
+    static final String ACTION_SET = "com.flycast.emulator.action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE";
+    static final String ACTION_CLEAR = "com.flycast.emulator.action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE";
+    static final String EXTRA_HOST = "host";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (intent == null || intent.getAction() == null) return;
+
+        String newHost = null;
+        if (ACTION_SET.equals(intent.getAction())) {
+            newHost = intent.getStringExtra(EXTRA_HOST);
+            if (newHost == null || newHost.isEmpty()) {
+                Log.w(TAG, "SET broadcast received but 'host' extra is missing or empty");
+                return;
+            }
+            Log.i(TAG, "SET host override: " + newHost);
+        } else if (ACTION_CLEAR.equals(intent.getAction())) {
+            Log.i(TAG, "CLEAR host override");
+        } else {
+            return;
+        }
+
+        File cfgFile = resolveConfigFile(context);
+        if (cfgFile == null) {
+            Log.w(TAG, "Could not resolve emu.cfg path");
+            return;
+        }
+
+        try {
+            writeHostUrl(cfgFile, newHost != null ? newHost : "");
+        } catch (IOException e) {
+            Log.e(TAG, "Failed to update emu.cfg: " + e.getMessage());
+        }
+
+        // Also update the in-memory config so the next game load picks it up immediately
+        // without requiring a full restart of Flycast.
+        try {
+            nativeSetHostOverride(newHost);
+            Log.i(TAG, "Updated in-memory host override via JNI");
+        } catch (UnsatisfiedLinkError e) {
+            Log.d(TAG, "Native library not yet loaded; emu.cfg change will take effect on next Flycast start");
+        }
+    }
+
+    private static native void nativeSetHostOverride(String host);
+
+    private File resolveConfigFile(Context context) {
+        String homeDir = PreferenceManager.getDefaultSharedPreferences(context)
+                .getString(Config.pref_home, "");
+        if (homeDir.isEmpty()) {
+            File dir = context.getExternalFilesDir(null);
+            if (dir == null) dir = context.getFilesDir();
+            homeDir = dir.getAbsolutePath();
+        }
+        return new File(homeDir, "emu.cfg");
+    }
+
+    private void writeHostUrl(File cfgFile, String hostUrl) throws IOException {
+        List<String> lines = new ArrayList<>();
+        boolean inAchievements = false;
+        boolean hostUrlWritten = false;
+        boolean achievementsSectionFound = false;
+
+        if (cfgFile.exists()) {
+            try (BufferedReader reader = new BufferedReader(new FileReader(cfgFile))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    String trimmed = line.trim();
+                    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+                        if (inAchievements && !hostUrlWritten) {
+                            // End of [achievements] section — append before next section
+                            if (!hostUrl.isEmpty()) {
+                                lines.add("HostUrl = " + hostUrl);
+                            }
+                            hostUrlWritten = true;
+                        }
+                        inAchievements = trimmed.equalsIgnoreCase("[achievements]");
+                        if (inAchievements) achievementsSectionFound = true;
+                    } else if (inAchievements) {
+                        int eq = trimmed.indexOf('=');
+                        if (eq != -1 && trimmed.substring(0, eq).trim().equalsIgnoreCase("HostUrl")) {
+                            if (!hostUrl.isEmpty()) {
+                                lines.add(line.substring(0, line.indexOf('=') + 1) + " " + hostUrl);
+                            }
+                            hostUrlWritten = true;
+                            continue;
+                        }
+                    }
+                    lines.add(line);
+                }
+            }
+        }
+
+        if (!achievementsSectionFound) {
+            if (!hostUrl.isEmpty()) {
+                lines.add("[achievements]");
+                lines.add("HostUrl = " + hostUrl);
+            }
+        } else if (inAchievements && !hostUrlWritten && !hostUrl.isEmpty()) {
+            lines.add("HostUrl = " + hostUrl);
+        }
+
+        try (FileWriter writer = new FileWriter(cfgFile)) {
+            for (String line : lines) {
+                writer.write(line);
+                writer.write('\n');
+            }
+        }
+
+        Log.i(TAG, "Updated HostUrl in " + cfgFile.getAbsolutePath()
+                + " -> " + (hostUrl.isEmpty() ? "(cleared)" : hostUrl));
+    }
+}

--- a/shell/android-studio/flycast/src/main/jni/src/Android.cpp
+++ b/shell/android-studio/flycast/src/main/jni/src/Android.cpp
@@ -18,6 +18,7 @@
 #include "jni_util.h"
 #include "android_storage.h"
 #include "http_client.h"
+#include "achievements/achievements.h"
 #include "android_locale.h"
 
 #include <android/log.h>
@@ -553,4 +554,13 @@ void dc_exit()
 		jmethodID finishAffinity = env->GetMethodID(env->GetObjectClass(g_activity), "finishAffinity", "()V");
 		jni::env()->CallVoidMethod(g_activity, finishAffinity);
 	}
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_flycast_emulator_RetroAchievementsHostOverrideReceiver_nativeSetHostOverride(JNIEnv* env, jclass, jstring jhost)
+{
+	const char* host = jhost ? env->GetStringUTFChars(jhost, nullptr) : nullptr;
+	achievements::setHostOverride(host ? std::string(host) : std::string());
+	if (host)
+		env->ReleaseStringUTFChars(jhost, host);
 }


### PR DESCRIPTION
[RAOfflineProxy](https://raofflineproxy.com/) is an Android app that proxies RetroAchievements traffic through `127.0.0.1`, enabling offline softcore achievement play through local caching and later sync.

On Android, controlling the RetroAchievements host override through a broadcast receiver is a cleaner integration point than relying on external tools to patch runtime config files directly.

This makes the host override controllable by the app at runtime instead of requiring external file edits, which is more brittle and harder to integrate cleanly on Android.

## Summary

- add an Android broadcast receiver for setting and clearing the RetroAchievements host override
- persist the override in `emu.cfg` across app restarts
- apply the override through the native `rc_client_set_host()` API both on client creation and immediately at runtime via JNI

## Testing

- built and installed debug APK on a physical device (API 33, Adreno 740)
- verified `SET_RETROACHIEVEMENTS_HOST_OVERRIDE` routes RetroAchievements traffic through the local proxy
- verified `CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE` removes the stored override and restores direct traffic
- verified offline play works through RAOfflineProxy while the override is active

## Related

- mirrors the same Android broadcast-driven host override support already merged for [ARMSX2](https://github.com/ARMSX2/ARMSX2/pull/164) and [PPSSPP](https://github.com/hrydgard/ppsspp/pull/21760)
- follows the same goal as the existing PRs for [melonDS](https://github.com/rafaelvcaetano/melonDS-android/pull/1633) and [Dolphin](https://github.com/dolphin-emu/dolphin/pull/14671)