### PR TITLE
android: allow cleartext HTTP to 127.0.0.1 for local proxy image loading

### DIFF
--- a/shell/android-studio/flycast/src/main/AndroidManifest.xml
+++ b/shell/android-studio/flycast/src/main/AndroidManifest.xml
@@ -44,6 +44,7 @@
         android:banner="@drawable/ic_banner"
         android:logo="@drawable/ic_banner"
         android:hardwareAccelerated="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:appCategory="game"
         android:isGame="true"
 		android:requestLegacyExternalStorage="true"

--- a/shell/android-studio/flycast/src/main/res/xml/network_security_config.xml
+++ b/shell/android-studio/flycast/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## Why

The RetroAchievements rcheevos library communicates with the RA server over HTTP/HTTPS using its own socket-based implementation, which is not subject to Android's Network Security Config. However, Flycast's Java-side `HttpClient`, used to fetch game icons and achievement badge images, goes through Android's standard URL connection stack (`com.android.okhttp`), which **does** enforce the NSC policy.

Since API 28, Android blocks cleartext HTTP to all hosts by default. The RA API responses (`patch`, `achievementsets`) embed absolute image URLs pointing to `https://i.retroachievements.org/...`. If anything on the device rewrites those URLs to a local HTTP endpoint (e.g. a local caching proxy at `http://127.0.0.1:8080/...`), the image fetch will fail with:

```
java.io.IOException: Cleartext HTTP traffic to 127.0.0.1 not permitted
at com.android.okhttp.HttpHandler$CleartextURLFilter.checkURLPermitted(HttpHandler.java:127)
at com.flycast.emulator.emu.HttpClient.openUrl(HttpClient.java:70)
```

More broadly, any local tooling or debugging setup that intercepts RA traffic via a loopback HTTP proxy will hit this wall. There is no security risk in permitting cleartext to the loopback address, traffic to `127.0.0.1` never leaves the device.

## What

Adds a minimal `network_security_config.xml` that permits cleartext HTTP **only** to `127.0.0.1`. All other hosts remain subject to the default HTTPS-only policy. The manifest references it via `android:networkSecurityConfig`.