### PR TITLE
Add configurable save folders on Android

### DIFF
--- a/core/hw/flashrom/flashrom.cpp
+++ b/core/hw/flashrom/flashrom.cpp
@@ -42,15 +42,15 @@ void MemChip::Load(const u8 *data, size_t size)
 
 void WritableChip::Save(const std::string& file)
 {
-	FILE *f = nowide::fopen(file.c_str(), "wb");
+	hostfs::File *f = hostfs::storage().openFile(file, "wb");
 	if (f == nullptr)
 	{
 		ERROR_LOG(FLASHROM, "Cannot save flash/nvmem to file '%s'", file.c_str());
 		return;
 	}
-	if (std::fwrite(data + write_protect_size, 1, size - write_protect_size, f) != size - write_protect_size)
+	if (f->write(data + write_protect_size, 1, size - write_protect_size) != size - write_protect_size)
 		ERROR_LOG(FLASHROM, "Failed or truncated write to flash file '%s'", file.c_str());
-	std::fclose(f);
+	delete f;
 }
 
 bool MemChip::Load(const std::string &prefix, const std::string &names_ro, const std::string &title)

--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -349,7 +349,7 @@ u8 vmu_default[] = {
 
 struct maple_sega_vmu: maple_base
 {
-	FILE *file = nullptr;
+	hostfs::File *file = nullptr;
 	u8 flash_data[128_KB];
 	u8 lcd_data[192];
 	u8 lcd_data_decoded[48*32];
@@ -403,11 +403,11 @@ struct maple_sega_vmu: maple_base
 	{
 		if (file == nullptr)
 			return false;
-		if (std::fseek(file, 0, SEEK_SET) != 0) {
+		if (file->seek(0, SEEK_SET) != 0) {
 			ERROR_LOG(MAPLE, "VMU %s: I/O error", logical_port);
 			return false;
 		}
-		if (std::fwrite(flash_data, sizeof(flash_data), 1, file) != 1) {
+		if (file->write(flash_data, sizeof(flash_data), 1) != 1) {
 			ERROR_LOG(MAPLE, "Failed to write the VMU %s to disk", logical_port);
 			return false;
 		}
@@ -437,6 +437,7 @@ struct maple_sega_vmu: maple_base
         std::string rpath = hostfs::getVmuPath(logical_port, false);
         // this might be a storage url
         hostfs::File *rfile = hostfs::storage().openFile(rpath, "rb");
+        bool loadedFromExistingFile = rfile != nullptr;
         if (rfile == nullptr) {
             INFO_LOG(MAPLE, "Unable to open VMU file \"%s\", creating new file", rpath.c_str());
         }
@@ -448,19 +449,20 @@ struct maple_sega_vmu: maple_base
         }
         // Open or create the vmu file to save to
         std::string wpath = hostfs::getVmuPath(logical_port, true);
-        file = nowide::fopen(wpath.c_str(), "rb+");
+        file = hostfs::storage().openFile(wpath, "r+b");
         if (file == nullptr)
         {
-            file = nowide::fopen(wpath.c_str(), "wb+");
+            file = hostfs::storage().openFile(wpath, "w+b");
 			if (file == nullptr) {
                 ERROR_LOG(MAPLE, "Failed to create VMU save file \"%s\"", wpath.c_str());
 			}
-			else if (rfile != nullptr)
+			else if (loadedFromExistingFile)
 			{
 				// VMU file is being renamed so save it fully now
 				// and delete the old file
 				if (fullSave())
-					nowide::remove(rpath.c_str());
+					if (!hostfs::storage().remove(rpath))
+						WARN_LOG(MAPLE, "Failed to delete old VMU file '%s'", rpath.c_str());
 			}
         }
 
@@ -477,7 +479,7 @@ struct maple_sega_vmu: maple_base
 	~maple_sega_vmu() override
 	{
 		if (file != nullptr)
-			std::fclose(file);
+			delete file;
 		memset(lcd_data, 0, sizeof(lcd_data));
 		updateMapleLinkScreen();
 	}
@@ -703,8 +705,8 @@ struct maple_sega_vmu: maple_base
 								if (!fullSave())
 									return MDRE_FileError;
 							}
-							else if (std::fseek(file, write_adr, SEEK_SET) != 0
-									|| std::fwrite(&flash_data[write_adr], write_len, 1, file) != 1)
+							else if (file->seek(write_adr, SEEK_SET) != 0
+									|| file->write(&flash_data[write_adr], write_len, 1) != 1)
 							{
 								ERROR_LOG(MAPLE, "Failed to save VMU %s: I/O error", logical_port);
 								return MDRE_FileError; // I/O error
@@ -1909,7 +1911,7 @@ struct MapleLinkVmu : public maple_sega_vmu
 
 		// Ensure file is not being used
 		if (file != nullptr) {
-			std::fclose(file);
+			delete file;
 			file = nullptr;
 		}
 

--- a/core/hw/maple/maple_jvs.cpp
+++ b/core/hw/maple/maple_jvs.cpp
@@ -22,6 +22,7 @@
 #include <xxhash.h>
 #include "oslib/oslib.h"
 #include "oslib/i18n.h"
+#include "oslib/storage.h"
 #include "stdclass.h"
 #include "cfg/option.h"
 #include "network/output.h"
@@ -1613,14 +1614,14 @@ MIEImpl::MIEImpl()
 	}
 
 	std::string eeprom_file = getEepromPath();
-	FILE* f = nullptr;
+	hostfs::File* f = nullptr;
 	if (!eeprom_file.empty())
-		f = nowide::fopen(eeprom_file.c_str(), "rb");
+		f = hostfs::storage().openFile(eeprom_file, "rb");
 	if (f != nullptr)
 	{
-		if (std::fread(eeprom, 1, 0x80, f) != 0x80)
+		if (f->read(eeprom, 1, 0x80) != 0x80)
 			WARN_LOG(MAPLE, "Failed or truncated read of EEPROM '%s'", eeprom_file.c_str());
-		std::fclose(f);
+		delete f;
 		DEBUG_LOG(MAPLE, "Loaded EEPROM from %s", eeprom_file.c_str());
 	}
 	else if (naomi_default_eeprom != nullptr)
@@ -1895,11 +1896,11 @@ void MIEImpl::handle_86_subcommand()
 			std::string eeprom_file = getEepromPath();
 			if (!eeprom_file.empty())
 			{
-				FILE* f = nowide::fopen(eeprom_file.c_str(), "wb");
+				hostfs::File* f = hostfs::storage().openFile(eeprom_file, "wb");
 				if (f)
 				{
-					std::fwrite(eeprom, 1, sizeof(eeprom), f);
-					std::fclose(f);
+					f->write(eeprom, 1, sizeof(eeprom));
+					delete f;
 					INFO_LOG(MAPLE, "Saved EEPROM to %s", eeprom_file.c_str());
 				}
 				else {
@@ -2728,7 +2729,7 @@ void RFIDReaderWriterImpl::loadCard()
 	if (transientData)
 		return;
 	std::string path = getCardPath();
-	FILE *fp = nowide::fopen(path.c_str(), "rb");
+	hostfs::File *fp = hostfs::storage().openFile(path, "rb");
 	if (fp == nullptr)
 	{
 		if (settings.content.gameId.substr(0, 8) == "MKG TKOB")
@@ -2792,9 +2793,9 @@ void RFIDReaderWriterImpl::loadCard()
 	else
 	{
 		INFO_LOG(NAOMI, "Loading card file from %s", path.c_str());
-		if (fread(cardData, 1, sizeof(cardData), fp) != sizeof(cardData))
+		if (fp->read(cardData, 1, sizeof(cardData)) != sizeof(cardData))
 			WARN_LOG(NAOMI, "Truncated or empty card file: %s" ,path.c_str());
-		fclose(fp);
+		delete fp;
 	}
 }
 
@@ -2803,16 +2804,16 @@ void RFIDReaderWriterImpl::saveCard() const
 	if (transientData)
 		return;
 	std::string path = getCardPath();
-	FILE *fp = nowide::fopen(path.c_str(), "wb");
+	hostfs::File *fp = hostfs::storage().openFile(path, "wb");
 	if (fp == nullptr)
 	{
 		WARN_LOG(NAOMI, "Can't create card file %s: errno %d", path.c_str(), errno);
 		return;
 	}
 	INFO_LOG(NAOMI, "Saving card file to %s", path.c_str());
-	if (fwrite(cardData, 1, sizeof(cardData), fp) != sizeof(cardData))
+	if (fp->write(cardData, 1, sizeof(cardData)) != sizeof(cardData))
 		WARN_LOG(NAOMI, "Truncated write to file: %s", path.c_str());
-	fclose(fp);
+	delete fp;
 }
 
 void RFIDReaderWriterImpl::serialize(Serializer& ser) const

--- a/core/hw/naomi/card_reader.cpp
+++ b/core/hw/naomi/card_reader.cpp
@@ -18,6 +18,7 @@
  */
 #include "card_reader.h"
 #include "oslib/oslib.h"
+#include "oslib/storage.h"
 #include "hw/sh4/modules/modules.h"
 #include "hw/maple/maple_cfg.h"
 #include "hw/maple/maple_devs.h"
@@ -46,14 +47,14 @@ protected:
 	bool loadCard(u8 *cardData, u32 len)
 	{
 		std::string path = hostfs::getArcadeFlashPath() + ".card";
-		FILE *fp = nowide::fopen(path.c_str(), "rb");
+		hostfs::File *fp = hostfs::storage().openFile(path, "rb");
 		if (fp == nullptr)
 			return false;
 
 		INFO_LOG(NAOMI, "Loading card file from %s", path.c_str());
-		if (fread(cardData, 1, len, fp) != len)
+		if (fp->read(cardData, 1, len) != len)
 			WARN_LOG(NAOMI, "Truncated or empty card file: %s" ,path.c_str());
-		fclose(fp);
+		delete fp;
 
 		return true;
 	}
@@ -61,16 +62,16 @@ protected:
 	void saveCard(const u8 *cardData, u32 len)
 	{
 		std::string path = hostfs::getArcadeFlashPath() + ".card";
-		FILE *fp = nowide::fopen(path.c_str(), "wb");
+		hostfs::File *fp = hostfs::storage().openFile(path, "wb");
 		if (fp == nullptr)
 		{
 			WARN_LOG(NAOMI, "Can't create card file %s: errno %d", path.c_str(), errno);
 			return;
 		}
 		INFO_LOG(NAOMI, "Saving card file to %s", path.c_str());
-		if (fwrite(cardData, 1, len, fp) != len)
+		if (fp->write(cardData, 1, len) != len)
 			WARN_LOG(NAOMI, "Truncated write to file: %s", path.c_str());
-		fclose(fp);
+		delete fp;
 	}
 
 	template<typename T>

--- a/core/hw/naomi/dinokich.cpp
+++ b/core/hw/naomi/dinokich.cpp
@@ -23,6 +23,7 @@
 #include "dinokich_card.h"
 #include "cfg/option.h"
 #include "oslib/oslib.h"
+#include "oslib/storage.h"
 #include <algorithm>
 
 namespace systemsp
@@ -126,12 +127,12 @@ DinokichCardReader::DinokichCardReader(SerialPort *port, int index, const std::s
 
 	for (Slot& slot : slots_)
 	{
-		FILE *f = nowide::fopen(getCardDataPath(index).c_str(), "rb");
+		hostfs::File *f = hostfs::storage().openFile(getCardDataPath(index), "rb");
 		if (f != nullptr)
 		{
-			if (fread(slot.eeprom.data(), 1, slot.eeprom.size(), f) != slot.eeprom.size())
+			if (f->read(slot.eeprom.data(), 1, slot.eeprom.size()) != slot.eeprom.size())
 				WARN_LOG(NAOMI, "Rfid card %d: truncated read", index);
-			fclose(f);
+			delete f;
 			// TODO Decrypt card and check game credits. Renew if zero.
 		}
 		else
@@ -385,12 +386,12 @@ DinokichCardReader::Reply DinokichCardReader::on_63(const std::vector<u8>& f) {
 void DinokichCardReader::saveCard(int slotId)
 {
     Slot& slot = slots_[slotId];
-	FILE *f = nowide::fopen(getCardDataPath(index + slotId).c_str(), "wb");
+	hostfs::File *f = hostfs::storage().openFile(getCardDataPath(index + slotId), "wb");
 	if (f != nullptr)
 	{
-		if (fwrite(slot.eeprom.data(), 1, slot.eeprom.size(), f) != slot.eeprom.size())
+		if (f->write(slot.eeprom.data(), 1, slot.eeprom.size()) != slot.eeprom.size())
 			WARN_LOG(NAOMI, "Rfid card %d: truncated write", index);
-		fclose(f);
+		delete f;
 	}
 	else {
 		WARN_LOG(NAOMI, "Card saved failed to %s", getCardDataPath(index).c_str());

--- a/core/hw/naomi/hopper.cpp
+++ b/core/hw/naomi/hopper.cpp
@@ -23,6 +23,7 @@
 #include "hw/sh4/modules/modules.h"
 #include "serialize.h"
 #include "oslib/oslib.h"
+#include "oslib/storage.h"
 #include "emulator.h"
 #include "cfg/option.h"
 
@@ -44,15 +45,15 @@ public:
 		EventManager::listen(Event::Pause, handleEvent, this);
 
 		std::string path = getConfigFileName();
-		FILE *f = fopen(path.c_str(), "rb");
+		hostfs::File *f = hostfs::storage().openFile(path, "rb");
 		if (f == nullptr) {
 			INFO_LOG(NAOMI, "Hopper config not found at %s", path.c_str());
 		}
 		else
 		{
 			u8 data[4096];
-			size_t len = fread(data, 1, sizeof(data), f);
-			fclose(f);
+			size_t len = f->read(data, 1, sizeof(data));
+			delete f;
 			verify(len < sizeof(data));
 			if (len <= 0) {
 				ERROR_LOG(NAOMI, "Hopper config empty or I/O error: %s", path.c_str());
@@ -141,7 +142,7 @@ public:
 	void saveConfig() const
 	{
 		std::string path = getConfigFileName();
-		FILE *f = fopen(path.c_str(), "wb");
+		hostfs::File *f = hostfs::storage().openFile(path, "wb");
 		if (f == nullptr) {
 			ERROR_LOG(NAOMI, "Can't save hopper config to %s", path.c_str());
 			return;
@@ -152,8 +153,8 @@ public:
 		ser = Serializer(data.get(), ser.size());
 		serializeConfig(ser);
 
-		size_t len = fwrite(data.get(), 1, ser.size(), f);
-		fclose(f);
+		size_t len = f->write(data.get(), 1, ser.size());
+		delete f;
 		if (len != ser.size())
 			ERROR_LOG(NAOMI, "Hopper config I/O error: %s", path.c_str());
 	}

--- a/core/hw/naomi/systemsp.cpp
+++ b/core/hw/naomi/systemsp.cpp
@@ -128,12 +128,12 @@ public:
 	{
 		port->setPipe(this);
 
-		FILE *f = nowide::fopen(getCardDataPath().c_str(), "rb");
+		hostfs::File *f = hostfs::storage().openFile(getCardDataPath(), "rb");
 		if (f != nullptr)
 		{
-			if (fread(cardData.data(), 1, cardData.size(), f) != cardData.size())
+			if (f->read(cardData.data(), 1, cardData.size()) != cardData.size())
 				WARN_LOG(NAOMI, "Rfid card %d: truncated read", index);
-			fclose(f);
+			delete f;
 		}
 		else {
 			makeNewCard();
@@ -432,13 +432,13 @@ private:
 
 	void saveData()
 	{
-		FILE *f = nowide::fopen(getCardDataPath().c_str(), "wb");
+		hostfs::File *f = hostfs::storage().openFile(getCardDataPath(), "wb");
 		if (f == nullptr) {
 			WARN_LOG(NAOMI, "Can't save RFID card: error %x", errno);
 			return;
 		}
-		fwrite(cardData.data(), 1, cardData.size(), f);
-		fclose(f);
+		f->write(cardData.data(), 1, cardData.size());
+		delete f;
 	}
 
 	u32 dinoShuffle(u32 v) {

--- a/core/oslib/oslib.cpp
+++ b/core/oslib/oslib.cpp
@@ -109,10 +109,16 @@ std::string getArcadeFlashPath()
 {
 	// Check user-defined save path first
 	if (!config::SavePath.get().empty())
-		return config::SavePath.get() + "/" + settings.content.fileName;
+	{
+		try {
+			return hostfs::storage().getSubPath(config::SavePath, settings.content.fileName);
+		} catch (const hostfs::StorageException& e) {
+		}
+	}
 	else
 		// Fall back to default
 		return get_game_save_prefix();
+	return get_game_save_prefix();
 }
 
 std::string findFlash(const std::string& prefix, const std::string& names)
@@ -127,6 +133,17 @@ std::string findFlash(const std::string& prefix, const std::string& names)
 		size_t percent = name.find('%');
 		if (percent != npos)
 			name = name.replace(percent, 1, prefix);
+
+		// First check user-defined save paths for writable flash/NVRAM files
+		if (!config::SavePath.get().empty() && name.find("nvmem") != std::string::npos)
+		{
+			try {
+				std::string fullpath = hostfs::storage().getSubPath(config::SavePath, name);
+				if (hostfs::storage().exists(fullpath))
+					return fullpath;
+			} catch (const hostfs::StorageException& e) {
+			}
+		}
 
 		// First check user-defined BIOS paths
 		for (const auto& path : config::BiosPath.get())
@@ -163,6 +180,13 @@ std::string findFlash(const std::string& prefix, const std::string& names)
 
 std::string getFlashSavePath(const std::string& prefix, const std::string& name)
 {
+	if (!config::SavePath.get().empty() && (!prefix.empty() || !name.empty()))
+	{
+		try {
+			return hostfs::storage().getSubPath(config::SavePath, prefix + name);
+		} catch (const hostfs::StorageException& e) {
+		}
+	}
 	return get_writable_data_path(prefix + name);
 }
 

--- a/core/oslib/storage.cpp
+++ b/core/oslib/storage.cpp
@@ -41,6 +41,7 @@ CustomStorage& customStorage()
 		std::string getSubPath(const std::string& reference, const std::string& relative) override { die("Not implemented"); }
 		FileInfo getFileInfo(const std::string& path) override { die("Not implemented"); }
 		bool exists(const std::string& path) override { die("Not implemented"); }
+		bool remove(const std::string& path) override { die("Not implemented"); }
 		bool addStorage(bool isDirectory, bool writeAccess, const std::string& description,
 				void (*callback)(bool cancelled, std::string selectedPath), const std::string& mimeType) override {
 			die("Not implemented");
@@ -291,6 +292,11 @@ public:
 #endif
 	}
 
+	bool remove(const std::string& path) override
+	{
+		return nowide::remove(path.c_str()) == 0;
+	}
+
 private:
 	std::vector<FileInfo> listRoots()
 	{
@@ -398,6 +404,14 @@ bool AllStorage::exists(const std::string& path)
 		return customStorage().exists(path);
 	else
 		return stdStorage.exists(path);
+}
+
+bool AllStorage::remove(const std::string& path)
+{
+	if (customStorage().isKnownPath(path))
+		return customStorage().remove(path);
+	else
+		return stdStorage.remove(path);
 }
 
 std::string AllStorage::getDefaultDirectory()

--- a/core/oslib/storage.h
+++ b/core/oslib/storage.h
@@ -133,6 +133,7 @@ public:
 	virtual std::string getSubPath(const std::string& reference, const std::string& subpath) = 0;
 	virtual FileInfo getFileInfo(const std::string& path) = 0;
 	virtual bool exists(const std::string& path) = 0;
+	virtual bool remove(const std::string& path) = 0;
 
 	virtual ~Storage() = default;
 };
@@ -155,6 +156,7 @@ public:
 	std::string getSubPath(const std::string& reference, const std::string& subpath) override;
 	FileInfo getFileInfo(const std::string& path) override;
 	bool exists(const std::string& path) override;
+	bool remove(const std::string& path) override;
 	std::string getDefaultDirectory();
 };
 

--- a/core/ui/settings_general.cpp
+++ b/core/ui/settings_general.cpp
@@ -24,18 +24,524 @@
 #include "stdclass.h"
 #include "achievements/achievements.h"
 #include "imgui_stdlib.h"
+#include <array>
+#include <cstring>
+
+enum class SaveMigrationKind
+{
+	None,
+	Vmu,
+	Savestate,
+	GameSave,
+};
 
 static std::vector<std::string>* g_currentPathList = nullptr;
+static std::string* g_currentSinglePath = nullptr;
+static SaveMigrationKind g_currentMigrationKind = SaveMigrationKind::None;
+
+static void manageSinglePathCallback(std::string selection);
+static void managePathListCallback(std::string selection);
+static void handlePathSelection(SaveMigrationKind kind, std::string selection);
+
+#ifdef __ANDROID__
+struct SaveMigrationFile
+{
+	std::string name;
+	std::string source;
+	std::string destination;
+};
+
+enum class SaveMigrationPhase
+{
+	Idle,
+	Copying,
+	Verifying,
+	Deleting,
+};
+
+struct SaveMigrationState
+{
+	SaveMigrationKind kind = SaveMigrationKind::None;
+	std::string* singlePath = nullptr;
+	std::vector<std::string>* pathList = nullptr;
+	std::string selection;
+	std::vector<SaveMigrationFile> files;
+	std::vector<SaveMigrationFile> conflicts;
+	hostfs::File *sourceFile = nullptr;
+	hostfs::File *destinationFile = nullptr;
+	SaveMigrationPhase phase = SaveMigrationPhase::Idle;
+	size_t currentIndex = 0;
+	s64 currentFileSize = 0;
+	s64 copiedBytes = 0;
+	s64 verifiedBytes = 0;
+	bool moveExisting = false;
+	bool overwriteConflicts = false;
+	bool running = false;
+	bool failed = false;
+	bool openActionPopup = false;
+	bool openConflictPopup = false;
+	bool openProgressPopup = false;
+};
+
+static SaveMigrationState g_saveMigration;
+static constexpr size_t SaveMigrationChunkSize = 128 * 1024;
+
+static void closeSaveMigrationFiles()
+{
+	delete g_saveMigration.destinationFile;
+	g_saveMigration.destinationFile = nullptr;
+	delete g_saveMigration.sourceFile;
+	g_saveMigration.sourceFile = nullptr;
+}
+
+static void resetSaveMigration()
+{
+	closeSaveMigrationFiles();
+	g_currentSinglePath = nullptr;
+	g_currentPathList = nullptr;
+	g_currentMigrationKind = SaveMigrationKind::None;
+	g_saveMigration = {};
+}
+
+static bool endsWith(const std::string& value, const char *suffix)
+{
+	size_t len = strlen(suffix);
+	return value.size() >= len && value.compare(value.size() - len, len, suffix) == 0;
+}
+
+static bool isMigratableSaveFile(SaveMigrationKind kind, std::string name)
+{
+	string_tolower(name);
+	switch (kind)
+	{
+	case SaveMigrationKind::Vmu:
+		return name.find("vmu_save") != std::string::npos && endsWith(name, ".bin");
+	case SaveMigrationKind::Savestate:
+		return endsWith(name, ".state") || endsWith(name, ".state.net") || endsWith(name, ".state.tmp");
+	case SaveMigrationKind::GameSave:
+		return name.find("nvmem") != std::string::npos
+			|| endsWith(name, ".eeprom")
+			|| endsWith(name, ".card")
+			|| endsWith(name, "-hopper.bin");
+	default:
+		return false;
+	}
+}
+
+static void addUniquePath(std::vector<std::string>& paths, const std::string& path)
+{
+	if (!path.empty() && std::find(paths.begin(), paths.end(), path) == paths.end())
+		paths.push_back(path);
+}
+
+static void collectSaveMigrationFiles(SaveMigrationKind kind, const std::vector<std::string>& sourcePaths,
+		const std::string& destinationPath, std::vector<SaveMigrationFile>& files)
+{
+	for (const auto& sourcePath : sourcePaths)
+	{
+		try {
+			for (const hostfs::FileInfo& info : hostfs::storage().listContent(sourcePath))
+			{
+				if (info.isDirectory || !isMigratableSaveFile(kind, info.name))
+					continue;
+
+				std::string destination = hostfs::storage().getSubPath(destinationPath, info.name);
+				if (destination == info.path)
+					continue;
+				files.push_back({ info.name, info.path, destination });
+			}
+		} catch (const FlycastException& e) {
+			WARN_LOG(COMMON, "Save migration: can't scan '%s': %s", sourcePath.c_str(), e.what());
+		}
+	}
+}
+
+static bool openCurrentMigrationFile()
+{
+	const SaveMigrationFile& file = g_saveMigration.files[g_saveMigration.currentIndex];
+	g_saveMigration.currentFileSize = 0;
+	g_saveMigration.copiedBytes = 0;
+	g_saveMigration.verifiedBytes = 0;
+	if (!g_saveMigration.moveExisting
+			|| (!g_saveMigration.overwriteConflicts && hostfs::storage().exists(file.destination)))
+	{
+		g_saveMigration.phase = SaveMigrationPhase::Deleting;
+		return true;
+	}
+
+	g_saveMigration.sourceFile = hostfs::storage().openFile(file.source, "rb");
+	if (g_saveMigration.sourceFile == nullptr)
+	{
+		g_saveMigration.failed = true;
+		g_saveMigration.currentIndex++;
+		return false;
+	}
+	g_saveMigration.destinationFile = hostfs::storage().openFile(file.destination, "wb");
+	if (g_saveMigration.destinationFile == nullptr)
+	{
+		closeSaveMigrationFiles();
+		g_saveMigration.failed = true;
+		g_saveMigration.currentIndex++;
+		return false;
+	}
+	g_saveMigration.currentFileSize = g_saveMigration.sourceFile->size();
+	g_saveMigration.phase = SaveMigrationPhase::Copying;
+	return true;
+}
+
+static void failCurrentMigrationFile(bool removeDestination)
+{
+	const SaveMigrationFile& file = g_saveMigration.files[g_saveMigration.currentIndex];
+	closeSaveMigrationFiles();
+	if (removeDestination)
+		hostfs::storage().remove(file.destination);
+	g_saveMigration.failed = true;
+	g_saveMigration.currentIndex++;
+	g_saveMigration.phase = SaveMigrationPhase::Idle;
+}
+
+static void startCurrentMigrationVerification()
+{
+	const SaveMigrationFile& file = g_saveMigration.files[g_saveMigration.currentIndex];
+	closeSaveMigrationFiles();
+	g_saveMigration.sourceFile = hostfs::storage().openFile(file.source, "rb");
+	g_saveMigration.destinationFile = hostfs::storage().openFile(file.destination, "rb");
+	if (g_saveMigration.sourceFile == nullptr || g_saveMigration.destinationFile == nullptr
+			|| g_saveMigration.sourceFile->size() != g_saveMigration.destinationFile->size())
+	{
+		failCurrentMigrationFile(true);
+		return;
+	}
+	g_saveMigration.currentFileSize = g_saveMigration.sourceFile->size();
+	g_saveMigration.verifiedBytes = 0;
+	g_saveMigration.phase = SaveMigrationPhase::Verifying;
+}
+
+static bool processSaveMigrationStep()
+{
+	static std::array<u8, SaveMigrationChunkSize> sourceBuffer;
+	static std::array<u8, SaveMigrationChunkSize> destinationBuffer;
+
+	if (g_saveMigration.currentIndex >= g_saveMigration.files.size())
+		return true;
+
+	if (g_saveMigration.phase == SaveMigrationPhase::Idle && !openCurrentMigrationFile())
+		return g_saveMigration.currentIndex >= g_saveMigration.files.size();
+
+	const SaveMigrationFile& file = g_saveMigration.files[g_saveMigration.currentIndex];
+	switch (g_saveMigration.phase)
+	{
+	case SaveMigrationPhase::Copying:
+	{
+		size_t read = g_saveMigration.sourceFile->read(sourceBuffer.data(), 1, sourceBuffer.size());
+		if (read > 0)
+		{
+			if (g_saveMigration.destinationFile->write(sourceBuffer.data(), 1, read) != read)
+			{
+				failCurrentMigrationFile(true);
+				return false;
+			}
+			g_saveMigration.copiedBytes += read;
+			return false;
+		}
+		if (g_saveMigration.sourceFile->error() != 0 || g_saveMigration.destinationFile->error() != 0
+				|| g_saveMigration.copiedBytes != g_saveMigration.currentFileSize)
+		{
+			failCurrentMigrationFile(true);
+			return false;
+		}
+		startCurrentMigrationVerification();
+		return false;
+	}
+	case SaveMigrationPhase::Verifying:
+	{
+		size_t sourceRead = g_saveMigration.sourceFile->read(sourceBuffer.data(), 1, sourceBuffer.size());
+		size_t destinationRead = g_saveMigration.destinationFile->read(destinationBuffer.data(), 1, destinationBuffer.size());
+		if (sourceRead != destinationRead || std::memcmp(sourceBuffer.data(), destinationBuffer.data(), sourceRead) != 0)
+		{
+			failCurrentMigrationFile(true);
+			return false;
+		}
+		if (sourceRead > 0)
+		{
+			g_saveMigration.verifiedBytes += sourceRead;
+			return false;
+		}
+		if (g_saveMigration.sourceFile->error() != 0 || g_saveMigration.destinationFile->error() != 0
+				|| g_saveMigration.verifiedBytes != g_saveMigration.currentFileSize)
+		{
+			failCurrentMigrationFile(true);
+			return false;
+		}
+		closeSaveMigrationFiles();
+		g_saveMigration.phase = SaveMigrationPhase::Deleting;
+		return false;
+	}
+	case SaveMigrationPhase::Deleting:
+		if (!hostfs::storage().remove(file.source))
+			g_saveMigration.failed = true;
+		g_saveMigration.currentIndex++;
+		g_saveMigration.phase = SaveMigrationPhase::Idle;
+		return g_saveMigration.currentIndex >= g_saveMigration.files.size();
+	default:
+		return false;
+	}
+}
+
+static void finishSaveMigrationSelection()
+{
+	if (g_saveMigration.singlePath != nullptr)
+		*g_saveMigration.singlePath = g_saveMigration.selection;
+	else if (g_saveMigration.pathList != nullptr)
+	{
+		g_saveMigration.pathList->erase(std::remove(g_saveMigration.pathList->begin(), g_saveMigration.pathList->end(),
+				g_saveMigration.selection), g_saveMigration.pathList->end());
+		if (g_saveMigration.kind == SaveMigrationKind::Savestate)
+			g_saveMigration.pathList->insert(g_saveMigration.pathList->begin(), g_saveMigration.selection);
+		else
+			g_saveMigration.pathList->push_back(g_saveMigration.selection);
+	}
+
+	resetSaveMigration();
+}
+
+static void beginSaveMigrationRun(bool overwriteConflicts)
+{
+	closeSaveMigrationFiles();
+	g_saveMigration.overwriteConflicts = overwriteConflicts;
+	g_saveMigration.currentIndex = 0;
+	g_saveMigration.currentFileSize = 0;
+	g_saveMigration.copiedBytes = 0;
+	g_saveMigration.verifiedBytes = 0;
+	g_saveMigration.phase = SaveMigrationPhase::Idle;
+	g_saveMigration.running = true;
+	g_saveMigration.failed = false;
+	g_saveMigration.openProgressPopup = true;
+}
+
+static void continueSaveMigration(bool moveExisting)
+{
+	g_saveMigration.moveExisting = moveExisting;
+	if (!moveExisting)
+	{
+		beginSaveMigrationRun(false);
+		return;
+	}
+
+	g_saveMigration.conflicts.clear();
+	for (const SaveMigrationFile& file : g_saveMigration.files)
+	{
+		if (hostfs::storage().exists(file.destination))
+			g_saveMigration.conflicts.push_back(file);
+	}
+	if (g_saveMigration.conflicts.empty())
+		beginSaveMigrationRun(false);
+	else
+		g_saveMigration.openConflictPopup = true;
+}
+
+static void startSaveMigration(SaveMigrationKind kind, std::string selection)
+{
+	g_saveMigration.kind = kind;
+	g_saveMigration.singlePath = g_currentSinglePath;
+	g_saveMigration.pathList = g_currentPathList;
+	g_saveMigration.selection = std::move(selection);
+	g_saveMigration.files.clear();
+	g_saveMigration.conflicts.clear();
+
+	std::vector<std::string> sourcePaths;
+	addUniquePath(sourcePaths, get_writable_data_path(""));
+	if (kind == SaveMigrationKind::Vmu)
+	{
+		addUniquePath(sourcePaths, config::VMUPath.get());
+		addUniquePath(sourcePaths, get_writable_config_path(""));
+	}
+	else if (kind == SaveMigrationKind::Savestate)
+	{
+		for (const auto& path : config::SavestatePath.get())
+			addUniquePath(sourcePaths, path);
+	}
+	else if (kind == SaveMigrationKind::GameSave)
+	{
+		addUniquePath(sourcePaths, config::SavePath.get());
+	}
+
+	collectSaveMigrationFiles(kind, sourcePaths, g_saveMigration.selection, g_saveMigration.files);
+	if (g_saveMigration.files.empty())
+		finishSaveMigrationSelection();
+	else
+		g_saveMigration.openActionPopup = true;
+}
+
+static void handlePathSelection(SaveMigrationKind kind, std::string selection)
+{
+	if (kind == SaveMigrationKind::None)
+	{
+		if (g_currentSinglePath != nullptr)
+			manageSinglePathCallback(selection);
+		else
+			managePathListCallback(selection);
+	}
+	else
+		startSaveMigration(kind, std::move(selection));
+}
+
+static void centerNextSaveMigrationPopup()
+{
+	const ImGuiViewport *viewport = ImGui::GetMainViewport();
+	ImGui::SetNextWindowPos(ImVec2(viewport->WorkPos.x + viewport->WorkSize.x * 0.5f,
+			viewport->WorkPos.y + viewport->WorkSize.y * 0.5f),
+			ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+}
+
+static void centerCurrentSaveMigrationPopup()
+{
+	const ImGuiViewport *viewport = ImGui::GetMainViewport();
+	const ImVec2 size = ImGui::GetWindowSize();
+	ImGui::SetWindowPos(ImVec2(
+			viewport->WorkPos.x + (viewport->WorkSize.x - size.x) * 0.5f,
+			viewport->WorkPos.y + (viewport->WorkSize.y - size.y) * 0.5f));
+}
+
+static void drawSaveMigrationPopups()
+{
+	const char *actionPopup = T("Move existing saves?");
+	if (g_saveMigration.openActionPopup)
+	{
+		ImGui::OpenPopup(actionPopup);
+		g_saveMigration.openActionPopup = false;
+	}
+	centerNextSaveMigrationPopup();
+	if (ImGui::BeginPopupModal(actionPopup, nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove))
+	{
+		centerCurrentSaveMigrationPopup();
+		ImGui::TextWrapped("%s", T("Move existing saves to the selected folder? Choosing Delete removes the originals instead."));
+		ImGui::Spacing();
+		if (ImGui::Button(T("Move"), ScaledVec2(100.f, 0)))
+		{
+			ImGui::CloseCurrentPopup();
+			continueSaveMigration(true);
+		}
+		ImGui::SameLine();
+		if (ImGui::Button(T("Delete"), ScaledVec2(100.f, 0)))
+		{
+			ImGui::CloseCurrentPopup();
+			continueSaveMigration(false);
+		}
+		ImGui::SameLine();
+		if (ImGui::Button(T("Cancel"), ScaledVec2(100.f, 0)))
+		{
+			resetSaveMigration();
+			ImGui::CloseCurrentPopup();
+		}
+		ImGui::EndPopup();
+	}
+
+	const char *conflictPopup = T("Save files already exist");
+	if (g_saveMigration.openConflictPopup)
+	{
+		ImGui::OpenPopup(conflictPopup);
+		g_saveMigration.openConflictPopup = false;
+	}
+	centerNextSaveMigrationPopup();
+	if (ImGui::BeginPopupModal(conflictPopup, nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove))
+	{
+		centerCurrentSaveMigrationPopup();
+		ImGui::TextWrapped("%s", T("The selected folder already contains save files with the same names. Skip keeps those files and deletes the old originals."));
+		ImGui::Spacing();
+		if (ImGui::Button(T("Overwrite"), ScaledVec2(120.f, 0)))
+		{
+			ImGui::CloseCurrentPopup();
+			beginSaveMigrationRun(true);
+		}
+		ImGui::SameLine();
+		if (ImGui::Button(T("Skip"), ScaledVec2(100.f, 0)))
+		{
+			ImGui::CloseCurrentPopup();
+			beginSaveMigrationRun(false);
+		}
+		ImGui::SameLine();
+		if (ImGui::Button(T("Cancel"), ScaledVec2(100.f, 0)))
+		{
+			resetSaveMigration();
+			ImGui::CloseCurrentPopup();
+		}
+		ImGui::EndPopup();
+	}
+
+	const char *progressPopup = T("Migrating saves");
+	if (g_saveMigration.openProgressPopup)
+	{
+		ImGui::OpenPopup(progressPopup);
+		g_saveMigration.openProgressPopup = false;
+	}
+	centerNextSaveMigrationPopup();
+	if (ImGui::BeginPopupModal(progressPopup, nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove))
+	{
+		centerCurrentSaveMigrationPopup();
+		size_t totalFiles = g_saveMigration.files.size();
+		size_t currentFileIndex = std::min(g_saveMigration.currentIndex, totalFiles);
+		float fileProgress = 0.f;
+		if (g_saveMigration.currentIndex < totalFiles && g_saveMigration.currentFileSize > 0)
+		{
+			if (g_saveMigration.phase == SaveMigrationPhase::Copying)
+				fileProgress = std::min(1.f, (float)g_saveMigration.copiedBytes / g_saveMigration.currentFileSize);
+			else if (g_saveMigration.phase == SaveMigrationPhase::Verifying)
+				fileProgress = std::min(1.f, (float)g_saveMigration.verifiedBytes / g_saveMigration.currentFileSize);
+			else if (g_saveMigration.phase == SaveMigrationPhase::Deleting)
+				fileProgress = 1.f;
+		}
+		float totalProgress = totalFiles == 0 ? 1.f : (currentFileIndex + fileProgress) / totalFiles;
+		ImGui::Text("%s", T("Migrating save files..."));
+		if (g_saveMigration.currentIndex < totalFiles)
+			ImGui::TextWrapped("%s", g_saveMigration.files[g_saveMigration.currentIndex].name.c_str());
+		ImGui::ProgressBar(totalProgress, ScaledVec2(320.f, 0));
+		ImGui::Text("%zu / %zu", currentFileIndex, totalFiles);
+
+		if (processSaveMigrationStep())
+		{
+			bool failed = g_saveMigration.failed;
+			ImGui::CloseCurrentPopup();
+			if (failed)
+				gui_error(Ts("Some save files could not be migrated or deleted."));
+			finishSaveMigrationSelection();
+		}
+		ImGui::EndPopup();
+	}
+}
+#else
+static void handlePathSelection(SaveMigrationKind kind, std::string selection)
+{
+	(void)kind;
+	if (g_currentSinglePath != nullptr)
+		manageSinglePathCallback(std::move(selection));
+	else
+		managePathListCallback(std::move(selection));
+}
+#endif
+
+static void manageSinglePathCallback(std::string selection)
+{
+    if (g_currentSinglePath != nullptr)
+    {
+        *g_currentSinglePath = selection;
+        g_currentSinglePath = nullptr;
+        g_currentMigrationKind = SaveMigrationKind::None;
+    }
+}
+
 static void managePathListCallback(std::string selection)
 {
     if (g_currentPathList != nullptr)
     {
         g_currentPathList->push_back(selection);
         g_currentPathList = nullptr;
+        g_currentMigrationKind = SaveMigrationKind::None;
     }
 }
 
-static void manageSinglePath(const char* label, const char *popupName, config::Option<std::string, false>& pathOption, const char* helpText)
+static void manageSinglePath(const char* label, const char *popupName, config::Option<std::string, false>& pathOption, const char* helpText,
+		bool writeAccess = false, SaveMigrationKind migrationKind = SaveMigrationKind::None)
 {
     ImVec2 size;
     size.x = 0.0f;
@@ -48,7 +554,7 @@ static void manageSinglePath(const char* label, const char *popupName, config::O
         ImGui::AlignTextToFramePadding();
         if (pathOption.get().empty()) {
             ImguiStyleVar _(ImGuiStyleVar_FramePadding, ScaledVec2(24, 3));
-            std::string buttonLabel = T("Set") + std::string("##") + label;
+            std::string buttonLabel = T("Add") + std::string("##") + label;
             openPopup = ImGui::Button(buttonLabel.c_str());
         }
         else
@@ -67,18 +573,40 @@ static void manageSinglePath(const char* label, const char *popupName, config::O
     ImGui::SameLine();
     ShowHelpMarker(helpText);
     
-    static std::string *pCurrentPath;
-    pCurrentPath = &pathOption.get();
     select_file_popup(popupName, [](bool cancelled, std::string selection) {
-    	if (!cancelled)
-    		*pCurrentPath = selection;
+		if (!cancelled)
+			handlePathSelection(g_currentMigrationKind, std::move(selection));
+		else
+		{
+			g_currentSinglePath = nullptr;
+			g_currentMigrationKind = SaveMigrationKind::None;
+		}
     	return true;
     });
     if (openPopup)
+    {
+        g_currentSinglePath = &pathOption.get();
+        g_currentMigrationKind = migrationKind;
+#ifdef __ANDROID__
+		bool supported = hostfs::addStorage(true, writeAccess, T(popupName), [](bool cancelled, std::string selection) {
+			if (!cancelled)
+				handlePathSelection(g_currentMigrationKind, std::move(selection));
+			else
+			{
+				g_currentSinglePath = nullptr;
+				g_currentMigrationKind = SaveMigrationKind::None;
+			}
+		});
+		if (!supported)
+			ImGui::OpenPopup(T(popupName));
+#else
         ImGui::OpenPopup(T(popupName));
+#endif
+    }
 }
 
-static void managePathList(const char* label, const char *popupName, std::vector<std::string>& paths, const char* helpText)
+static void managePathList(const char* label, const char *popupName, std::vector<std::string>& paths, const char* helpText,
+		bool writeAccess = false, SaveMigrationKind migrationKind = SaveMigrationKind::None)
 {
     ImguiID _(label);
     ImVec2 size;
@@ -120,18 +648,31 @@ static void managePathList(const char* label, const char *popupName, std::vector
 
     // Handle file selection popup (following the same pattern as addContentPath)
     if (openPopup)
+    {
 	    g_currentPathList = &paths;
+	    g_currentMigrationKind = migrationKind;
+    }
     select_file_popup(popupName, [](bool cancelled, std::string selection) {
-    	if (!cancelled)
-    		managePathListCallback(selection);
+		if (!cancelled)
+			handlePathSelection(g_currentMigrationKind, std::move(selection));
+		else
+		{
+			g_currentPathList = nullptr;
+			g_currentMigrationKind = SaveMigrationKind::None;
+		}
     	return true;
     });
 #ifdef __ANDROID__
     if (openPopup)
     {
-		bool supported = hostfs::addStorage(true, false, T(popupName), [](bool cancelled, std::string selection) {
+		bool supported = hostfs::addStorage(true, writeAccess, T(popupName), [](bool cancelled, std::string selection) {
 			if (!cancelled)
-				managePathListCallback(selection);
+				handlePathSelection(g_currentMigrationKind, std::move(selection));
+			else
+			{
+				g_currentPathList = nullptr;
+				g_currentMigrationKind = SaveMigrationKind::None;
+			}
 		});
 		if (!supported)
 			ImGui::OpenPopup(T(popupName));
@@ -182,6 +723,9 @@ void addContentPath(bool start)
 
 void gui_settings_general()
 {
+#ifdef __ANDROID__
+	drawSaveMigrationPopups();
+#endif
 	struct
 	{
 		const char* label;
@@ -467,19 +1011,20 @@ void gui_settings_general()
     		T("Folders containing BIOS files (e.g. dc_boot.bin or dc_bios.bin) and arcade BIOS"));
     ImGui::Spacing();
 
-#if !defined(__ANDROID__)
     manageSinglePath(T("VMU Folder"), T("Select the VMU folder"), config::VMUPath,
-    		T("Folder where VMU (.bin) saves are stored"));
+			T("Folder where VMU (.bin) saves are stored. This can be the same folder as save states and game saves"),
+			true, SaveMigrationKind::Vmu);
     ImGui::Spacing();
 
     managePathList(T("Savestate Folders"), T("Select a savestate folder"), config::SavestatePath.get(),
-    		T("Folders for save states. First path is used for new states; all are searched when loading"));
+			T("Folders for save states. First path is used for new states; all are searched when loading. This can be the same folder as VMUs and game saves"),
+			true, SaveMigrationKind::Savestate);
     ImGui::Spacing();
 
     manageSinglePath(T("Game Save Folder"), T("Select the game save folder"), config::SavePath,
-    		T("Folder for game save data (e.g. arcade NVRAM)"));
+			T("Folder for Dreamcast internal flash and arcade NVRAM/card data. This can be the same folder as VMUs and save states"),
+			true, SaveMigrationKind::GameSave);
     ImGui::Spacing();
-#endif
 
     managePathList(T("Texture Pack Folders"), T("Select a texture pack folder"), config::TexturePath.get(),
     		T("Folders containing textures/<gameId> or <gameId> under a textures subfolder"));

--- a/shell/android-studio/flycast/src/main/java/com/flycast/emulator/AndroidStorage.java
+++ b/shell/android-studio/flycast/src/main/java/com/flycast/emulator/AndroidStorage.java
@@ -101,8 +101,49 @@ public class AndroidStorage {
     }
 
     public int openFile(String uri, String mode) throws FileNotFoundException {
-        ParcelFileDescriptor pfd = activity.getContentResolver().openFileDescriptor(Uri.parse(uri), mode);
+        Uri parsedUri = Uri.parse(uri);
+        ParcelFileDescriptor pfd;
+        try {
+            pfd = activity.getContentResolver().openFileDescriptor(parsedUri, mode);
+        } catch (Exception e) {
+            if (!mode.contains("w")) {
+                if (e instanceof FileNotFoundException)
+                    throw (FileNotFoundException)e;
+                FileNotFoundException fnfe = new FileNotFoundException(uri);
+                fnfe.initCause(e);
+                throw fnfe;
+            }
+            parsedUri = createMissingDocument(parsedUri);
+            if (parsedUri == null) {
+                if (e instanceof FileNotFoundException)
+                    throw (FileNotFoundException)e;
+                FileNotFoundException fnfe = new FileNotFoundException(uri);
+                fnfe.initCause(e);
+                throw fnfe;
+            }
+            pfd = activity.getContentResolver().openFileDescriptor(parsedUri, mode);
+        }
         return pfd.detachFd();
+    }
+
+    private Uri createMissingDocument(Uri uri)
+    {
+        try {
+            if (!DocumentsContract.isDocumentUri(activity, uri))
+                return null;
+            String documentId = DocumentsContract.getDocumentId(uri);
+            int separator = documentId.lastIndexOf('/');
+            if (separator < 0 || separator == documentId.length() - 1)
+                return null;
+            String parentId = documentId.substring(0, separator);
+            String name = documentId.substring(separator + 1);
+            Uri parentUri = DocumentsContract.buildDocumentUriUsingTree(uri, parentId);
+            return DocumentsContract.createDocument(activity.getContentResolver(), parentUri,
+                    "application/octet-stream", name);
+        } catch (Exception e) {
+            Log.w("Flycast", "Failed to create document: " + uri, e);
+            return null;
+        }
     }
 
     public InputStream openInputStream(String uri) throws FileNotFoundException {
@@ -248,6 +289,21 @@ public class AndroidStorage {
         } finally {
             if (cursor != null)
                 cursor.close();
+        }
+    }
+
+    public boolean remove(String uriString)
+    {
+        Uri uri = Uri.parse(uriString);
+        try {
+            if (DocumentsContract.isDocumentUri(activity, uri)) {
+                return DocumentsContract.deleteDocument(activity.getContentResolver(), uri);
+            }
+            DocumentFile docFile = DocumentFile.fromTreeUri(activity, uri);
+            return docFile != null && docFile.delete();
+        } catch (Exception e) {
+            Log.w("Flycast", "Failed to delete: " + uriString, e);
+            return false;
         }
     }
 

--- a/shell/android-studio/flycast/src/main/jni/src/android_storage.h
+++ b/shell/android-studio/flycast/src/main/jni/src/android_storage.h
@@ -39,6 +39,7 @@ public:
 		jgetSubPath = env->GetMethodID(clazz, "getSubPath", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
 		jgetFileInfo = env->GetMethodID(clazz, "getFileInfo", "(Ljava/lang/String;)Lcom/flycast/emulator/FileInfo;");
 		jexists = env->GetMethodID(clazz, "exists", "(Ljava/lang/String;)Z");
+		jremove = env->GetMethodID(clazz, "remove", "(Ljava/lang/String;)Z");
 		jaddStorage = env->GetMethodID(clazz, "addStorage", "(ZZLjava/lang/String;Ljava/lang/String;)Z");
 		jsaveScreenshot = env->GetMethodID(clazz, "saveScreenshot", "(Ljava/lang/String;[B)V");
 		jimportHomeDirectory = env->GetMethodID(clazz, "importHomeDirectory", "()V");
@@ -142,6 +143,18 @@ public:
 		}
 	}
 
+	bool remove(const std::string& uri) override
+	{
+		jni::String juri(uri);
+		bool ret = jni::env()->CallBooleanMethod(jstorage, jremove, (jstring)juri);
+		try {
+			checkException();
+			return ret;
+		} catch (...) {
+			return false;
+		}
+	}
+
 	bool addStorage(bool isDirectory, bool writeAccess, const std::string& description,
 			void (*callback)(bool cancelled, std::string selectedPath), const std::string& mimeType) override
 	{
@@ -237,6 +250,7 @@ private:
 	jmethodID jgetSubPath;
 	jmethodID jgetFileInfo;
 	jmethodID jexists;
+	jmethodID jremove;
 	jmethodID jsaveScreenshot;
 	jmethodID jexportHomeDirectory;
 	jmethodID jimportHomeDirectory;

--- a/shell/libretro/storage.cpp
+++ b/shell/libretro/storage.cpp
@@ -178,6 +178,11 @@ bool hostfs::LibretroStorage::exists(const std::string& path)
 	return filestream_exists(path.c_str());
 }
 
+bool hostfs::LibretroStorage::remove(const std::string& path)
+{
+	return filestream_delete(path.c_str()) == 0;
+}
+
 bool hostfs::LibretroStorage::addStorage(bool isDirectory, bool writeAccess, const std::string& description,
 		void (*callback)(bool cancelled, std::string selectedPath), const std::string& mimeType)
 {

--- a/shell/libretro/storage.h
+++ b/shell/libretro/storage.h
@@ -103,6 +103,7 @@ public:
 	std::string getSubPath(const std::string& reference, const std::string& relative) override;
 	FileInfo getFileInfo(const std::string& path) override;
 	bool exists(const std::string& path) override;
+	bool remove(const std::string& path) override;
 	bool addStorage(bool isDirectory, bool writeAccess, const std::string& description,
 			void (*callback)(bool cancelled, std::string selectedPath), const std::string& mimeType) override;
 };


### PR DESCRIPTION
Added code so that users can choose where to move or write saves to (for VMU, Savestates & Game Saves). 

In General, under Custom Paths, added three new options for VMU Folder, Savestate Folders & Game Save Folder. Users can click Add, navigate using SAF and choose a different directory to store data in. If there already is saves, it will ask the user if they want to move them to this new directory as well. Choosing not to will delete so there's no leftover files.

The main reason for this PR and code is there are devices that cannot access scoped storage and so can't backup saves easily, can't access the saves, and so on. Newer devices lock scoped storage access, this lets users have access to them.

This was tested on my end using a few devices, everything seems to work as intended - but could use more testers on this to triple check. 

_Created with the help of Claude AI._ 