### PR TITLE
Fix DreamPicoPort enumeration issues on Windows

### DIFF
--- a/core/sdl/dreampicoport.cpp
+++ b/core/sdl/dreampicoport.cpp
@@ -1412,7 +1412,11 @@ private:
 		const char* joystick_serial = SDL_JoystickGetSerial(sdl_joystick);
 		if (joystick_serial) {
 			hw_info.serial_number = joystick_serial;
-		} else {
+		}
+
+	// Windows will cache the joystick name, so it's not a good idea to check SDL_JoystickName() on Windows
+#if !defined(_WIN32)
+	if (hw_info.serial_number.empty()) {
 			// Version 1.2.0 and later embeds serial in name as a workaround for MacOS and Linux
 			// Serial is expected between a dash (-) and space ( ) character or until end of string
 			const char* joystick_name = SDL_JoystickName(sdl_joystick);
@@ -1432,6 +1436,7 @@ private:
 				}
 			}
 		}
+#endif
 
 #if defined(_WIN32)
 		// This only works in Windows because the joystick_path is not given in other OSes

--- a/core/sdl/dreampicoport.cpp
+++ b/core/sdl/dreampicoport.cpp
@@ -1438,6 +1438,20 @@ private:
 		}
 #endif
 
+		// The number of buttons gives a clue as to what index the controller is
+		int nbuttons = SDL_JoystickNumButtons(sdl_joystick);
+		if (nbuttons >= 32 || nbuttons <= 27) {
+			// Older version of firmware or single player
+			hw_info.hardware_bus = 0;
+			hw_info.is_hardware_bus_implied = true;
+			hw_info.is_single_device = true;
+		}
+		else {
+			hw_info.hardware_bus = 31 - nbuttons;
+			hw_info.is_hardware_bus_implied = false;
+			hw_info.is_single_device = false;
+		}
+
 #if defined(_WIN32)
 		// This only works in Windows because the joystick_path is not given in other OSes
 		const char* joystick_path = SDL_JoystickPath(sdl_joystick);
@@ -1448,7 +1462,6 @@ private:
 
 			if (!devs->next) {
 				// Only single device found, so this is simple (host-1p firmware used)
-				hw_info.hardware_bus = 0;
 				hw_info.is_hardware_bus_implied = false;
 				hw_info.is_single_device = true;
 				my_dev = devs;
@@ -1481,22 +1494,15 @@ private:
 							it = it->next;
 						}
 
-						if (count == 1) {
-							// Single device of this serial found
-							hw_info.is_single_device = true;
-							hw_info.hardware_bus = 0;
+						hw_info.is_single_device = (count == 1);
+						if (my_dev->release_number < 0x0102) {
+							// Interfaces go in decending order
+							hw_info.hardware_bus = (count - (my_dev->interface_number % 4) - 1);
 							hw_info.is_hardware_bus_implied = false;
 						} else {
-							hw_info.is_single_device = false;
-							if (my_dev->release_number < 0x0102) {
-								// Interfaces go in decending order
-								hw_info.hardware_bus = (count - (my_dev->interface_number % 4) - 1);
-								hw_info.is_hardware_bus_implied = false;
-							} else {
-								// Version 1.02 of interface will make interfaces in ascending order
-								hw_info.hardware_bus = (my_dev->interface_number % 4);
-								hw_info.is_hardware_bus_implied = false;
-							}
+							// Version 1.02 of interface will make interfaces in ascending order
+							hw_info.hardware_bus = (my_dev->interface_number % 4);
+							hw_info.is_hardware_bus_implied = false;
 						}
 					}
 				}
@@ -1518,23 +1524,6 @@ private:
 		}
 
 #endif // #if defined(_WIN32)
-
-		if (hw_info.hardware_bus < 0) {
-			// The number of buttons gives a clue as to what index the controller is
-			int nbuttons = SDL_JoystickNumButtons(sdl_joystick);
-
-			if (nbuttons >= 32 || nbuttons <= 27) {
-				// Older version of firmware or single player
-				hw_info.hardware_bus = 0;
-				hw_info.is_hardware_bus_implied = true;
-				hw_info.is_single_device = true;
-			}
-			else {
-				hw_info.hardware_bus = 31 - nbuttons;
-				hw_info.is_hardware_bus_implied = false;
-				hw_info.is_single_device = false;
-			}
-		}
 
 		hw_info.unique_id.clear();
 		if (!hw_info.is_hardware_bus_implied && !hw_info.serial_number.empty()) {


### PR DESCRIPTION
Fixed 2 bugs:
- Windows likes to cache device name and link it to VID/PID, so getting the serial from the name is not a good idea for Windows
- Fixed hardware_bus enumeration on Windows when single device on B, C, or D port