### PR TITLE
Update UI scaling when SDL window display metrics change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,7 +520,7 @@ if(NOT LIBRETRO)
 		endif()
 
 		if(USE_HOST_SDL)
-			find_package(SDL2 2.0.9)
+			find_package(SDL2 2.0.18)
 		endif()
 		if(NOT SDL2_FOUND)
 			set(SDL_TEST_ENABLED_BY_DEFAULT OFF)

--- a/core/rend/vulkan/vulkan_context.cpp
+++ b/core/rend/vulkan/vulkan_context.cpp
@@ -945,16 +945,8 @@ bool VulkanContext::init()
     	return false;
     }
     this->surface.reset(vk::SurfaceKHR(surface));
-    SDL_Window *sdlWin = (SDL_Window *)window;
-    int w, h;
-    SDL_GetWindowSize(sdlWin, &w, &h);
-    SDL_Vulkan_GetDrawableSize(sdlWin, &settings.display.width, &settings.display.height);
-    settings.display.pointScale = (float)settings.display.width / w;
-	float hdpi, vdpi;
-	if (!SDL_GetDisplayDPI(SDL_GetWindowDisplayIndex(sdlWin), nullptr, &hdpi, &vdpi))
-		settings.display.dpi = roundf(std::max(hdpi, vdpi));
-
-	sdl_fix_steamdeck_dpi(sdlWin);
+	SDL_Window *sdlWin = (SDL_Window *)window;
+	sdl_update_display_metrics(sdlWin, SDL_WINDOW_VULKAN);
 #elif defined(VK_USE_PLATFORM_WIN32_KHR)
 	vk::Win32SurfaceCreateInfoKHR createInfo(vk::Win32SurfaceCreateFlagsKHR(), GetModuleHandle(NULL), (HWND)window);
 	surface = instance->createWin32SurfaceKHRUnique(createInfo);

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -15,6 +15,7 @@
 #include "sdl_keyboard.h"
 #include "sdl_keyboard_mac.h"
 #include "wsi/context.h"
+#include "ui/gui.h"
 #include "emulator.h"
 #include "stdclass.h"
 #include "imgui.h"
@@ -33,6 +34,8 @@
 #include "dreamlink.h"
 #include "oslib/i18n.h"
 #include <unordered_map>
+#include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <cstdio>
 
@@ -406,23 +409,18 @@ void input_sdl_handle()
 				break;
 
 			case SDL_WINDOWEVENT:
-				if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED
+			{
+				bool displayMetricsEvent = event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED
 						|| event.window.event == SDL_WINDOWEVENT_RESTORED
 						|| event.window.event == SDL_WINDOWEVENT_MINIMIZED
-						|| event.window.event == SDL_WINDOWEVENT_MAXIMIZED)
+						|| event.window.event == SDL_WINDOWEVENT_MAXIMIZED
+						|| event.window.event == SDL_WINDOWEVENT_DISPLAY_CHANGED;
+				if (displayMetricsEvent)
 				{
-#ifdef USE_VULKAN
-					if (windowFlags & SDL_WINDOW_VULKAN)
-						SDL_Vulkan_GetDrawableSize(window, &settings.display.width, &settings.display.height);
-					else
-#endif
-#ifdef USE_OPENGL
-					if (windowFlags & SDL_WINDOW_OPENGL)
-						SDL_GL_GetDrawableSize(window, &settings.display.width, &settings.display.height);
-					else
-#endif
-						SDL_GetWindowSize(window, &settings.display.width, &settings.display.height);
+					bool scaleChanged = sdl_update_display_metrics(window, windowFlags);
 					GraphicsContext::Instance()->resize();
+					if (scaleChanged)
+						gui_updateStyle();
 				}
 				else if (event.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
 				{
@@ -435,6 +433,7 @@ void input_sdl_handle()
 						SDL_ShowCursor(SDL_ENABLE);
 				}
 				break;
+			}
 
 			case SDL_JOYBUTTONDOWN:
 			case SDL_JOYBUTTONUP:
@@ -626,6 +625,49 @@ void sdlReceiveSlaveKeyboardEvent(u16 scancode, bool pressed)
 }
 
 static float hdpiScaling = 1.f;
+
+bool sdl_update_display_metrics(SDL_Window *window, u32 windowFlags)
+{
+	float oldPointScale = settings.display.pointScale;
+	float oldDpi = settings.display.dpi;
+
+	int windowWidth = 0;
+	int windowHeight = 0;
+	SDL_GetWindowSize(window, &windowWidth, &windowHeight);
+
+#ifdef USE_VULKAN
+	if (windowFlags & SDL_WINDOW_VULKAN)
+		SDL_Vulkan_GetDrawableSize(window, &settings.display.width, &settings.display.height);
+	else
+#endif
+#ifdef USE_OPENGL
+	if (windowFlags & SDL_WINDOW_OPENGL)
+		SDL_GL_GetDrawableSize(window, &settings.display.width, &settings.display.height);
+	else
+#endif
+	{
+		settings.display.width = windowWidth;
+		settings.display.height = windowHeight;
+	}
+
+	if (windowWidth > 0)
+		settings.display.pointScale = (float)settings.display.width / windowWidth;
+
+	int displayIndex = SDL_GetWindowDisplayIndex(window);
+	if (displayIndex >= 0)
+	{
+		float hdpi, vdpi;
+		if (SDL_GetDisplayDPI(displayIndex, nullptr, &hdpi, &vdpi) == 0)
+			settings.display.dpi = roundf(std::max(hdpi, vdpi));
+	}
+	else {
+		WARN_LOG(RENDERER, "Cannot get the window display index: %s", SDL_GetError());
+	}
+
+	sdl_fix_steamdeck_dpi(window);
+
+	return settings.display.pointScale != oldPointScale || settings.display.dpi != oldDpi;
+}
 
 static inline void get_window_state()
 {
@@ -965,10 +1007,13 @@ void sdl_fix_steamdeck_dpi(SDL_Window *window)
 	{
 		int displayIndex = SDL_GetWindowDisplayIndex(window);
 		SDL_DisplayMode mode;
-		SDL_GetDisplayMode(displayIndex, 0, &mode);
+		const char *displayName = nullptr;
+		if (displayIndex < 0 || SDL_GetDisplayMode(displayIndex, 0, &mode) != 0
+				|| (displayName = SDL_GetDisplayName(displayIndex)) == nullptr)
+			return;
 		if (displayIndex == 0
-				&& (strcmp(SDL_GetDisplayName(displayIndex), "ANX7530 U 3\"") == 0
-						|| strcmp(SDL_GetDisplayName(displayIndex), "XWAYLAND0 3\"") == 0)
+				&& (strcmp(displayName, "ANX7530 U 3\"") == 0
+						|| strcmp(displayName, "XWAYLAND0 3\"") == 0)
 				&& mode.w == 1280 && mode.h == 800)
 			settings.display.dpi = 206;
 	}

--- a/core/sdl/sdl.h
+++ b/core/sdl/sdl.h
@@ -8,4 +8,5 @@ void input_sdl_quit();
 void sdl_window_create();
 void sdl_window_destroy();
 bool sdl_recreate_window(u32 flags);
+bool sdl_update_display_metrics(SDL_Window *window, u32 windowFlags);
 void sdl_fix_steamdeck_dpi(SDL_Window *window);

--- a/core/sdl/sdl_gamepad.cpp
+++ b/core/sdl/sdl_gamepad.cpp
@@ -234,11 +234,7 @@ SDLGamepad::SDLGamepad(int maple_port, int joystick_idx, SDL_Joystick* sdl_joyst
 	hasAnalogStick = axes > 0;
 	set_maple_port(maple_port);
 
-#if SDL_VERSION_ATLEAST(2, 0, 18)
 	rumbleEnabled = SDL_JoystickHasRumble(sdl_joystick);
-#else
-	rumbleEnabled = (SDL_JoystickRumble(sdl_joystick, 1, 1, 1) != -1);
-#endif
 
 	// Open the haptic interface
 	haptic = SDL_HapticOpenFromJoystick(sdl_joystick);

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -204,7 +204,17 @@ void gui_updateStyle()
 	uiThreadRunner.init();
 
 #if !defined(TARGET_UWP) && !defined(__SWITCH__)
-	settings.display.uiScale = std::max(1.f, settings.display.dpi / 100.f * 0.75f);
+	const float dpiScale = std::max(1.f, settings.display.dpi / 100.f * 0.75f);
+#if defined(__APPLE__) && !defined(TARGET_IPHONE)
+	if (settings.display.pointScale > 1.f)
+		// Match macOS point scaling for HiDPI modes.
+		settings.display.uiScale = std::max(settings.display.pointScale, dpiScale);
+	else
+		// Dense 1x modes get only a small physical-DPI boost.
+		settings.display.uiScale = 1.f + (dpiScale - 1.f) * 0.15f;
+#else
+	settings.display.uiScale = dpiScale;
+#endif
    	// Limit scaling on small low-res screens
     if (settings.display.width <= 640 || settings.display.height <= 480)
     	settings.display.uiScale = std::min(1.2f, settings.display.uiScale);
@@ -227,7 +237,7 @@ void gui_updateStyle()
 #if defined(__ANDROID__) || defined(TARGET_IPHONE) || defined(__SWITCH__)
     ImGui::GetStyle().TouchExtraPadding = ImVec2(1, 1);	// from 0,0
 #endif
-	if (settings.display.uiScale > 1)
+	if (settings.display.uiScale != 1.f)
 		ImGui::GetStyle().ScaleAllSizes(settings.display.uiScale);
 	
 	gui_loadFonts();

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -973,13 +973,14 @@ static void gui_display_content()
 						if (counter % itemsPerLine != 0)
 							ImGui::SameLine();
 						counter++;
-						// Put the image inside a child window so we can detect when it's fully clipped and doesn't need to be loaded
-						if (ImGui::BeginChild("img", ImVec2(0, 0), ImGuiChildFlags_AutoResizeX | ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_NavFlattened))
+						if (ImGui::IsRectVisible(responsiveBoxVec2))
 						{
 							ImguiFileTexture tex(art.boxartPath);
 							pressed = gameImageButton(tex, game.name, responsiveBoxVec2, gameName);
 						}
-						ImGui::EndChild();
+						else {
+							ImGui::Dummy(responsiveBoxVec2);
+						}
 					}
 					else
 					{

--- a/core/ui/gui_achievements.cpp
+++ b/core/ui/gui_achievements.cpp
@@ -193,19 +193,20 @@ bool Notification::draw()
 	else if (type == Leaderboard)
 	{
 		ImFont *font = ImGui::GetFont();
+		const float fontSize = ImGui::GetStyle().FontSizeBase;
 		const ImVec2 padding = ImGui::GetStyle().FramePadding;
 		// iterate from the end
 		ImVec2 pos(insetLeft + padding.x, ImGui::GetIO().DisplaySize.y - padding.y);
 		for (auto it = leaderboards.rbegin(); it != leaderboards.rend(); ++it)
 		{
 			const std::string& text = it->second;
-			ImVec2 size = font->CalcTextSizeA(font->LegacySize, FLT_MAX, -1.f, text.c_str());
+			ImVec2 size = font->CalcTextSizeA(fontSize, FLT_MAX, -1.f, text.c_str());
 			ImVec2 psize = size + padding * 2;
 			pos.y -= psize.y;
 			dl->AddRectFilled(pos, pos + psize, bg_col, 0.f);
 			ImVec2 tpos = pos + padding;
 			const ImU32 col = alphaOverride(0xffffff, alpha);
-			dl->AddText(font, font->LegacySize, tpos, col, &text.front(), &text.back() + 1, FLT_MAX);
+			dl->AddText(font, fontSize, tpos, col, &text.front(), &text.back() + 1, FLT_MAX);
 			pos.y -= padding.y;
 		}
 	}
@@ -218,13 +219,14 @@ bool Notification::draw()
 		const float maxW = std::min(ImGui::GetIO().DisplaySize.x, uiScaled(640.f)) - padding.x
 				- (imgSize.x != 0.f ? imgSize.x + hspacing : padding.x);
 		ImFont *regularFont = ImGui::GetFont();
+		const float regularFontSize = ImGui::GetStyle().FontSizeBase;
 		ImVec2 textSize[3] {};
 		ImVec2 totalSize(0.f, padding.y * 2);
 		for (size_t i = 0; i < std::size(text); i++)
 		{
 			if (text[i].empty())
 				continue;
-			float fontSize = i == 0 ? uiLargeFontSize() : regularFont->LegacySize;
+			float fontSize = i == 0 ? uiLargeFontSize() : regularFontSize;
 			textSize[i] = ImGui::GetFont()->CalcTextSizeA(fontSize, FLT_MAX, maxW, text[i].c_str());
 			totalSize.x = std::max(totalSize.x, textSize[i].x);
 			totalSize.y += textSize[i].y;
@@ -265,7 +267,7 @@ bool Notification::draw()
 			if (text[i].empty())
 				continue;
 			ImFont *font = i == 0 ? boldFont : regularFont;
-			float fontSize = i == 0 ? uiLargeFontSize() : regularFont->LegacySize;
+			float fontSize = i == 0 ? uiLargeFontSize() : regularFontSize;
 			const ImU32 col = alphaOverride(i == 0 ? 0xffffff : 0x00ffff, alpha);
 			dl->AddText(font, fontSize, pos, col, &text[i].front(), &text[i].back() + 1, maxW);
 			pos.y += textSize[i].y + vspacing;

--- a/core/ui/gui_font.cpp
+++ b/core/ui/gui_font.cpp
@@ -257,7 +257,6 @@ void gui_loadFonts()
 	// Regular font
 	ImGuiStyle& style = ImGui::GetStyle();
 	const float fontSize = uiScaled(17.f);
-	style.FontSizeBase = fontSize;
 	
 	size_t dataSize;
 	std::unique_ptr<u8[]> data = resource::load("fonts/Roboto-Medium.ttf", dataSize);
@@ -478,4 +477,8 @@ void gui_loadFonts()
 	io.Fonts->AddFontFromMemoryTTF(data.get(), (int)dataSize, fontSize, &faFontConfig);
 	boldFontConfig.FontDataOwnedByAtlas = true;
 	io.Fonts->AddFontFromMemoryTTF(data.release(), (int)dataSize, fontSize, &boldFontConfig);
+
+	// AddFont() may sync the active ImGui font stack using the previous size.
+	// Re-apply the rebuilt atlas size after all fonts have been registered.
+	style.FontSizeBase = fontSize;
 }

--- a/core/ui/gui_util.cpp
+++ b/core/ui/gui_util.cpp
@@ -700,8 +700,9 @@ bool Toast::draw()
 	ImFont *regularFont = ImGui::GetFont();
 	const ImVec2 titleSize = title.empty() ? ImVec2()
 			: ImGui::GetFont()->CalcTextSizeA(uiLargeFontSize(), FLT_MAX, maxW, &title.front(), &title.back() + 1);
+	const float regularFontSize = ImGui::GetStyle().FontSizeBase;
 	const ImVec2 msgSize = message.empty() ? ImVec2()
-			: regularFont->CalcTextSizeA(regularFont->LegacySize, FLT_MAX, maxW, &message.front(), &message.back() + 1);
+			: regularFont->CalcTextSizeA(regularFontSize, FLT_MAX, maxW, &message.front(), &message.back() + 1);
 	const ScaledVec2 padding(5.f, 4.f);
 	const ScaledVec2 spacing(0.f, 2.f);
 	ImVec2 totalSize(std::max(titleSize.x, msgSize.x), titleSize.y + msgSize.y);
@@ -727,7 +728,7 @@ bool Toast::draw()
 	if (!message.empty())
 	{
 		const ImU32 col = alphaOverride(0xFF00FFFF, alpha);	// yellow
-		dl->AddText(regularFont, regularFont->LegacySize, pos, col, &message.front(), &message.back() + 1, maxW);
+		dl->AddText(regularFont, regularFontSize, pos, col, &message.front(), &message.back() + 1, maxW);
 	}
 
 	return true;

--- a/core/wsi/sdl.cpp
+++ b/core/wsi/sdl.cpp
@@ -24,9 +24,6 @@
 #include "sdl/sdl.h"
 #include "cfg/option.h"
 
-#include <algorithm>
-#include <cmath>
-
 SDLGLGraphicsContext::SDLGLGraphicsContext(void *window, void *display)
 	: GLGraphicsContext(window, display)
 {
@@ -83,16 +80,7 @@ bool SDLGLGraphicsContext::init()
 	}
 	SDL_GL_MakeCurrent(sdlWindow, NULL);
 
-	int w, h;
-	SDL_GetWindowSize(sdlWindow, &w, &h);
-	SDL_GL_GetDrawableSize(sdlWindow, &settings.display.width, &settings.display.height);
-	settings.display.pointScale = (float)settings.display.width / w;
-
-	float hdpi, vdpi;
-	if (!SDL_GetDisplayDPI(SDL_GetWindowDisplayIndex(sdlWindow), nullptr, &hdpi, &vdpi))
-		settings.display.dpi = roundf(std::max(hdpi, vdpi));
-	
-	sdl_fix_steamdeck_dpi(sdlWindow);
+	sdl_update_display_metrics(sdlWindow, SDL_WINDOW_OPENGL);
 
 	INFO_LOG(RENDERER, "Created SDL Window and GL Context successfully");
 


### PR DESCRIPTION
## Objective:

Solving rendering scaling and mouse coordinate issue when monitor DPI changes:
<img width="1018" height="669" alt="image" src="https://github.com/user-attachments/assets/2f25e061-b5c2-4e12-86cf-c2d3ab929797" />


## Changes

- Refresh SDL display metrics on resize/display-change events, including DPI and point scale
- Rebuild ImGui styling/fonts when display scale changes at runtime
- Adjust macOS UI scaling to follow backing point scale for HiDPI modes while lightly boosting dense 1x modes
- Avoid transient boxart grid layout glitches during runtime UI scale changes
- Raise the host SDL2 minimum from 2.0.9 to 2.0.18


## macOS UI scaling

macOS display scaling is not well represented by physical DPI alone. A Retina display can expose high physical DPI while the OS presents UI in logical points through a backing scale such as 1x, 2x, or another HiDPI mode.

This PR changes macOS scaling to use two paths:

- HiDPI/backing-scale modes use `pointScale` as the primary UI scale, matching how macOS maps logical points to backing pixels.
- Dense 1x modes keep a small physical-DPI boost, so native-resolution Retina displays do not fall all the way back to a plain 1.0 UI scale.

This avoids the old behavior where macOS could over-scale UI based only on physical DPI, especially on large external Retina displays or unusual scaled-resolution modes.

## Boxart grid layout

Wrong render during the first frame after DPI changes:
<img width="683" height="354" alt="image" src="https://github.com/user-attachments/assets/843bb4c8-27b4-409f-9fb0-c578a33e4aae" />

Took a few frames to "pack" when it is trying to fill up by `AutoResize` flag
<img width="546" height="432" alt="Jun-28-2026 16-12-09" src="https://github.com/user-attachments/assets/9f030bc6-47c9-4d6c-a3d8-c9b87f7c1ea3" />

The content browser previously wrapped each boxart tile in an auto-resizing child window. During runtime scale changes, those child windows could briefly carry stale auto-size layout state, causing visible tile spacing glitches.

This PR replaces that wrapper with `IsRectVisible()` for lazy texture loading and `Dummy()` to preserve layout space for clipped tiles. The grid keeps lazy loading while using deterministic tile layout across scale changes

## SDL2 minimum version

The previous host SDL2 minimum was 2.0.9, released on October 30, 2018.

This PR raises the minimum to 2.0.18, released on November 29, 2021, because the runtime display-scale update now relies on SDL 2.0.18-era APIs/events:

- `SDL_WINDOWEVENT_DISPLAY_CHANGED`
- `SDL_JoystickHasRumble()`

This removes the need for project-local `SDL_VERSION_ATLEAST(2, 0, 18)` guards while keeping host SDL support on a realistic baseline.

Closes #259