### PR TITLE
ci: maintenance updates

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,13 +11,16 @@ jobs:
     name: Android
     runs-on: ubuntu-latest
 
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+
     steps:
       - name: Set up build environment
         run: |
           sudo apt-get update
-          sudo apt-get -y install ccache cmake libcurl4-openssl-dev ninja-build
+          sudo apt-get -y install ccache libcurl4-openssl-dev
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
@@ -28,21 +31,18 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
-          path: ~/.ccache
-          key: android-ccache-${{ github.sha }}
-          restore-keys: android-ccache-
-            
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-android-${{ github.sha }}
+          restore-keys: ccache-android-
+
       - name: Disable release signing
-        run: sed -i 's/signingConfigs.getByName("release")/signingConfigs.getByName("debug")/g' shell/android-studio/flycast/build.gradle.kts
+        run: sed -i 's/signingConfigs.getByName("release")/signingConfigs.getByName("debug")/' shell/android-studio/flycast/build.gradle.kts
         if: github.repository != 'flyinghead/flycast' || github.event_name != 'push'
 
       - name: Bump version code
-        uses: chkfung/android-version-actions@v1.2.2
-        with:
-          gradlePath: shell/android-studio/flycast/build.gradle.kts
-          versionCode: ${{ github.run_number }}
+        run: sed -i 's/versionCode = 8/versionCode = ${{ github.run_number }}/' shell/android-studio/flycast/build.gradle.kts
 
       - name: Gradle
         working-directory: shell/android-studio
@@ -51,7 +51,7 @@ jobs:
           SENTRY_UPLOAD_URL: ${{ secrets.SENTRY_UPLOAD_URL }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: flycast-release.apk
           path: shell/android-studio/flycast/build/outputs/apk/release/flycast-release.apk
@@ -85,21 +85,15 @@ jobs:
           rclone copy shell/android-studio/flycast/build/outputs/apk/release scaleway:flycast-builds/android/${GITHUB_REF#refs/}-$GITHUB_SHA --exclude '*.json'
         if: github.repository == 'flyinghead/flycast' && github.event_name == 'push'
 
-      - name: Setup Sentry CLI
-        uses: mathieu-bour/setup-sentry-cli@v2
-        env:
-          SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
-        with:
-          url: https://sentry.io
-          token: ${{ env.SENTRY_TOKEN }}
-          organization: flycast
-          project: minidump
-          version: 2.21.2
-        if: ${{ env.SENTRY_TOKEN != '' }}
-      
+      - uses: getsentry/action-setup-cli@v1
+
       - name: Upload symbols to Sentry
         run: |
           VERSION=$(git describe --tags --always)
+          export SENTRY_AUTH_TOKEN=${{ env.SENTRY_TOKEN }}
+          export SENTRY_ORG=flycast
+          export SENTRY_PROJECT=minidump
+          sentry-cli login
           sentry-cli releases new "$VERSION"
           sentry-cli releases set-commits "$VERSION" --auto
           sentry-cli debug-files upload symbols

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -18,10 +18,10 @@ jobs:
         libretro: [ OFF, ON ]
         include:
           - operating_system: freebsd
-            version: '15.0'
-            pkginstall: sudo pkg update && sudo pkg install -y alsa-lib ccache cmake evdev-proto git libao libcdio libevdev libudev-devd libzip lua54 miniupnpc ninja pkgconf pulseaudio sdl2
+            version: '15.1'
+            pkginstall: sudo pkg upgrade -y && sudo pkg install -y alsa-lib ccache cmake evdev-proto git libao libcdio libevdev libudev-devd libzip lua54 miniupnpc ninja pkgconf pulseaudio sdl2
           - operating_system: netbsd
-            version: '10.1'
+            version: '11.0'
             pkginstall: sudo pkgin update && sudo pkgin -y install alsa-lib ccache clang cmake git libao libcdio libusb1-1.0.30 libzip lua54 miniupnpc ninja-build pkgconf pulseaudio SDL2
           - operating_system: openbsd
             version: '7.9'
@@ -30,16 +30,16 @@ jobs:
           - architecture: arm64
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ matrix.operating_system }}-${{ matrix.architecture }}-${{ github.sha }}
-          restore-keys: ccache-${{ matrix.operating_system }}-${{ matrix.architecture }}-
+          key: ccache-${{ matrix.operating_system }}-${{ matrix.architecture }}-${{ matrix.libretro }}-${{ github.sha }}
+          restore-keys: ccache-${{ matrix.operating_system }}-${{ matrix.architecture }}-${{ matrix.libretro }}-
 
       - name: Start VM
         uses: cross-platform-actions/action@v1

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -21,13 +21,13 @@ jobs:
     strategy:
       matrix:
         config:
-          - {name: i686-pc-windows-msvc, os: windows-2022, shell: cmd, arch: x86, cmakeArgs: -G Ninja, buildType: Release}
-          - {name: apple-darwin, os: macos-latest, shell: sh, cmakeArgs: -G Xcode -DUSE_DISCORD=ON -DMOLTENVK_DYLIB=$MOLTENVK_DYLIB, destDir: osx, buildType: RelWithDebInfo}
-          - {name: x86_64-pc-linux-gnu, os: ubuntu-22.04, shell: sh, cmakeArgs: -G Ninja -DUSE_DISCORD=ON -DUSE_LIBCDIO=ON, destDir: linux, buildType: RelWithDebInfo}
-          - {name: x86_64-pc-windows-msvc, os: windows-2022, shell: cmd, arch: x64, cmakeArgs: -G Ninja -DUSE_DISCORD=ON, buildType: Release}
-          - {name: x86_64-w64-mingw32, os: windows-2022, shell: 'msys2 {0}', cmakeArgs: -G Ninja -DUSE_DISCORD=ON -DUSE_LIBCDIO=ON, destDir: win, buildType: RelWithDebInfo}
-          - {name: libretro-x86_64-pc-linux-gnu, os: ubuntu-22.04, shell: sh, cmakeArgs: -DLIBRETRO=ON -DUSE_LIBCDIO=ON -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -G Ninja, buildType: Release}
-          - {name: libretro-x86_64-w64-mingw32, os: windows-2022, shell: 'msys2 {0}', cmakeArgs: -DLIBRETRO=ON -DUSE_LIBCDIO=ON -G Ninja, buildType: Release}
+          - { name: i686-pc-windows-msvc, os: windows-2022, shell: cmd, arch: x86, cmakeArgs: -G Ninja, buildType: Release }
+          - { name: apple-darwin, os: macos-latest, shell: sh, cmakeArgs: -G Xcode -DUSE_DISCORD=ON -DMOLTENVK_DYLIB=$MOLTENVK_DYLIB, destDir: osx, buildType: RelWithDebInfo }
+          - { name: x86_64-pc-linux-gnu, os: ubuntu-22.04, shell: sh, cmakeArgs: -G Ninja -DUSE_DISCORD=ON -DUSE_LIBCDIO=ON, destDir: linux, buildType: RelWithDebInfo }
+          - { name: x86_64-pc-windows-msvc, os: windows-2022, shell: cmd, arch: x64, cmakeArgs: -G Ninja -DUSE_DISCORD=ON, buildType: Release }
+          - { name: x86_64-w64-mingw32, os: windows-2022, shell: 'msys2 {0}', cmakeArgs: -G Ninja -DUSE_DISCORD=ON -DUSE_LIBCDIO=ON, destDir: win, buildType: RelWithDebInfo }
+          - { name: libretro-x86_64-pc-linux-gnu, os: ubuntu-22.04, shell: sh, cmakeArgs: -DLIBRETRO=ON -DUSE_LIBCDIO=ON -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -G Ninja, buildType: Release }
+          - { name: libretro-x86_64-w64-mingw32, os: windows-2022, shell: 'msys2 {0}', cmakeArgs: -DLIBRETRO=ON -DUSE_LIBCDIO=ON -G Ninja, buildType: Release }
 
     steps:
       - name: Set up build environment (macOS)
@@ -38,11 +38,11 @@ jobs:
           brew install libao ldid pulseaudio
           brew uninstall --ignore-dependencies zstd
 
-          moltenvk_tag="v1.4.2-pre.973bb08"
+          moltenvk_tag="v1.4.2"
           moltenvk_root="$RUNNER_TEMP/MoltenVK-$moltenvk_tag"
           rm -rf "$moltenvk_root"
           mkdir -p "$moltenvk_root"
-          aria2c "https://github.com/vkedwardli/MoltenVK/releases/download/$moltenvk_tag/MoltenVK-macos.tar" -d "$RUNNER_TEMP" -o "MoltenVK-macos-$moltenvk_tag.tar"
+          aria2c "https://github.com/KhronosGroup/MoltenVK/releases/download/$moltenvk_tag/MoltenVK-macos.tar" -d "$RUNNER_TEMP" -o "MoltenVK-macos-$moltenvk_tag.tar"
           tar -xf "$RUNNER_TEMP/MoltenVK-macos-$moltenvk_tag.tar" -C "$moltenvk_root"
           moltenvk_dylib="$(find "$moltenvk_root" -type f -path '*/macOS/*' -name libMoltenVK.dylib | head -n 1)"
           if [ -z "$moltenvk_dylib" ]; then
@@ -56,7 +56,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:christianrauch/libdecoration
           sudo apt-get update
-          sudo apt-get -y install ccache libao-dev libasound2-dev libevdev-dev libgl1-mesa-dev liblua5.3-dev libminiupnpc-dev libpulse-dev libsdl2-dev libudev-dev libzip-dev ninja-build libcurl4-openssl-dev libcdio-dev libfuse2 locales
+          sudo apt-get -y install ccache libao-dev libasound2-dev libevdev-dev libgl1-mesa-dev liblua5.3-dev libminiupnpc-dev libpulse-dev libsdl2-dev libudev-dev libzip-dev libcurl4-openssl-dev libcdio-dev libfuse2 locales
           sudo apt-get -y install libwayland-dev libdecor-0-dev libaudio-dev libjack-dev libsndio-dev libsamplerate0-dev libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxkbcommon-dev libdrm-dev libgbm-dev libgles2-mesa-dev libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev fcitx-libs-dev
           sudo sed -i 's/# fr_FR.UTF-8 UTF-8/fr_FR.UTF-8 UTF-8/g' /etc/locale.gen
           sudo locale-gen
@@ -66,12 +66,13 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
-          install: git make mingw-w64-x86_64-ccache mingw-w64-x86_64-cmake mingw-w64-x86_64-lua mingw-w64-x86_64-ninja mingw-w64-x86_64-SDL2 mingw-w64-x86_64-toolchain mingw-w64-x86_64-libcdio
+          install: git make
+          pacboy: ccache:p cmake:p libcdio:p lua:p ninja:p SDL2:p toolchain:p
         if: matrix.config.shell == 'msys2 {0}'
 
       - name: Set up build environment (Windows, Visual Studio)
         run: |
-          choco install ccache directx-sdk ninja
+          choco install ccache directx-sdk
           echo DXSDK_DIR=C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)>> %GITHUB_ENV%
         if: matrix.config.shell == 'cmd'
 
@@ -80,7 +81,7 @@ jobs:
           arch: ${{ matrix.config.arch }}
         if: matrix.config.shell == 'cmd'
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
@@ -91,12 +92,12 @@ jobs:
             libname=$(basename "$formula" .rb)
             HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 HOMEBREW_DEVELOPER=1 brew install --build-from-source --formula "$formula" || \
             HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 HOMEBREW_DEVELOPER=1 brew reinstall --build-from-source --formula "$formula"
-            
+          
             prefix=$(brew --prefix $libname)
             # Find and verify the static library
             libfile=$(find "$prefix/lib" -name "*.a" | head -n1)
             lipo -info "$libfile"
-            
+          
             # Export prefix for subsequent CMake steps
             if [ -z "$CMAKE_PREFIX_PATH" ]; then
               CMAKE_PREFIX_PATH="$prefix"
@@ -107,7 +108,7 @@ jobs:
           echo "CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
         if: matrix.config.name == 'apple-darwin'
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ matrix.config.name }}-${{ github.sha }}
@@ -153,7 +154,7 @@ jobs:
           rm artifact/bin/flycast
         if: matrix.config.name == 'x86_64-pc-linux-gnu'
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: flycast-${{ matrix.config.name }}
           path: |
@@ -193,7 +194,7 @@ jobs:
           project: minidump
           version: 2.21.2
         if: ${{ env.SENTRY_TOKEN != '' }}
-      
+
       - name: Upload symbols to Sentry (Windows, macOS, Linux)
         run: |
           VERSION=$(git describe --tags --always)
@@ -204,4 +205,3 @@ jobs:
         env:
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
         if: ${{ env.SENTRY_TOKEN != '' && (matrix.config.name == 'x86_64-w64-mingw32' || matrix.config.name == 'apple-darwin' || matrix.config.name == 'x86_64-pc-linux-gnu') && github.event_name == 'push' }}
-        

--- a/.github/workflows/switch.yml
+++ b/.github/workflows/switch.yml
@@ -12,19 +12,22 @@ jobs:
     runs-on: ubuntu-latest
     container: devkitpro/devkita64:latest
 
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+
     strategy:
       matrix:
         config:
-          - {name: standalone, destDir: switch}
-          - {name: libretro, cmakeArgs: -DLIBRETRO=ON}
+          - { name: standalone, destDir: switch }
+          - { name: libretro, cmakeArgs: -DLIBRETRO=ON }
 
     steps:
       - name: Set up build environment
         run: |
           sudo apt-get update
-          sudo apt-get -y install ccache cmake
+          sudo apt-get -y install ccache gh
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
@@ -32,9 +35,9 @@ jobs:
       - name: Mark git repository as safe
         run: git config --global --add safe.directory $PWD
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
-          path: ~/.ccache
+          path: ${{ env.CCACHE_DIR }}
           key: ccache-switch-${{ matrix.config.name }}-${{ github.sha }}
           restore-keys: ccache-switch-${{ matrix.config.name }}-
 
@@ -43,7 +46,7 @@ jobs:
           $DEVKITPRO/portlibs/switch/bin/aarch64-none-elf-cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=artifact -G Ninja ${{ matrix.config.cmakeArgs }}
           cmake --build build --config Release --target install
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: flycast-switch-${{ matrix.config.name }}
           path: |
@@ -58,7 +61,6 @@ jobs:
         uses: AnimMouse/setup-rclone@v1
         with:
           rclone_config: ${{ secrets.RCLONE_CONFIG }}
-          version: v1.69.1
 
       - name: Upload to S3
         run: rclone copy artifact/bin scaleway:flycast-builds/${{ matrix.config.destDir }}/${GITHUB_REF#refs/}-$GITHUB_SHA

--- a/.github/workflows/uwp.yml
+++ b/.github/workflows/uwp.yml
@@ -16,7 +16,7 @@ jobs:
         arch: [ Win32, x64, ARM64 ]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
@@ -35,7 +35,7 @@ jobs:
           cd build\AppPackages\flycast\flycast_*_Test
           mkdir tmp
           ren *.msix flycast.msix
-          makeappx.exe unpack /p .\flycast.msix /d tmp
+          makeappx unpack /p .\flycast.msix /d tmp
           copy ..\..\..\Release\*.dll tmp
           makeappx pack /d tmp /p ..\..\..\artifact\flycast.appx
 
@@ -43,7 +43,7 @@ jobs:
         run: signtool sign /f shell\uwp\sign_cert.pfx /p '${{ secrets.SIGN_CERT_PWD }}' /v /fd SHA256 build\artifact\flycast.appx
         if: github.repository == 'flyinghead/flycast' && github.event_name == 'push'
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: flycast-uwp-${{ matrix.arch }}
           path: build/artifact


### PR DESCRIPTION
- Bump action versions
- Improve ccache support
- Reformat files
- Replace chkfung/android-version-actions and mathieu-bour/setup-sentry-cli from android workflow
- Update MoltenVK to use the latest official tag
- Update BSD operating systems

@flyinghead I replaced the unmaintained mathieu-bour/setup-sentry-cli@v2 with the official getsentry/action-setup-cli@v1. Since I don't have a sentry token, I did no tests so some tweaking might be necessary after the merge