### PR TITLE
Validate PicoTCP DNS responses

### DIFF
--- a/core/archive/rzip.cpp
+++ b/core/archive/rzip.cpp
@@ -20,8 +20,10 @@
 #include <zlib.h>
 
 #include <cstring>
+#include <new>
 
 const u8 RZipHeader[8] = { '#', 'R', 'Z', 'I', 'P', 'v', 1, '#' };
+constexpr u32 MaxChunkSize = 64_MB;
 
 bool RZipFile::Open(hostfs::File *file, bool write)
 {
@@ -45,7 +47,17 @@ bool RZipFile::Open(hostfs::File *file, bool write)
 			size &= 0xffffffff;
 			file->seek(-4, SEEK_CUR);
 		}
-		chunk = new u8[maxChunkSize];
+		if (maxChunkSize == 0 || maxChunkSize > MaxChunkSize)
+		{
+			file->seek(startOffset, SEEK_SET);
+			return false;
+		}
+		try {
+			chunk = new u8[maxChunkSize];
+		} catch (const std::bad_alloc&) {
+			file->seek(startOffset, SEEK_SET);
+			return false;
+		}
 		chunkIndex = 0;
 		chunkSize = 0;
 	}
@@ -114,7 +126,16 @@ size_t RZipFile::Read(void *data, size_t length)
 				break;
 			if (zippedSize == 0)
 				continue;
-			u8 *zipped = new u8[zippedSize];
+			const u64 maxZippedSize = (u64)maxChunkSize
+					+ maxChunkSize / 1000 + 12;
+			if (zippedSize > maxZippedSize)
+				break;
+			u8 *zipped;
+			try {
+				zipped = new u8[zippedSize];
+			} catch (const std::bad_alloc&) {
+				break;
+			}
 			if (file->read(zipped, zippedSize, 1) != 1)
 			{
 				delete [] zipped;

--- a/core/imgread/cue.cpp
+++ b/core/imgread/cue.cpp
@@ -154,14 +154,16 @@ Disc* cue_parse(const char* file, std::vector<u8> *digest)
 			track_filename.clear();
 			char last;
 			do {
-				cuesheet >> last;
-			} while (isspace(last));
+				if (!(cuesheet >> last))
+					throw FlycastException(i18n::T("Invalid CUE file"));
+			} while (isspace((unsigned char)last));
 
 			if (last == '"')
 			{
 				cuesheet >> std::noskipws;
 				for (;;) {
-					cuesheet >> last;
+					if (!(cuesheet >> last))
+						throw FlycastException(i18n::T("Invalid CUE file"));
 					if (last == '"')
 						break;
 					track_filename += last;

--- a/core/imgread/gdi.cpp
+++ b/core/imgread/gdi.cpp
@@ -59,14 +59,16 @@ static Disc* load_gdi(const char* file, std::vector<u8> *digest)
 
 		char last;
 		do {
-			gdi >> last;
-		} while (isspace(last));
+			if (!(gdi >> last))
+				throw FlycastException(i18n::T("Invalid GDI file"));
+		} while (isspace((unsigned char)last));
 		
 		if (last == '"')
 		{
 			gdi >> std::noskipws;
 			for(;;) {
-				gdi >> last;
+				if (!(gdi >> last))
+					throw FlycastException(i18n::T("Invalid GDI file"));
 				if (last == '"')
 					break;
 				track_filename += last;

--- a/core/imgread/isofs.cpp
+++ b/core/imgread/isofs.cpp
@@ -19,6 +19,7 @@
 #include "isofs.h"
 #include "iso9660.h"
 
+#include <cstddef>
 #include <cstring>
 
 static u32 decode_iso733(iso733_t v)
@@ -87,7 +88,22 @@ IsoFs::Entry *IsoFs::Directory::nextEntry()
 		if (dir->length == 0)
 			return nullptr;
 	}
-	std::string name(dir->filename.str + 1, dir->filename.str[0]);
+	constexpr size_t filenameOffset = offsetof(iso9660_dir_t, filename);
+	if (data.size() - index <= filenameOffset)
+	{
+		WARN_LOG(GDROM, "Invalid ISO9660 directory record");
+		return nullptr;
+	}
+	const size_t recordLength = dir->length;
+	const size_t filenameLength = dir->filename.len;
+	if (recordLength <= filenameOffset
+			|| recordLength > data.size() - index
+			|| filenameLength > recordLength - filenameOffset - 1)
+	{
+		WARN_LOG(GDROM, "Invalid ISO9660 directory record");
+		return nullptr;
+	}
+	std::string name(dir->filename.str + 1, filenameLength);
 
 	u32 startFad = decode_iso733(dir->extent) + 150;
 	u32 len = decode_iso733(dir->size);

--- a/core/network/dns.cpp
+++ b/core/network/dns.cpp
@@ -94,12 +94,27 @@ u32 makeDnsQueryPacket(void *buf, const char *host)
     return sizeof(pico_dns_packet) + qname_len + sizeof(pico_dns_question_suffix);
 }
 
-static int dnsNameLen(const char *s)
+static bool skipDnsName(const u8 *&reader, const u8 *end)
 {
-	if ((uint8_t)s[0] & 0xC0)
-		return 2;
-	else
-		return strlen(s) + 1;
+	if (reader == end)
+		return false;
+	if ((*reader & 0xC0) != 0)
+	{
+		if ((*reader & 0xC0) != 0xC0 || end - reader < 2)
+			return false;
+		reader += 2;
+		return true;
+	}
+	while (reader != end)
+	{
+		u8 labelLength = *reader++;
+		if (labelLength == 0)
+			return true;
+		if (labelLength > 63 || labelLength > end - reader)
+			return false;
+		reader += labelLength;
+	}
+	return false;
 }
 
 int get_dns_answer(struct pico_ip4 *address, struct pico_ip4 dnsaddr)
@@ -128,29 +143,44 @@ int get_dns_answer(struct pico_ip4 *address, struct pico_ip4 dnsaddr)
 
 pico_ip4 parseDnsResponsePacket(const void *buf, size_t len)
 {
+	const u8 *reader = (const u8 *)buf;
+	const u8 *end = reader + len;
+	if (len < sizeof(pico_dns_packet))
+		return { ~0u };
 	const pico_dns_packet *dns = (const pico_dns_packet *)buf;
+	if (dns->qr != PICO_DNS_QR_RESPONSE || ntohs(dns->qdcount) != 1)
+		return { ~0u };
 
-    // move to the first answer
-	const char *reader = (const char *)buf + sizeof(pico_dns_packet);
-    reader += strlen(reader) + 1 + sizeof(pico_dns_question_suffix);
+	// move to the first answer
+	reader += sizeof(pico_dns_packet);
+	if (!skipDnsName(reader, end)
+			|| (size_t)(end - reader) < sizeof(pico_dns_question_suffix))
+		return { ~0u };
+	reader += sizeof(pico_dns_question_suffix);
 
-    for (int i = 0; i < ntohs(dns->ancount); i++)
-    {
-    	// TODO Check name?
-        reader += dnsNameLen(reader);
-        const pico_dns_record_suffix *record = (const pico_dns_record_suffix *)reader;
-        reader += sizeof(pico_dns_record_suffix);
+	for (int i = 0; i < ntohs(dns->ancount); i++)
+	{
+		if (!skipDnsName(reader, end)
+				|| (size_t)(end - reader) < sizeof(pico_dns_record_suffix))
+			return { ~0u };
+		const pico_dns_record_suffix *record = (const pico_dns_record_suffix *)reader;
+		reader += sizeof(pico_dns_record_suffix);
+		u16 dataLength = ntohs(record->rdlength);
+		if (dataLength > (size_t)(end - reader))
+			return { ~0u };
 
         if (ntohs(record->rtype) == PICO_DNS_TYPE_A) // Address record
         {
+			if (dataLength != sizeof(pico_ip4))
+				return { ~0u };
         	pico_ip4 address;
             memcpy(&address.addr, reader, 4);
 
             return address;
         }
-        reader = reader + ntohs(record->rdlength);
-    }
-    return { ~0u };
+		reader += dataLength;
+	}
+	return { ~0u };
 }
 
 #if !defined(_WIN32) && !defined(__SWITCH__)

--- a/core/network/picoppp.cpp
+++ b/core/network/picoppp.cpp
@@ -37,6 +37,7 @@ extern "C" {
 #include <pico_ipv4.h>
 #include <pico_tcp.h>
 #include <pico_dhcp_server.h>
+#include <pico_dns_common.h>
 #ifdef _MSC_VER
 #pragma pack(pop)
 #endif
@@ -1029,6 +1030,7 @@ public:
 		verify(!busy);
 		busy = true;
 		u32 len = makeDnsQueryPacket(buf, host);
+		queryId = ((const pico_dns_packet *)buf)->id;
 		socket.async_send_to(asio::buffer(buf, len), nsEndpoint,
 				std::bind(&DnsResolver::querySent, shared_from_this(),
 						result,
@@ -1049,22 +1051,31 @@ private:
 	void querySent(pico_ip4 *result, const std::error_code& ec, size_t len)
 	{
 		if (!ec)
-		{
-			socket.async_receive_from(asio::mutable_buffer(buf, sizeof(buf)), nsEndpoint,
-					std::bind(&DnsResolver::responseReceived, shared_from_this(),
-						result,
-						asio::placeholders::error,
-						asio::placeholders::bytes_transferred));
-		}
+			receiveResponse(result);
 		else {
 			busy = false;
 		}
+	}
+
+	void receiveResponse(pico_ip4 *result)
+	{
+		socket.async_receive_from(asio::mutable_buffer(buf, sizeof(buf)), responseEndpoint,
+				std::bind(&DnsResolver::responseReceived, shared_from_this(),
+						result,
+						asio::placeholders::error,
+						asio::placeholders::bytes_transferred));
 	}
 
 	void responseReceived(pico_ip4 *result, const std::error_code& ec, size_t len)
 	{
 		if (!ec)
 		{
+			if (responseEndpoint != nsEndpoint || len < sizeof(pico_dns_packet)
+					|| ((const pico_dns_packet *)buf)->id != queryId)
+			{
+				receiveResponse(result);
+				return;
+			}
 			*result = parseDnsResponsePacket(buf, len);
 			DEBUG_LOG(NETWORK, "dns resolved: %s (using %s)",
 					asio::ip::address_v4(*(std::array<u8, 4> *)result).to_string().c_str(),
@@ -1075,8 +1086,10 @@ private:
 
 	asio::io_context& io_context;
 	asio::ip::udp::endpoint nsEndpoint;
+	asio::ip::udp::endpoint responseEndpoint;
 	asio::ip::udp::socket socket;
 	char buf[1024];
+	u16 queryId;
 	bool busy = false;
 	friend super;
 };
@@ -1504,4 +1517,3 @@ void PicoTcpService::receiveEthFrame(const u8 *frame, u32 size) {
 }
 
 }
-


### PR DESCRIPTION
PicoTCP accepted the first UDP response received during startup DNS
resolution and parsed DNS names and record lengths without validating
the received length. A forged or malformed response could read past
Flycast's resolver buffer and terminate the process.

This matches replies to the queried endpoint and transaction ID, and
performs bounds checks for DNS questions, names, records, and record
data before reading them.