### PR TITLE
Bound RZIP chunk allocations

### DIFF
--- a/core/archive/rzip.cpp
+++ b/core/archive/rzip.cpp
@@ -20,8 +20,10 @@
 #include <zlib.h>
 
 #include <cstring>
+#include <new>
 
 const u8 RZipHeader[8] = { '#', 'R', 'Z', 'I', 'P', 'v', 1, '#' };
+constexpr u32 MaxChunkSize = 64_MB;
 
 bool RZipFile::Open(hostfs::File *file, bool write)
 {
@@ -45,7 +47,17 @@ bool RZipFile::Open(hostfs::File *file, bool write)
 			size &= 0xffffffff;
 			file->seek(-4, SEEK_CUR);
 		}
-		chunk = new u8[maxChunkSize];
+		if (maxChunkSize == 0 || maxChunkSize > MaxChunkSize)
+		{
+			file->seek(startOffset, SEEK_SET);
+			return false;
+		}
+		try {
+			chunk = new u8[maxChunkSize];
+		} catch (const std::bad_alloc&) {
+			file->seek(startOffset, SEEK_SET);
+			return false;
+		}
 		chunkIndex = 0;
 		chunkSize = 0;
 	}
@@ -114,7 +126,16 @@ size_t RZipFile::Read(void *data, size_t length)
 				break;
 			if (zippedSize == 0)
 				continue;
-			u8 *zipped = new u8[zippedSize];
+			const u64 maxZippedSize = (u64)maxChunkSize
+					+ maxChunkSize / 1000 + 12;
+			if (zippedSize > maxZippedSize)
+				break;
+			u8 *zipped;
+			try {
+				zipped = new u8[zippedSize];
+			} catch (const std::bad_alloc&) {
+				break;
+			}
 			if (file->read(zipped, zippedSize, 1) != 1)
 			{
 				delete [] zipped;

--- a/core/imgread/cue.cpp
+++ b/core/imgread/cue.cpp
@@ -154,14 +154,16 @@ Disc* cue_parse(const char* file, std::vector<u8> *digest)
 			track_filename.clear();
 			char last;
 			do {
-				cuesheet >> last;
-			} while (isspace(last));
+				if (!(cuesheet >> last))
+					throw FlycastException(i18n::T("Invalid CUE file"));
+			} while (isspace((unsigned char)last));
 
 			if (last == '"')
 			{
 				cuesheet >> std::noskipws;
 				for (;;) {
-					cuesheet >> last;
+					if (!(cuesheet >> last))
+						throw FlycastException(i18n::T("Invalid CUE file"));
 					if (last == '"')
 						break;
 					track_filename += last;

--- a/core/imgread/gdi.cpp
+++ b/core/imgread/gdi.cpp
@@ -59,14 +59,16 @@ static Disc* load_gdi(const char* file, std::vector<u8> *digest)
 
 		char last;
 		do {
-			gdi >> last;
-		} while (isspace(last));
+			if (!(gdi >> last))
+				throw FlycastException(i18n::T("Invalid GDI file"));
+		} while (isspace((unsigned char)last));
 		
 		if (last == '"')
 		{
 			gdi >> std::noskipws;
 			for(;;) {
-				gdi >> last;
+				if (!(gdi >> last))
+					throw FlycastException(i18n::T("Invalid GDI file"));
 				if (last == '"')
 					break;
 				track_filename += last;

--- a/core/imgread/isofs.cpp
+++ b/core/imgread/isofs.cpp
@@ -19,6 +19,7 @@
 #include "isofs.h"
 #include "iso9660.h"
 
+#include <cstddef>
 #include <cstring>
 
 static u32 decode_iso733(iso733_t v)
@@ -87,7 +88,22 @@ IsoFs::Entry *IsoFs::Directory::nextEntry()
 		if (dir->length == 0)
 			return nullptr;
 	}
-	std::string name(dir->filename.str + 1, dir->filename.str[0]);
+	constexpr size_t filenameOffset = offsetof(iso9660_dir_t, filename);
+	if (data.size() - index <= filenameOffset)
+	{
+		WARN_LOG(GDROM, "Invalid ISO9660 directory record");
+		return nullptr;
+	}
+	const size_t recordLength = dir->length;
+	const size_t filenameLength = dir->filename.len;
+	if (recordLength <= filenameOffset
+			|| recordLength > data.size() - index
+			|| filenameLength > recordLength - filenameOffset - 1)
+	{
+		WARN_LOG(GDROM, "Invalid ISO9660 directory record");
+		return nullptr;
+	}
+	std::string name(dir->filename.str + 1, filenameLength);
 
 	u32 startFad = decode_iso733(dir->extent) + 150;
 	u32 len = decode_iso733(dir->size);


### PR DESCRIPTION
Flycast used maxChunkSize and compressed chunk sizes from an RZIP
savestate as allocation sizes without limits. A malformed savestate
could trigger an impractically large allocation and terminate Flycast.

This rejects zero or oversized chunk values, caps compressed chunks to
the corresponding valid zlib bound, and handles allocation failure as a
load error.