### PR TITLE
Handle unknown keys for manual mapping in Android

### DIFF
--- a/shell/android-studio/flycast/src/main/java/com/flycast/emulator/BaseGLActivity.java
+++ b/shell/android-studio/flycast/src/main/java/com/flycast/emulator/BaseGLActivity.java
@@ -345,8 +345,21 @@ public abstract class BaseGLActivity extends Activity implements ActivityCompat.
         return super.onGenericMotionEvent(event);
     }
 
+    private static int scrubKeyCode(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_UNKNOWN) {
+            // Android subsystem was not able to translate this event, so use the scan code instead
+            keyCode = event.getScanCode();
+            if (keyCode > 0) {
+                // Scan codes to key code conversion must be negative to avoid stomping on existing codes
+                keyCode = -keyCode;
+            }
+        }
+        return keyCode;
+    }
+
     @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {
+        keyCode = scrubKeyCode(keyCode, event);
         if (InputDeviceManager.getInstance().buttonEvent(event.getDeviceId(), keyCode, false))
             return true;
         if (hasKeyboard && InputDeviceManager.getInstance().keyboardEvent(keyCode, false))
@@ -356,6 +369,7 @@ public abstract class BaseGLActivity extends Activity implements ActivityCompat.
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
+        keyCode = scrubKeyCode(keyCode, event);
         if (event.getRepeatCount() == 0) {
             if (keyCode == KeyEvent.KEYCODE_BACK) {
                 if (JNIdc.guiIsContentBrowser()) {
@@ -477,11 +491,11 @@ public abstract class BaseGLActivity extends Activity implements ActivityCompat.
     }
 
     private static native void register(BaseGLActivity activity);
-    
+
 	public String getNativeLibDir() {
         return getApplicationContext().getApplicationInfo().nativeLibraryDir;
     }
-    
+
 	public String getInternalFilesDir() {
         return getFilesDir().getAbsolutePath();
     }


### PR DESCRIPTION
For gamepads with many buttons, the Linux kernel maps extra button bits to `BTN_TRIGGER_HAPPY*` input event key codes. Android's framework does not have corresponding `KEYCODE` definitions for these events in its default key layout files, causing them to resolve to `KEYCODE_UNKNOWN`. This fix intercepts unmapped events and uses the negation of the raw Linux scan code as an internal identifier so flycast can still bind them.

I'm open to changing this to limit to only `BTN_TRIGGER_HAPPY*` scan codes ([0x2c0 to 0x2e7](https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h#L794C9-L794C29)) if this seems too heavy-handed.