### PR TITLE
Reject unterminated quoted disc filenames

### DIFF
--- a/core/imgread/cue.cpp
+++ b/core/imgread/cue.cpp
@@ -154,14 +154,16 @@ Disc* cue_parse(const char* file, std::vector<u8> *digest)
 			track_filename.clear();
 			char last;
 			do {
-				cuesheet >> last;
-			} while (isspace(last));
+				if (!(cuesheet >> last))
+					throw FlycastException(i18n::T("Invalid CUE file"));
+			} while (isspace((unsigned char)last));
 
 			if (last == '"')
 			{
 				cuesheet >> std::noskipws;
 				for (;;) {
-					cuesheet >> last;
+					if (!(cuesheet >> last))
+						throw FlycastException(i18n::T("Invalid CUE file"));
 					if (last == '"')
 						break;
 					track_filename += last;

--- a/core/imgread/gdi.cpp
+++ b/core/imgread/gdi.cpp
@@ -59,14 +59,16 @@ static Disc* load_gdi(const char* file, std::vector<u8> *digest)
 
 		char last;
 		do {
-			gdi >> last;
-		} while (isspace(last));
+			if (!(gdi >> last))
+				throw FlycastException(i18n::T("Invalid GDI file"));
+		} while (isspace((unsigned char)last));
 		
 		if (last == '"')
 		{
 			gdi >> std::noskipws;
 			for(;;) {
-				gdi >> last;
+				if (!(gdi >> last))
+					throw FlycastException(i18n::T("Invalid GDI file"));
 				if (last == '"')
 					break;
 				track_filename += last;


### PR DESCRIPTION
A CUE or GDI descriptor with a FILE line whose quoted filename reaches
EOF can leave the parser appending to the filename indefinitely. Opening
such a descriptor can hang Flycast or exhaust process memory.

This checks character extraction while skipping whitespace and reading
quoted filenames, treating EOF as an invalid descriptor.