### PR TITLE
Delay OIT PVR resource allocation until game start

### DIFF
--- a/core/rend/vulkan/oit/oit_buffer.h
+++ b/core/rend/vulkan/oit/oit_buffer.h
@@ -37,11 +37,6 @@ public:
 		maxWidth = std::max(maxWidth, width);
 		maxHeight = std::max(maxHeight, height);
 
-		if (!pixelBuffer)
-		{
-			pixelBufferSize = config::PixelBufferSize;
-			makePixelBuffer();
-		}
 		if (!pixelCounter)
 		{
 			pixelCounter = std::make_unique<BufferData>(4,

--- a/core/rend/vulkan/oit/oit_drawer.cpp
+++ b/core/rend/vulkan/oit/oit_drawer.cpp
@@ -302,6 +302,9 @@ bool OITDrawer::Draw(const Texture *fogTexture, const Texture *paletteTexture)
 	OITDescriptorSets::VertexShaderUniforms vtxUniforms;
 	vtxUniforms.ndcMat = matrices.GetNormalMatrix();
 
+	bool firstFrameAfterInit = oitBuffers->isFirstFrameAfterInit();
+	oitBuffers->OnNewFrame(cmdBuffer);
+
 	const vk::DeviceAddress pixelBufferAddress = oitBuffers->getPixelBufferAddress();
 	OITDescriptorSets::FragmentShaderUniforms fragUniforms = MakeFragmentUniforms<OITDescriptorSets::FragmentShaderUniforms>();
 	fragUniforms.shade_scale_factor = FPU_SHAD_SCALE.scale_factor / 256.f;
@@ -332,9 +335,6 @@ bool OITDrawer::Draw(const Texture *fogTexture, const Texture *paletteTexture)
 	}
 
 	currentScissor = vk::Rect2D();
-
-	bool firstFrameAfterInit = oitBuffers->isFirstFrameAfterInit();
-	oitBuffers->OnNewFrame(cmdBuffer);
 
 	if (VulkanContext::Instance()->hasProvokingVertex())
 	{


### PR DESCRIPTION
Delay OIT renderer PVR resource allocation until a game is actually starting, instead of allocating those resources during renderer initialization

This keeps normal renderer/device initialization available for the UI, while avoiding early Vulkan OIT allocations before the emulator/JIT memory path has been set up.

Fixes the Xbyak `offset is too big` problem with the new MoltenVK 1.4, improve app launch time also

Changes:

- ~~Add renderer-level `InitPVRResources()` / `TermPVRResources()` hooks.~~
- ~~Move Vulkan OIT resource creation out of Init() and into delayed PVR resource init.~~
- ~~Apply the same delayed-resource lifecycle to DX11 OIT.~~
- ~~Initialize delayed PVR resources after game load, before emulator start/render.~~
- ~~Term delayed PVR resources when stopping, unloading, cancelling, or resetting a game.~~
- ~~Keep renderer initialization itself lightweight enough for UI startup.~~
- deleted buffer allocation during renderer init
- moved  `oitBuffers->OnNewFrame(cmdBuffer)` before `getPixelBufferAddress()`