### PR TITLE
arm7: Implement MSR fully in AICA dynarec

### DIFF
--- a/core/hw/arm7/arm7.cpp
+++ b/core/hw/arm7/arm7.cpp
@@ -382,13 +382,22 @@ void DYNACALL interpret(u32 opcode)
 }
 
 template<u32 Pd>
-void DYNACALL MSR_do(u32 v)
+void DYNACALL MSR_do(u32 v, u32 mask)
 {
 	if (Pd)
 	{
 		if(armMode > 0x10 && armMode < 0x1f) /* !=0x10 ?*/
 		{
-			reg[RN_SPSR].I = (reg[RN_SPSR].I & 0x00FFFF00) | (v & 0xFF0000FF);
+			u32 newValue = reg[RN_SPSR].I;
+			if (mask & 1)
+				newValue = (newValue & 0xFFFFFF00) | (v & 0x000000FF);
+			if (mask & 2)
+				newValue = (newValue & 0xFFFF00FF) | (v & 0x0000FF00);
+			if (mask & 4)
+				newValue = (newValue & 0xFF00FFFF) | (v & 0x00FF0000);
+			if (mask & 8)
+				newValue = (newValue & 0x00FFFFFF) | (v & 0xFF000000);
+			reg[RN_SPSR].I = newValue;
 		}
 	}
 	else
@@ -398,10 +407,15 @@ void DYNACALL MSR_do(u32 v)
 		u32 newValue = reg[RN_CPSR].I;
 		if(armMode > 0x10)
 		{
-			newValue = (newValue & 0xFFFFFF00) | (v & 0x000000FF);
+			if (mask & 1)
+				newValue = (newValue & 0xFFFFFF00) | (v & 0x000000FF);
+			if (mask & 2)
+				newValue = (newValue & 0xFFFF00FF) | (v & 0x0000FF00);
+			if (mask & 4)
+				newValue = (newValue & 0xFF00FFFF) | (v & 0x00FF0000);
 		}
-
-		newValue = (newValue & 0x00FFFFFF) | (v & 0xFF000000);
+		if (mask & 8)
+			newValue = (newValue & 0x00FFFFFF) | (v & 0xFF000000);
 		newValue |= 0x10;
 		if(armMode > 0x10)
 		{
@@ -411,8 +425,8 @@ void DYNACALL MSR_do(u32 v)
 		CPUUpdateFlags();
 	}
 }
-template void DYNACALL MSR_do<0>(u32 v);
-template void DYNACALL MSR_do<1>(u32 v);
+template void DYNACALL MSR_do<0>(u32 v, u32 mask);
+template void DYNACALL MSR_do<1>(u32 v, u32 mask);
 
 } // namespace recompiler
 #endif	// FEAT_AREC != DYNAREC_NONE

--- a/core/hw/arm7/arm7_rec.cpp
+++ b/core/hw/arm7/arm7_rec.cpp
@@ -164,15 +164,17 @@ static ArmOp decodeArmOp(u32 opcode, u32 arm_pc)
 				op.rd = ArmOp::Operand((Arm7Reg)bits.rd);
 				verify(bits.rd != 15);
 			}
-			else if ((bits.full & 0x0FBFFFF0) == 0x0129F000)
+			else if ((bits.full & 0x0FB0FFF0) == 0x0120F000)
 			{
 				op.op_type = ArmOp::MSR;
+				op.psrMask = (bits.full >> 16) & 0xF;
 				op.arg[0] = ArmOp::Operand((Arm7Reg)bits.rm);
 				op.cycles++;
 			}
-			else if ((bits.full & 0x0DBFF000) == 0x0128F000)
+			else if ((bits.full & 0x0DB0F000) == 0x0120F000)
 			{
 				op.op_type = ArmOp::MSR;
+				op.psrMask = (bits.full >> 16) & 0xF;
 				if (bits.imm_op == 0)
 				{
 					// source is reg

--- a/core/hw/arm7/arm7_rec.h
+++ b/core/hw/arm7/arm7_rec.h
@@ -101,6 +101,8 @@ struct ArmOp
 	u8 flags = 0;
 	u8 cycles = 6;
 	bool spsr = false;
+	// For MSR
+	u8 psrMask = 0;
 
 	bool isLogicalOp() const
 	{
@@ -428,7 +430,7 @@ void term();
 void flush();
 void compile();
 void *getMemOp(bool load, bool byte);
-template<u32 Pd> void DYNACALL MSR_do(u32 v);
+template<u32 Pd> void DYNACALL MSR_do(u32 v, u32 mask);
 void DYNACALL interpret(u32 opcode);
 
 extern u8* icPtr;

--- a/core/hw/arm7/arm7_rec_arm32.cpp
+++ b/core/hw/arm7/arm7_rec_arm32.cpp
@@ -408,6 +408,7 @@ static void emitMSR(const ArmOp& op)
 		ass.Mov(r0, op.arg[0].getImmediate());
 	else
 		ass.Mov(r0, regalloc->map(op.arg[0].getReg().armreg));
+	ass.Mov(r1, op.psrMask);
 
 	if (op.spsr)
 		call((void *)recompiler::MSR_do<1>);

--- a/core/hw/arm7/arm7_rec_arm64.cpp
+++ b/core/hw/arm7/arm7_rec_arm64.cpp
@@ -551,6 +551,7 @@ class Arm7Compiler : public MacroAssembler
 			Mov(w0, op.arg[0].getImmediate());
 		else
 			Mov(w0, regalloc->map(op.arg[0].getReg().armreg));
+		Mov(w1, op.psrMask);
 		if (op.spsr)
 			call((void*)recompiler::MSR_do<1>);
 		else

--- a/core/hw/arm7/arm7_rec_x64.cpp
+++ b/core/hw/arm7/arm7_rec_x64.cpp
@@ -780,6 +780,7 @@ class Arm7Compiler : public Xbyak::CodeGenerator
 			mov(call_regs[0], op.arg[0].getImmediate());
 		else
 			mov(call_regs[0], regalloc->map(op.arg[0].getReg().armreg));
+		mov(call_regs[1], op.psrMask);
 		if (op.spsr)
 			call(recompiler::MSR_do<1>);
 		else


### PR DESCRIPTION
Super simple PR, this fixes audio in tip-of-branch KallistiOS versions, due to [this FIQ enable MSR](https://github.com/KallistiOS/KallistiOS/blob/master/kernel/arch/dreamcast/sound/arm/crt0.s#L113) being no-op'd with the dynarec (0xE121F000 & 0x0FBFFFF0 => 0x121f000, so the comparison to 0x0129F000 failed)

I've tested this on arm64 macOS Tahoe against my own project OpenJKDF2, and a small handful of Dreamcast games I actually owned (Tony Hawk 1+2, Crazy Taxi, Star Wars Demolition) and none had any audio issues. For the other architectures I just eyeballed the changes (but it's simple enough that it should be fine).