### PR TITLE
Validate ISO9660 directory record bounds

### DIFF
--- a/core/imgread/cue.cpp
+++ b/core/imgread/cue.cpp
@@ -154,14 +154,16 @@ Disc* cue_parse(const char* file, std::vector<u8> *digest)
 			track_filename.clear();
 			char last;
 			do {
-				cuesheet >> last;
-			} while (isspace(last));
+				if (!(cuesheet >> last))
+					throw FlycastException(i18n::T("Invalid CUE file"));
+			} while (isspace((unsigned char)last));
 
 			if (last == '"')
 			{
 				cuesheet >> std::noskipws;
 				for (;;) {
-					cuesheet >> last;
+					if (!(cuesheet >> last))
+						throw FlycastException(i18n::T("Invalid CUE file"));
 					if (last == '"')
 						break;
 					track_filename += last;

--- a/core/imgread/gdi.cpp
+++ b/core/imgread/gdi.cpp
@@ -59,14 +59,16 @@ static Disc* load_gdi(const char* file, std::vector<u8> *digest)
 
 		char last;
 		do {
-			gdi >> last;
-		} while (isspace(last));
+			if (!(gdi >> last))
+				throw FlycastException(i18n::T("Invalid GDI file"));
+		} while (isspace((unsigned char)last));
 		
 		if (last == '"')
 		{
 			gdi >> std::noskipws;
 			for(;;) {
-				gdi >> last;
+				if (!(gdi >> last))
+					throw FlycastException(i18n::T("Invalid GDI file"));
 				if (last == '"')
 					break;
 				track_filename += last;

--- a/core/imgread/isofs.cpp
+++ b/core/imgread/isofs.cpp
@@ -19,6 +19,7 @@
 #include "isofs.h"
 #include "iso9660.h"
 
+#include <cstddef>
 #include <cstring>
 
 static u32 decode_iso733(iso733_t v)
@@ -87,7 +88,22 @@ IsoFs::Entry *IsoFs::Directory::nextEntry()
 		if (dir->length == 0)
 			return nullptr;
 	}
-	std::string name(dir->filename.str + 1, dir->filename.str[0]);
+	constexpr size_t filenameOffset = offsetof(iso9660_dir_t, filename);
+	if (data.size() - index <= filenameOffset)
+	{
+		WARN_LOG(GDROM, "Invalid ISO9660 directory record");
+		return nullptr;
+	}
+	const size_t recordLength = dir->length;
+	const size_t filenameLength = dir->filename.len;
+	if (recordLength <= filenameOffset
+			|| recordLength > data.size() - index
+			|| filenameLength > recordLength - filenameOffset - 1)
+	{
+		WARN_LOG(GDROM, "Invalid ISO9660 directory record");
+		return nullptr;
+	}
+	std::string name(dir->filename.str + 1, filenameLength);
 
 	u32 startFad = decode_iso733(dir->extent) + 150;
 	u32 len = decode_iso733(dir->size);


### PR DESCRIPTION
ISO9660 directory records carry their own record and filename lengths,
but the reader did not confirm they fit in the loaded directory buffer.
A malformed disc image can read past that buffer while Flycast looks up
boot files or artwork.

This validates the fixed record, record length, and filename length
before reading directory fields.