### PR TITLE
libretro: report exact SPG refresh rate

### DIFF
--- a/core/hw/pvr/spg.cpp
+++ b/core/hw/pvr/spg.cpp
@@ -64,7 +64,9 @@ void CalculateSync()
 	sh4_sched_request(vblank_schid, Line_Cycles);
 
 #ifdef LIBRETRO
-	retro_refresh_av_info((double)SH4_MAIN_CLOCK / ((double)Line_Cycles * (double)pvr_numscanlines));
+	const double exact_refresh = (double)pixel_clock * (SPG_CONTROL.interlace ? 2.0 : 1.0)
+			/ ((double)(SPG_LOAD.hcount + 1) * (double)pvr_numscanlines);
+	retro_refresh_av_info(exact_refresh);
 #endif
 }
 

--- a/shell/libretro/libretro.cpp
+++ b/shell/libretro/libretro.cpp
@@ -744,7 +744,7 @@ static void setGameGeometry(retro_game_geometry& geometry)
 bool setAVInfo(retro_system_av_info& avinfo)
 {
 	double sample_rate = 44100.0;
-	double fps = (fps_spg) ? fps_spg : SPG_CONTROL.isPAL() ? 50.0 : 59.945300;
+	double fps = (fps_spg) ? fps_spg : SPG_CONTROL.isPAL() ? 50.0 : 59.940060;
 
 	setGameGeometry(avinfo.geometry);
 	avinfo.timing.sample_rate = sample_rate;


### PR DESCRIPTION
This is a small follow-up to https://github.com/flyinghead/flycast/pull/2396

The SPG-based AVInfo update currently derives the reported refresh from the scheduler's integer `Line_Cycles`, which includes the scheduler's internal quantization.

For Dreamcast VGA:

`200000000 * 858 / 27000000 = 6355.555...`

Because `Line_Cycles` is stored as an integer, it is truncated to `6355`, producing:

`200000000 / (6355 * 525) = 59.94530 Hz`

The exact video refresh from the live SPG totals is:

`27000000.0 / (858.0 * 525.0) = 59.94006 Hz`

The practical difference is very small, but it affects the reported value:

- `59.94530 Hz` rounds to `59.95 Hz`
- `59.94006 Hz` rounds to the expected `59.94 Hz`

This change leaves the integer-based internal scheduler unchanged and only reports the exact SPG video refresh through libretro AVInfo.