### PR TITLE
vk oit: honor maxStorageBufferRange and use BDA if available

### DIFF
--- a/core/rend/vulkan/oit/oit_buffer.h
+++ b/core/rend/vulkan/oit/oit_buffer.h
@@ -22,6 +22,7 @@
 #include "../buffer.h"
 #include "../texture.h"
 
+#include <cinttypes>
 #include <memory>
 
 class OITBuffers
@@ -39,8 +40,7 @@ public:
 		if (!pixelBuffer)
 		{
 			pixelBufferSize = config::PixelBufferSize;
-			pixelBuffer = std::make_unique<BufferData>(std::min<vk::DeviceSize>(pixelBufferSize, context->GetMaxMemoryAllocationSize()),
-					vk::BufferUsageFlagBits::eStorageBuffer, vk::MemoryPropertyFlagBits::eDeviceLocal);
+			makePixelBuffer();
 		}
 		if (!pixelCounter)
 		{
@@ -62,6 +62,11 @@ public:
 	{
 		static vk::DescriptorBufferInfo pixelBufferInfo({}, 0, vk::WholeSize);
 		pixelBufferInfo.buffer = *pixelBuffer->buffer;
+		/**
+		 * The intention behind setting the range to 1 byte in BDA mode is to make it easier to spot any missing or invalid USE_BDA defines in shader sources.
+		 * If USE_BDA is missing or invalid, the shader will access PixelBuffer as an SSBO, and if it's this tiny, it should result in obvious graphical glitches.
+		 */
+		pixelBufferInfo.range = pixelBufferAddress ? 1 : VK_WHOLE_SIZE;
 		writeDescSets.emplace_back(descSet, 7, 0, vk::DescriptorType::eStorageBuffer, nullptr, pixelBufferInfo);
 		static vk::DescriptorBufferInfo pixelCounterBufferInfo({}, 0, 4);
 		pixelCounterBufferInfo.buffer = *pixelCounter->buffer;
@@ -77,8 +82,8 @@ public:
 		if (pixelBufferSize != config::PixelBufferSize)
 		{
 			pixelBufferSize = config::PixelBufferSize;
-			pixelBuffer = std::make_unique<BufferData>(std::min<vk::DeviceSize>(pixelBufferSize, VulkanContext::Instance()->GetMaxMemoryAllocationSize()),
-					vk::BufferUsageFlagBits::eStorageBuffer, vk::MemoryPropertyFlagBits::eDeviceLocal);
+			VulkanContext::Instance()->WaitIdle();
+			makePixelBuffer();
 		}
 	}
 
@@ -90,6 +95,7 @@ public:
 
 	void Term()
 	{
+		pixelBufferAddress = 0;
 		pixelBuffer.reset();
 		pixelCounter.reset();
 		pixelCounterReset.reset();
@@ -97,6 +103,13 @@ public:
 	}
 
 	bool isFirstFrameAfterInit() const { return firstFrameAfterInit; }
+
+	vk::DeviceAddress getPixelBufferAddress() const { return pixelBufferAddress; }
+
+	vk::DeviceSize getPixelBufferSize() const
+	{
+		return pixelBuffer ? pixelBuffer->bufferSize : 0;
+	}
 
 private:
 	std::unique_ptr<BufferData> pixelBuffer;
@@ -107,4 +120,26 @@ private:
 	int maxWidth = 0;
 	int maxHeight = 0;
 	int64_t pixelBufferSize = 0;
+	vk::DeviceAddress pixelBufferAddress = 0;
+
+	void makePixelBuffer() {
+		const VulkanContext *context = VulkanContext::Instance();
+		const u32 maxStorageBufferRange = context->GetMaxStorageBufferRange();
+		vk::DeviceSize allocSize = std::min<vk::DeviceSize>(pixelBufferSize, context->GetMaxMemoryAllocationSize());
+		vk::BufferUsageFlags usage = vk::BufferUsageFlagBits::eStorageBuffer;
+		if (allocSize > maxStorageBufferRange) {
+			if (context->SupportsBufferDeviceAddress()) {
+				NOTICE_LOG(RENDERER, "PixelBuffer allocSize %" PRIu64 " > maxStorageBufferRange %lu; will use BDA", allocSize, (unsigned long)maxStorageBufferRange);
+				usage |= vk::BufferUsageFlagBits::eShaderDeviceAddressKHR;
+			} else {
+				NOTICE_LOG(RENDERER, "PixelBuffer allocSize %" PRIu64 " > maxStorageBufferRange %lu; capping allocSize, as the GPU doesn't support BDA", allocSize, (unsigned long)maxStorageBufferRange);
+				allocSize = maxStorageBufferRange;
+			}
+		}
+		pixelBuffer = std::make_unique<BufferData>(allocSize, usage, vk::MemoryPropertyFlagBits::eDeviceLocal);
+		pixelBufferAddress =
+			(usage & vk::BufferUsageFlagBits::eShaderDeviceAddressKHR)
+			? context->GetDevice().getBufferAddress(vk::BufferDeviceAddressInfo{*pixelBuffer->buffer}) : 0;
+		DEBUG_LOG(RENDERER, "PixelBuffer allocated. size %" PRIu64 " address %" PRIu64 "", allocSize, pixelBufferAddress);
+	}
 };

--- a/core/rend/vulkan/oit/oit_drawer.cpp
+++ b/core/rend/vulkan/oit/oit_drawer.cpp
@@ -302,10 +302,12 @@ bool OITDrawer::Draw(const Texture *fogTexture, const Texture *paletteTexture)
 	OITDescriptorSets::VertexShaderUniforms vtxUniforms;
 	vtxUniforms.ndcMat = matrices.GetNormalMatrix();
 
+	const vk::DeviceAddress pixelBufferAddress = oitBuffers->getPixelBufferAddress();
 	OITDescriptorSets::FragmentShaderUniforms fragUniforms = MakeFragmentUniforms<OITDescriptorSets::FragmentShaderUniforms>();
 	fragUniforms.shade_scale_factor = FPU_SHAD_SCALE.scale_factor / 256.f;
 	// sizeof(Pixel) == 16
-	fragUniforms.pixelBufferSize = std::min<u64>(config::PixelBufferSize, GetContext()->GetMaxMemoryAllocationSize()) / 16;
+	fragUniforms.pixelBufferSize = oitBuffers->getPixelBufferSize() / 16;
+	fragUniforms.pixelBufferAddress = pixelBufferAddress;
 	fragUniforms.viewportWidth = maxWidth;
 	dithering = config::EmulateFramebuffer && rendContext->fb_W_CTRL.fb_dither && rendContext->fb_W_CTRL.fb_packmode <= 3;
 	if (dithering)
@@ -381,13 +383,14 @@ bool OITDrawer::Draw(const Texture *fogTexture, const Texture *paletteTexture)
     {
         const RenderPass& current_pass = rendContext->render_passes[render_pass];
 
-        DEBUG_LOG(RENDERER, "Render pass %d OP %d PT %d TR %d MV %d TrMV %d autosort %d", render_pass + 1,
+        DEBUG_LOG(RENDERER, "Render pass %d OP %d PT %d TR %d MV %d TrMV %d autosort %d BDA %d", render_pass + 1,
         		current_pass.op_count - previous_pass.op_count,
 				current_pass.pt_count - previous_pass.pt_count,
 				current_pass.tr_count - previous_pass.tr_count,
 				current_pass.mvo_count - previous_pass.mvo_count,
 				current_pass.mv_op_tr_shared ? current_pass.mvo_count - previous_pass.mvo_count : current_pass.mvo_tr_count - previous_pass.mvo_tr_count,
-				current_pass.autosort);
+				current_pass.autosort,
+				!!pixelBufferAddress);
 
         // Reset the pixel counter
     	oitBuffers->ResetPixelCounter(cmdBuffer);

--- a/core/rend/vulkan/oit/oit_pipeline.cpp
+++ b/core/rend/vulkan/oit/oit_pipeline.cpp
@@ -21,7 +21,7 @@
 #include "oit_pipeline.h"
 #include "../quad.h"
 
-void OITPipelineManager::CreatePipeline(u32 listType, bool autosort, const PolyParam& pp, Pass pass, int gpuPalette)
+void OITPipelineManager::CreatePipeline(u32 listType, bool autosort, const PolyParam& pp, Pass pass, int gpuPalette, bool useBDA)
 {
 	vk::PipelineVertexInputStateCreateInfo pipelineVertexInputStateCreateInfo = GetMainVertexInputStateCreateInfo(true, pp.isNaomi2());
 
@@ -168,6 +168,7 @@ void OITPipelineManager::CreatePipeline(u32 listType, bool autosort, const PolyP
 	params.twoVolume = twoVolume;
 	params.palette = gpuPalette;
 	params.divPosZ = divPosZ;
+	params.useBDA = useBDA;
 	vk::ShaderModule fragment_module = shaderManager->GetFragmentShader(params);
 
 	std::array<vk::PipelineShaderStageCreateInfo, 2> stages = {
@@ -192,11 +193,11 @@ void OITPipelineManager::CreatePipeline(u32 listType, bool autosort, const PolyP
 	  pass == Pass::Depth ? (listType == ListType_Translucent ? 2 : 0) : 1 // subpass
 	);
 
-	pipelines[hash(listType, autosort, &pp, pass, gpuPalette)] = GetContext()->GetDevice().createGraphicsPipelineUnique(GetContext()->GetPipelineCache(),
+	pipelines[hash(listType, autosort, &pp, pass, gpuPalette, useBDA)] = GetContext()->GetDevice().createGraphicsPipelineUnique(GetContext()->GetPipelineCache(),
 			graphicsPipelineCreateInfo).value;
 }
 
-void OITPipelineManager::CreateFinalPipeline(bool dithering)
+void OITPipelineManager::CreateFinalPipeline(bool dithering, bool useBDA)
 {
 	vk::PipelineVertexInputStateCreateInfo pipelineVertexInputStateCreateInfo = GetQuadInputStateCreateInfo(false);
 
@@ -253,7 +254,7 @@ void OITPipelineManager::CreateFinalPipeline(bool dithering)
 	vk::PipelineDynamicStateCreateInfo pipelineDynamicStateCreateInfo(vk::PipelineDynamicStateCreateFlags(), dynamicStates);
 
 	vk::ShaderModule vertex_module = shaderManager->GetFinalVertexShader();
-	vk::ShaderModule fragment_module = shaderManager->GetFinalShader(dithering);
+	vk::ShaderModule fragment_module = shaderManager->GetFinalShader(OITShaderManager::FinalShaderParams{dithering, useBDA});
 
 	std::array<vk::PipelineShaderStageCreateInfo, 2> stages = {
 			vk::PipelineShaderStageCreateInfo(vk::PipelineShaderStageCreateFlags(), vk::ShaderStageFlagBits::eVertex, vertex_module, "main"),
@@ -277,7 +278,7 @@ void OITPipelineManager::CreateFinalPipeline(bool dithering)
 	  2                                           // subpass
 	);
 
-	finalPipelines[dithering] = GetContext()->GetDevice().createGraphicsPipelineUnique(GetContext()->GetPipelineCache(), graphicsPipelineCreateInfo).value;
+	finalPipelines[hash(dithering, useBDA)] = GetContext()->GetDevice().createGraphicsPipelineUnique(GetContext()->GetPipelineCache(), graphicsPipelineCreateInfo).value;
 }
 
 void OITPipelineManager::CreateClearPipeline()
@@ -460,12 +461,12 @@ void OITPipelineManager::CreateModVolPipeline(ModVolMode mode, int cullMode, boo
 	  renderPasses->GetRenderPass(true, true)     // renderPass
 	);
 
-	modVolPipelines[hash(mode, cullMode, naomi2)] =
+	modVolPipelines[hash(mode, cullMode, naomi2, false)] =
 			GetContext()->GetDevice().createGraphicsPipelineUnique(GetContext()->GetPipelineCache(),
 					graphicsPipelineCreateInfo).value;
 }
 
-void OITPipelineManager::CreateTrModVolPipeline(ModVolMode mode, int cullMode, bool naomi2)
+void OITPipelineManager::CreateTrModVolPipeline(ModVolMode mode, int cullMode, bool naomi2, bool useBDA)
 {
 	verify(mode != ModVolMode::Final);
 
@@ -522,7 +523,7 @@ void OITPipelineManager::CreateTrModVolPipeline(ModVolMode mode, int cullMode, b
 
 	bool divPosZ = !settings.platform.isNaomi2() && config::NativeDepthInterpolation;
 	vk::ShaderModule vertex_module = shaderManager->GetModVolVertexShader(OITShaderManager::ModVolShaderParams{ naomi2, divPosZ });
-	vk::ShaderModule fragment_module = shaderManager->GetTrModVolShader(OITShaderManager::TrModVolShaderParams{ mode, divPosZ });
+	vk::ShaderModule fragment_module = shaderManager->GetTrModVolShader(OITShaderManager::TrModVolShaderParams{ mode, divPosZ, useBDA });
 
 	std::array<vk::PipelineShaderStageCreateInfo, 2> stages = {
 			vk::PipelineShaderStageCreateInfo(vk::PipelineShaderStageCreateFlags(), vk::ShaderStageFlagBits::eVertex, vertex_module, "main"),
@@ -546,7 +547,7 @@ void OITPipelineManager::CreateTrModVolPipeline(ModVolMode mode, int cullMode, b
       2                                           // subpass
 	);
 
-	trModVolPipelines[hash(mode, cullMode, naomi2)] =
+	trModVolPipelines[hash(mode, cullMode, naomi2, useBDA)] =
 			GetContext()->GetDevice().createGraphicsPipelineUnique(GetContext()->GetPipelineCache(),
 					graphicsPipelineCreateInfo).value;
 }
@@ -558,7 +559,6 @@ void OITPipelineManager::checkMaxLayers()
 	{
 		maxLayers = layers;
 		trModVolPipelines.clear();
-		finalPipelines[0].reset();
-		finalPipelines[1].reset();
+		finalPipelines.clear();
 	}
 }

--- a/core/rend/vulkan/oit/oit_pipeline.h
+++ b/core/rend/vulkan/oit/oit_pipeline.h
@@ -50,7 +50,9 @@ public:
 		float sp_FOG_DENSITY;
 		float shade_scale_factor;	// new for OIT
 		u32 pixelBufferSize;
+		u64 pixelBufferAddress;
 		u32 viewportWidth;
+		u32 _pad;
 	};
 
 	struct PushConstants
@@ -274,6 +276,7 @@ public:
 	virtual void Init(OITShaderManager *shaderManager, OITBuffers *oitBuffers)
 	{
 		this->shaderManager = shaderManager;
+		this->oitBuffers = oitBuffers;
 
 		if (!perFrameLayout)
 		{
@@ -321,26 +324,26 @@ public:
 		pipelines.clear();
 		modVolPipelines.clear();
 		trModVolPipelines.clear();
-		finalPipelines[0].reset();
-		finalPipelines[1].reset();
+		finalPipelines.clear();
 		clearPipeline.reset();
 	}
 
 	vk::Pipeline GetPipeline(u32 listType, bool autosort, const PolyParam& pp, Pass pass, int gpuPalette)
 	{
-		u64 pipehash = hash(listType, autosort, &pp, pass, gpuPalette);
+		const bool useBDA = oitBuffers->getPixelBufferAddress();
+		u64 pipehash = hash(listType, autosort, &pp, pass, gpuPalette, useBDA);
 		const auto &pipeline = pipelines.find(pipehash);
 		if (pipeline != pipelines.end())
 			return pipeline->second.get();
 
-		CreatePipeline(listType, autosort, pp, pass, gpuPalette);
+		CreatePipeline(listType, autosort, pp, pass, gpuPalette, useBDA);
 
 		return *pipelines[pipehash];
 	}
 
 	vk::Pipeline GetModifierVolumePipeline(ModVolMode mode, int cullMode, bool naomi2)
 	{
-		u32 pipehash = hash(mode, cullMode, naomi2);
+		u32 pipehash = hash(mode, cullMode, naomi2, false);
 		const auto &pipeline = modVolPipelines.find(pipehash);
 		if (pipeline != modVolPipelines.end())
 			return pipeline->second.get();
@@ -351,20 +354,26 @@ public:
 	vk::Pipeline GetTrModifierVolumePipeline(ModVolMode mode, int cullMode, bool naomi2)
 	{
 		checkMaxLayers();
-		u32 pipehash = hash(mode, cullMode, naomi2);
+		const bool useBDA = oitBuffers->getPixelBufferAddress();
+		u32 pipehash = hash(mode, cullMode, naomi2, useBDA);
 		const auto &pipeline = trModVolPipelines.find(pipehash);
 		if (pipeline != trModVolPipelines.end())
 			return pipeline->second.get();
-		CreateTrModVolPipeline(mode, cullMode, naomi2);
+		CreateTrModVolPipeline(mode, cullMode, naomi2, useBDA);
 
 		return *trModVolPipelines[pipehash];
 	}
 	vk::Pipeline GetFinalPipeline(bool dithering)
 	{
 		checkMaxLayers();
-		if (!finalPipelines[dithering])
-			CreateFinalPipeline(dithering);
-		return *finalPipelines[dithering];
+		const bool useBDA = oitBuffers->getPixelBufferAddress();
+		u32 pipehash = hash(dithering, useBDA);
+		const auto &pipeline = finalPipelines.find(pipehash);
+		if (pipeline != finalPipelines.end())
+			return pipeline->second.get();
+		CreateFinalPipeline(dithering, useBDA);
+
+		return *finalPipelines[pipehash];
 	}
 	vk::Pipeline GetClearPipeline()
 	{
@@ -381,9 +390,9 @@ public:
 
 private:
 	void CreateModVolPipeline(ModVolMode mode, int cullMode, bool naomi2);
-	void CreateTrModVolPipeline(ModVolMode mode, int cullMode, bool naomi2);
+	void CreateTrModVolPipeline(ModVolMode mode, int cullMode, bool naomi2, bool useBDA);
 
-	u64 hash(u32 listType, bool autosort, const PolyParam *pp, Pass pass, int gpuPalette) const
+	u64 hash(u32 listType, bool autosort, const PolyParam *pp, Pass pass, int gpuPalette, bool useBDA) const
 	{
 		u64 hash = pp->pcw.Gouraud | (pp->pcw.Offset << 1) | (pp->pcw.Texture << 2) | (pp->pcw.Shadow << 3)
 			| (((pp->tileclip >> 28) == 3) << 4);
@@ -404,12 +413,17 @@ private:
 		hash |= ((u64)gpuPalette << 26) | ((u64)pass << 28) | ((u64)pp->isNaomi2() << 30);
 		hash |= (u64)(!settings.platform.isNaomi2() && config::NativeDepthInterpolation) << 31;
 		hash |= (u64)(pp->tcw.PixelFmt == PixelBumpMap) << 32;
+		hash |= (u64)useBDA << 34;
 
 		return hash;
 	}
-	u32 hash(ModVolMode mode, int cullMode, bool naomi2) const
+	u32 hash(ModVolMode mode, int cullMode, bool naomi2, bool useBDA) const
 	{
-		return ((int)mode << 2) | cullMode | ((u32)naomi2 << 5) | ((u32)(!settings.platform.isNaomi2() && config::NativeDepthInterpolation) << 6);
+		return ((int)mode << 2) | cullMode | ((u32)naomi2 << 5) | ((u32)(!settings.platform.isNaomi2() && config::NativeDepthInterpolation) << 6) | ((u32)useBDA << 7);
+	}
+	u32 hash(bool dithering, bool useBDA) const
+	{
+		return (u32)dithering | ((u32)useBDA << 1);
 	}
 
 	vk::PipelineVertexInputStateCreateInfo GetMainVertexInputStateCreateInfo(bool full = true, bool naomi2 = false) const
@@ -459,15 +473,15 @@ private:
 		);
 	}
 
-	void CreatePipeline(u32 listType, bool autosort, const PolyParam& pp, Pass pass, int gpuPalette);
-	void CreateFinalPipeline(bool dithering);
+	void CreatePipeline(u32 listType, bool autosort, const PolyParam& pp, Pass pass, int gpuPalette, bool useBDA);
+	void CreateFinalPipeline(bool dithering, bool useBDA);
 	void CreateClearPipeline();
 	void checkMaxLayers();
 
 	std::map<u64, vk::UniquePipeline> pipelines;
 	std::map<u32, vk::UniquePipeline> modVolPipelines;
 	std::map<u32, vk::UniquePipeline> trModVolPipelines;
-	vk::UniquePipeline finalPipelines[2];
+	std::map<u32, vk::UniquePipeline> finalPipelines;
 	vk::UniquePipeline clearPipeline;
 
 	vk::UniquePipelineLayout pipelineLayout;
@@ -482,6 +496,7 @@ protected:
 
 	RenderPasses *renderPasses;
 	OITShaderManager *shaderManager = nullptr;
+	OITBuffers *oitBuffers = nullptr;
 };
 
 class RttOITPipelineManager : public OITPipelineManager
@@ -490,7 +505,6 @@ public:
 	RttOITPipelineManager() { renderPasses = &rttRenderPasses; }
 	void Init(OITShaderManager *shaderManager, OITBuffers *oitBuffers) override
 	{
-		this->oitBuffers = oitBuffers;
 		OITPipelineManager::Init(shaderManager, oitBuffers);
 
 		renderToTextureBuffer = config::RenderToTextureBuffer;
@@ -507,5 +521,4 @@ public:
 private:
 	bool renderToTextureBuffer = false;
 	RttRenderPasses rttRenderPasses;
-	OITBuffers *oitBuffers = nullptr;
 };

--- a/core/rend/vulkan/oit/oit_shaders.cpp
+++ b/core/rend/vulkan/oit/oit_shaders.cpp
@@ -83,6 +83,9 @@ void main()
 )";
 
 static const char OITShaderHeader[] = R"(
+#extension GL_EXT_buffer_reference : enable
+#extension GL_EXT_buffer_reference_uvec2 : enable
+
 precision highp float;
 
 layout (std140, set = 0, binding = 1) uniform FragmentShaderUniforms
@@ -96,6 +99,9 @@ layout (std140, set = 0, binding = 1) uniform FragmentShaderUniforms
 	float sp_FOG_DENSITY;
 	float shade_scale_factor;
 	uint pixelBufferSize;
+	// we can't use PixelBufferRef here, because it would have to be defined somewhere above this block,
+	// but also uvec2 lets us conveniently avoid emitting "OpCapability PhysicalStorageBufferAddresses" outside of BDA
+	uvec2 pixelBufferAddress;
 	uint viewportWidth;
 } uniformBuffer;
 
@@ -110,16 +116,23 @@ layout(set = 0, binding = 8) buffer PixelCounter_ {
 OIT_POLY_PARAM
 R"(
 
+#if USE_BDA == 1
+layout(buffer_reference, buffer_reference_align = 16, std430) coherent restrict buffer PixelBufferRef {
+	Pixel pixels[];
+};
+#define PixelBuffer PixelBufferRef(uniformBuffer.pixelBufferAddress)
+#else
 layout (set = 0, binding = 7, std430) coherent restrict buffer PixelBuffer_ {
 	Pixel pixels[];
 } PixelBuffer;
+#endif
 
 uint getNextPixelIndex()
 {
 	uint index = atomicAdd(PixelCounter.buffer_index, 1);
-	// we should be able to simply use PixelBuffer.pixels.length()
-	// but a regression in the adreno 600 driver (v502) forces us
-	// to use a uniform.
+	// If USE_BDA == 1, PixelBuffer.pixels.length() would fail to compile.
+	// However, even outside of BDA, a regression in the adreno 600 driver (v502) forces us
+	// to use a uniform anyway.
 	if (index >= uniformBuffer.pixelBufferSize)
 		// Buffer overflow
 		discard;
@@ -758,6 +771,7 @@ vk::UniqueShaderModule OITShaderManager::compileShader(const FragmentShaderParam
 		.addConstant("pp_Palette", params.palette)
 		.addConstant("DIV_POS_Z", (int)params.divPosZ)
 		.addConstant("PASS", (int)params.pass)
+		.addConstant("USE_BDA", (int)params.useBDA)
 		.addSource(GouraudSource)
 		.addSource(OITShaderHeader)
 		.addSource(OITFragmentShaderTop)
@@ -766,11 +780,12 @@ vk::UniqueShaderModule OITShaderManager::compileShader(const FragmentShaderParam
 	return ShaderCompiler::Compile(vk::ShaderStageFlagBits::eFragment, src.generate());
 }
 
-vk::UniqueShaderModule OITShaderManager::compileFinalShader(bool dithering)
+vk::UniqueShaderModule OITShaderManager::compileShader(const FinalShaderParams& params)
 {
 	VulkanSource src;
 	src.addConstant("MAX_PIXELS_PER_FRAGMENT", maxLayers)
-		.addConstant("DITHERING", dithering)
+		.addConstant("DITHERING", (int)params.dithering)
+		.addConstant("USE_BDA", (int)params.useBDA)
 		.addSource(OITShaderHeader)
 		.addSource(OITFinalShaderSource);
 
@@ -813,6 +828,7 @@ vk::UniqueShaderModule OITShaderManager::compileShader(const TrModVolShaderParam
 	src.addConstant("MAX_PIXELS_PER_FRAGMENT", maxLayers)
 		.addConstant("MV_MODE", (int)params.mode)
 		.addConstant("DIV_POS_Z", (int)params.divPosZ)
+		.addConstant("USE_BDA", (int)params.useBDA)
 		.addSource(OITShaderHeader)
 		.addSource(OITTranslucentModvolShaderSource);
 	return ShaderCompiler::Compile(vk::ShaderStageFlagBits::eFragment, src.generate());
@@ -825,7 +841,6 @@ void OITShaderManager::checkMaxLayers()
 	{
 		maxLayers = layers;
 		trModVolShaders.clear();
-		finalFragmentShaders[0].reset();
-		finalFragmentShaders[1].reset();
+		finalFragmentShaders.clear();
 	}
 }

--- a/core/rend/vulkan/oit/oit_shaders.h
+++ b/core/rend/vulkan/oit/oit_shaders.h
@@ -60,6 +60,7 @@ public:
 		bool twoVolume;
 		int palette;
 		bool divPosZ;
+		bool useBDA;
 		Pass pass;
 
 		u32 hash()
@@ -68,7 +69,8 @@ public:
 				| ((u32)texture << 3) | ((u32)ignoreTexAlpha << 4) | (shaderInstr << 5)
 				| ((u32)offset << 7) | ((u32)fog << 8) | ((u32)gouraud << 10)
 				| ((u32)bumpmap << 11) | ((u32)clamping << 12) | ((u32)twoVolume << 13)
-				| ((u32)palette << 14) | ((int)pass << 16) | ((u32)divPosZ << 18);
+				| ((u32)palette << 14) | ((int)pass << 16) | ((u32)divPosZ << 18)
+				| ((u32)useBDA << 19);
 		}
 	};
 
@@ -84,8 +86,17 @@ public:
 	{
 		ModVolMode mode;
 		bool divPosZ;
+		bool useBDA;
 
-		u32 hash() { return (u32)mode | ((u32)divPosZ << 3); }
+		u32 hash() { return (u32)mode | ((u32)divPosZ << 3) | ((u32)useBDA << 4); }
+	};
+
+	struct FinalShaderParams
+	{
+		bool dithering;
+		bool useBDA;
+
+		u32 hash() { return (u32)dithering | ((u32)useBDA << 1); }
 	};
 
 	vk::ShaderModule GetVertexShader(const VertexShaderParams& params) { return getShader(vertexShaders, params); }
@@ -105,12 +116,10 @@ public:
 		return getShader(trModVolShaders, params);
 	}
 
-	vk::ShaderModule GetFinalShader(bool dithering)
+	vk::ShaderModule GetFinalShader(const FinalShaderParams& params)
 	{
 		checkMaxLayers();
-		if (!finalFragmentShaders[dithering])
-			finalFragmentShaders[dithering] = compileFinalShader(dithering);
-		return *finalFragmentShaders[dithering];
+		return getShader(finalFragmentShaders, params);
 	}
 
 	vk::ShaderModule GetFinalVertexShader()
@@ -136,8 +145,7 @@ public:
 		trModVolShaders.clear();
 
 		finalVertexShader.reset();
-		finalFragmentShaders[0].reset();
-		finalFragmentShaders[1].reset();
+		finalFragmentShaders.clear();
 		clearShader.reset();
 	}
 
@@ -157,7 +165,7 @@ private:
 	vk::UniqueShaderModule compileShader(const ModVolShaderParams& params);
 	vk::UniqueShaderModule compileModVolFragmentShader(bool divPosZ);
 	vk::UniqueShaderModule compileShader(const TrModVolShaderParams& params);
-	vk::UniqueShaderModule compileFinalShader(bool dithering);
+	vk::UniqueShaderModule compileShader(const FinalShaderParams& params);
 	vk::UniqueShaderModule compileFinalVertexShader();
 	vk::UniqueShaderModule compileClearShader();
 	void checkMaxLayers();
@@ -167,9 +175,9 @@ private:
 	std::map<u32, vk::UniqueShaderModule> modVolVertexShaders;
 	vk::UniqueShaderModule modVolShaders[2];
 	std::map<u32, vk::UniqueShaderModule> trModVolShaders;
+	std::map<u32, vk::UniqueShaderModule> finalFragmentShaders;
 
 	vk::UniqueShaderModule finalVertexShader;
-	vk::UniqueShaderModule finalFragmentShaders[2];
 	vk::UniqueShaderModule clearShader;
 	int maxLayers = 0;
 };

--- a/core/rend/vulkan/vk_context_lr.cpp
+++ b/core/rend/vulkan/vk_context_lr.cpp
@@ -34,6 +34,7 @@ bool VulkanContext::fragmentStoresAndAtomics = false;
 bool VulkanContext::samplerAnisotropy = false;
 bool VulkanContext::dedicatedAllocationSupported = false;
 bool VulkanContext::provokingVertexSupported = false;
+bool VulkanContext::bufferDeviceAddressSupported = false;
 
 const VkApplicationInfo* VkGetApplicationInfo()
 {
@@ -177,17 +178,30 @@ bool VkCreateDevice(retro_vulkan_context* context, VkInstance instance, VkPhysic
 		? true : tryAddDeviceExtension(vk::KHRGetPhysicalDeviceProperties2ExtensionName);
 
 	if (getPhysicalDeviceProperties2Supported)
+	{
 		// Enable VK_EXT_provoking_vertex if available
 		VulkanContext::provokingVertexSupported = tryAddDeviceExtension(vk::EXTProvokingVertexExtensionName);
+		VulkanContext::bufferDeviceAddressSupported = tryAddDeviceExtension(vk::KHRBufferDeviceAddressExtensionName);
+	}
 
 	// Get device features
 
-	vk::PhysicalDeviceFeatures2 featuresChain{};
+	vk::StructureChain<
+		vk::PhysicalDeviceFeatures2,
+		vk::PhysicalDeviceProvokingVertexFeaturesEXT,
+		vk::PhysicalDeviceBufferDeviceAddressFeaturesKHR
+	> featuresChainHelper;
+
+	vk::PhysicalDeviceFeatures2& featuresChain = featuresChainHelper.get();
 	vk::PhysicalDeviceFeatures& features = featuresChain.features;
 
-	vk::PhysicalDeviceProvokingVertexFeaturesEXT provokingVertexFeatures{};
-	if (VulkanContext::provokingVertexSupported)
-		featuresChain.pNext = &provokingVertexFeatures;
+	auto& provokingVertexFeatures = featuresChainHelper.get<vk::PhysicalDeviceProvokingVertexFeaturesEXT>();
+	if (!VulkanContext::provokingVertexSupported)
+		featuresChainHelper.unlink<vk::PhysicalDeviceProvokingVertexFeaturesEXT>();
+
+	auto& bufferDeviceAddressFeatures = featuresChainHelper.get<vk::PhysicalDeviceBufferDeviceAddressFeaturesKHR>();
+	if (!VulkanContext::bufferDeviceAddressSupported)
+		featuresChainHelper.unlink<vk::PhysicalDeviceBufferDeviceAddressFeaturesKHR>();
 
 	// Get the physical device's features
 	if (getPhysicalDeviceProperties2Supported && featuresChain.pNext)
@@ -196,7 +210,16 @@ bool VkCreateDevice(retro_vulkan_context* context, VkInstance instance, VkPhysic
 		physicalDevice.getFeatures(&features);
 
 	if (VulkanContext::provokingVertexSupported)
+	{
 		VulkanContext::provokingVertexSupported &= provokingVertexFeatures.provokingVertexLast;
+		NOTICE_LOG(RENDERER, "provokingVertexSupported %d", VulkanContext::provokingVertexSupported);
+	}
+
+	if (VulkanContext::bufferDeviceAddressSupported)
+	{
+		VulkanContext::bufferDeviceAddressSupported &= bufferDeviceAddressFeatures.bufferDeviceAddress;
+		NOTICE_LOG(RENDERER, "bufferDeviceAddressSupported %d", VulkanContext::bufferDeviceAddressSupported);
+	}
 
 	VulkanContext::samplerAnisotropy = features.samplerAnisotropy;
 	VulkanContext::fragmentStoresAndAtomics = features.fragmentStoresAndAtomics;

--- a/core/rend/vulkan/vk_context_lr.h
+++ b/core/rend/vulkan/vk_context_lr.h
@@ -88,10 +88,12 @@ public:
 	static VulkanContext *Instance() { return static_cast<VulkanContext *>(GraphicsContext::Instance()); }
 	bool SupportsSamplerAnisotropy() const { return samplerAnisotropy; }
 	bool SupportsDedicatedAllocation() const { return dedicatedAllocationSupported; }
+	bool SupportsBufferDeviceAddress() const { return bufferDeviceAddressSupported; }
 	bool hasPerPixel() override { return fragmentStoresAndAtomics; }
 	bool hasProvokingVertex() { return provokingVertexSupported; }
 	const VMAllocator& GetAllocator() const { return allocator; }
 	vk::DeviceSize GetMaxMemoryAllocationSize() const { return maxMemoryAllocationSize; }
+	u32 GetMaxStorageBufferRange() const { return maxStorageBufferRange; }
 	f32 GetMaxSamplerAnisotropy() const { return samplerAnisotropy ? maxSamplerAnisotropy : 1.f; }
 	u32 GetVendorID() const { return vendorID; }
 	void addToFlight(Deletable *object) override {
@@ -124,7 +126,7 @@ private:
 
 	vk::DeviceSize uniformBufferAlignment = 0;
 	vk::DeviceSize storageBufferAlignment = 0;
-	u32 maxStorageBufferRange = 0;
+	u32 maxStorageBufferRange = 0xFFFFFFFFu;
 	vk::DeviceSize maxMemoryAllocationSize = 0;
 	bool optimalTilingSupported565 = false;
 	bool optimalTilingSupported1555 = false;
@@ -135,6 +137,7 @@ public:
 	f32 maxSamplerAnisotropy = 0.f;
 	static bool dedicatedAllocationSupported;
 	static bool provokingVertexSupported;
+	static bool bufferDeviceAddressSupported;
 private:
 	u32 vendorID = 0;
 

--- a/core/rend/vulkan/vmallocator.cpp
+++ b/core/rend/vulkan/vmallocator.cpp
@@ -50,9 +50,12 @@ static const VmaDeviceMemoryCallbacks memoryCallbacks = { vmaAllocateDeviceMemor
 void VMAllocator::Init(vk::PhysicalDevice physicalDevice, vk::Device device, vk::Instance instance)
 {
 	assert(allocator == VK_NULL_HANDLE);
+	const VulkanContext *context = VulkanContext::Instance();
 	VmaAllocatorCreateInfo allocatorInfo = { VMA_ALLOCATOR_CREATE_EXTERNALLY_SYNCHRONIZED_BIT };
-	if (VulkanContext::Instance()->SupportsDedicatedAllocation())
+	if (context->SupportsDedicatedAllocation())
 		allocatorInfo.flags |= VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT;
+	if (context->SupportsBufferDeviceAddress())
+		allocatorInfo.flags |= VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
 
 	allocatorInfo.physicalDevice = (VkPhysicalDevice)physicalDevice;
 	// Top-out at vulkan 1.1

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -297,6 +297,7 @@ bool VulkanContext::InitInstance(const char** extensions, uint32_t extensions_co
 
 		uniformBufferAlignment = properties.limits.minUniformBufferOffsetAlignment;
 		storageBufferAlignment = properties.limits.minStorageBufferOffsetAlignment;
+		maxStorageBufferRange = properties.limits.maxStorageBufferRange;
 		maxSamplerAnisotropy =  properties.limits.maxSamplerAnisotropy;
 		vendorID = properties.vendorID;
 		NOTICE_LOG(RENDERER, "Vulkan API %s. Device %s", vulkan11 ? "1.1" : "1.0", properties.deviceName.data());
@@ -497,6 +498,7 @@ bool VulkanContext::InitDevice()
 		{
 			// Enable VK_EXT_provoking_vertex if available
 			provokingVertexSupported = tryAddDeviceExtension(vk::EXTProvokingVertexExtensionName);
+			bufferDeviceAddressSupported = tryAddDeviceExtension(vk::KHRBufferDeviceAddressExtensionName);
 		}
 		bool googleTimingSupported = false;
 #if defined(SWAPPY)
@@ -507,13 +509,25 @@ bool VulkanContext::InitDevice()
 
 		// Get device features
 
-		vk::PhysicalDeviceFeatures2 featuresChain{};
+		vk::StructureChain<
+			vk::PhysicalDeviceFeatures2,
+			vk::PhysicalDeviceProvokingVertexFeaturesEXT,
+			vk::PhysicalDeviceBufferDeviceAddressFeaturesKHR
+		> featuresChainHelper;
+
+		vk::PhysicalDeviceFeatures2& featuresChain = featuresChainHelper.get();
 		vk::PhysicalDeviceFeatures& features = featuresChain.features;
 
-		vk::PhysicalDeviceProvokingVertexFeaturesEXT provokingVertexFeatures{};
-		if (provokingVertexSupported)
+		auto& provokingVertexFeatures = featuresChainHelper.get<vk::PhysicalDeviceProvokingVertexFeaturesEXT>();
+		if (!provokingVertexSupported)
 		{
-			featuresChain.pNext = &provokingVertexFeatures;
+			featuresChainHelper.unlink<vk::PhysicalDeviceProvokingVertexFeaturesEXT>();
+		}
+
+		auto& bufferDeviceAddressFeatures = featuresChainHelper.get<vk::PhysicalDeviceBufferDeviceAddressFeaturesKHR>();
+		if (!bufferDeviceAddressSupported)
+		{
+			featuresChainHelper.unlink<vk::PhysicalDeviceBufferDeviceAddressFeaturesKHR>();
 		}
 		
 		// Get the physical device's features
@@ -529,6 +543,13 @@ bool VulkanContext::InitDevice()
 		if (provokingVertexSupported)
 		{
 			provokingVertexSupported &= provokingVertexFeatures.provokingVertexLast;
+			NOTICE_LOG(RENDERER, "provokingVertexSupported %d", provokingVertexSupported);
+		}
+
+		if (bufferDeviceAddressSupported)
+		{
+			bufferDeviceAddressSupported &= bufferDeviceAddressFeatures.bufferDeviceAddress;
+			NOTICE_LOG(RENDERER, "bufferDeviceAddressSupported %d", bufferDeviceAddressSupported);
 		}
 
 		samplerAnisotropy = features.samplerAnisotropy;

--- a/core/rend/vulkan/vulkan_context.h
+++ b/core/rend/vulkan/vulkan_context.h
@@ -155,8 +155,10 @@ public:
 	bool SupportsSamplerAnisotropy() const { return samplerAnisotropy; }
 	float GetMaxSamplerAnisotropy() const { return samplerAnisotropy ? maxSamplerAnisotropy : 1.f; }
 	bool SupportsDedicatedAllocation() const { return dedicatedAllocationSupported; }
+	bool SupportsBufferDeviceAddress() const { return bufferDeviceAddressSupported; }
 	const VMAllocator& GetAllocator() const { return allocator; }
 	vk::DeviceSize GetMaxMemoryAllocationSize() const { return maxMemoryAllocationSize; }
+	u32 GetMaxStorageBufferRange() const { return maxStorageBufferRange; }
 	u32 GetVendorID() const { return vendorID; }
 	vk::CommandBuffer PrepareOverlay(bool vmu, bool crosshair);
 	void DrawOverlay(float scaling, bool vmu, bool crosshair);
@@ -224,6 +226,7 @@ private:
 	vk::DeviceSize uniformBufferAlignment = 0;
 	vk::DeviceSize storageBufferAlignment = 0;
 	vk::DeviceSize maxMemoryAllocationSize = 0xFFFFFFFFu;
+	u32 maxStorageBufferRange = 0xFFFFFFFFu;
 	bool optimalTilingSupported565 = false;
 	bool optimalTilingSupported1555 = false;
 	bool optimalTilingSupported4444 = false;
@@ -232,6 +235,7 @@ private:
 	float maxSamplerAnisotropy = 0.f;
 	bool dedicatedAllocationSupported = false;
 	bool provokingVertexSupported = false;
+	bool bufferDeviceAddressSupported = false;
 	u32 vendorID = 0;
 	int swapInterval = 1;
 	vk::UniqueDevice device;


### PR DESCRIPTION
Fixes #2106 by adding support for VK_KHR_buffer_device_address and using it if available and beneficial, i.e. if the configured PixelBuffer size exceeds `maxStorageBufferRange`, but fits within `maxMemoryAllocationSize`.

As I mentioned earlier in https://github.com/flyinghead/flycast/issues/2106#issuecomment-4747114729, this will produce a validation error unless glslang is updated to 16.1.0+:
```
Validation Error: [ VUID-VkShaderModuleCreateInfo-pCode-08737 ] | MessageID = 0xa5625282
vkCreateShaderModule(): pCreateInfo->pCode (spirv-val produced an error):
Memory accesses Aligned operand value 0 is not a power of two.
  OpStore %251 %249 Aligned 0

Command to reproduce:
	spirv-val <input.spv> --relax-block-layout --target-env vulkan1.1

The Vulkan spec states: If pCode is a pointer to SPIR-V code, pCode must adhere to the validation rules described by the Validation Rules within a Module section of the SPIR-V Environment appendix (https://vulkan.lunarg.com/doc/view/1.4.328.1/windows/antora/spec/latest/chapters/shaders.html#VUID-VkShaderModuleCreateInfo-pCode-08737)
```
But this quirk doesn't seem to actually have any adverse effect at runtime with my Arc 750 on desktop and the Adreno 740 on Android.

The code is mostly identical to the [previous iteration](https://github.com/jpovixwm/flycast/commit/4b910b0d44aacca7507efa83cb80162840aa25e0), with the following changes:
- rebased on the dev branch
- applied matching changes to `vk_context_lr.h` and `vk_context_lr.cpp` for libretro
- moved the `provokingVertexSupported %d` and `bufferDeviceAddressSupported %d` logs into the conditional blocks directly above, so that they won't be printed if the GPU doesn't advertise the relevant device extension in the first place

I also built the libretro core locally for Windows and for Android, and verified it works on my hardware.