### PR TITLE
sh4: end the current timeslice on Stop()

### DIFF
--- a/core/hw/sh4/interpr/sh4_interpreter.cpp
+++ b/core/hw/sh4/interpr/sh4_interpreter.cpp
@@ -76,6 +76,7 @@ void Sh4Interpreter::Start()
 void Sh4Interpreter::Stop()
 {
 	ctx->CpuRunning = false;
+	ctx->cycle_counter = 0;
 }
 
 void Sh4Interpreter::Step()


### PR DESCRIPTION
This PR supersedes #2309 with a cheaper implementation of the same fix.

The previous PR fixed the issue by making rec-x64 observe `CpuRunning` between translated blocks, but that added work in the hottest part of the x64 dynarec.

This version takes a lower-cost approach instead:
- `Stop()` now also ends the current SH4 timeslice immediately
- rec-x64 exits before `UpdateSystem_INTC()` if `CpuRunning` is already false

In practice, this keeps the same useful behavior in the affected cases: execution stops before the following render starts, which restores the expected delayed frame swap behavior in single-threaded Win64 GL/DX11 and also fixes the PenPen loading screen cut.

So compared to #2309, the main benefit is that this avoids a per-block `CpuRunning` check in the hottest rec-x64 path while preserving the fix.

Fixes #1615
Fixes #2308