### PR TITLE
achievements: retry login when host override is set and login previously failed

### DIFF
--- a/core/achievements/achievements.cpp
+++ b/core/achievements/achievements.cpp
@@ -268,6 +268,16 @@ void Achievements::setHostOverride(const std::string& host)
 		if (!host.empty())
 		{
 			rc_client_set_hardcore_enabled(rc_client, 0);
+			if (!loggedOn
+				&& !config::AchievementsUserName.get().empty()
+				&& !config::AchievementsToken.get().empty())
+			{
+				INFO_LOG(COMMON, "RA: Retrying login via proxy host '%s'", host.c_str());
+				rc_client_begin_login_with_token(rc_client,
+					config::AchievementsUserName.get().c_str(),
+					config::AchievementsToken.get().c_str(),
+					clientLoginWithTokenCallback, nullptr);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
## Why

When Flycast starts while the device is offline and RAOfflineProxy is not yet running, `rc_client_begin_login_with_token` fails and `loggedOn` stays false. When RAOfflineProxy starts later and sends the `SET_RETROACHIEVEMENTS_HOST_OVERRIDE` broadcast (#2371), `setHostOverride` correctly redirects future API traffic to the proxy — but never retries the login. The user has to manually restart Flycast or relaunch the game to get a new login attempt.

## What

In `setHostOverride`, after switching to the new host, if `rc_client` is initialized but `loggedOn` is false and cached credentials are available, immediately issue another `rc_client_begin_login_with_token`. This reuses the same static callback as the initial login in `init()`, so success flows into `authenticationSuccess` and triggers `loadGame()` if content is already loaded.

The retry only fires when:
- a host is being set (not cleared)
- `rc_client` exists (native library is loaded)
- `loggedOn` is false (previous login failed or never completed)
- username and token are present in config