### PR TITLE
load elf sections that were being ignored.

### DIFF
--- a/core/reios/reios_elf.cpp
+++ b/core/reios/reios_elf.cpp
@@ -6,6 +6,22 @@ extern "C" {
 
 #include "hw/sh4/sh4_mem.h"
 
+// True if a PT_LOAD segment already copied [addr, addr + size) in. Tested
+// against file size, not memory size: the gap between them is only zero-filled.
+static bool isLoadedBySegment(const elf_t *elfFile, uint64_t addr, size_t size)
+{
+	for (size_t i = 0; i < elf_getNumProgramHeaders(elfFile); i++)
+	{
+		if (elf_getProgramHeaderType(elfFile, i) != PT_LOAD)
+			continue;
+		uint64_t start = elf_getProgramHeaderVaddr(elfFile, i);
+		uint64_t end = start + elf_getProgramHeaderFileSize(elfFile, i);
+		if (addr >= start && addr + size <= end)
+			return true;
+	}
+	return false;
+}
+
 bool reios_loadElf(const std::string& elf) {
 
 	FILE* f = nowide::fopen(elf.c_str(), "rb");
@@ -21,6 +37,10 @@ bool reios_loadElf(const std::string& elf) {
 	}
 
 	void* elfF = malloc(size);
+	if (elfF == nullptr) {
+		std::fclose(f);
+		return false;
+	}
 
 	std::fseek(f, 0, SEEK_SET);
 	size_t nread = std::fread(elfF, 1, size, f);
@@ -36,6 +56,8 @@ bool reios_loadElf(const std::string& elf) {
 	Elf32_Ehdr const *header = (const Elf32_Ehdr *)elfFile.elfFile;
 	if (header->e_machine != EM_SH)
 		WARN_LOG(REIOS, "Elf file is not for Hitachi SH: machine %d", header->e_machine);
+
+	unsigned loaded = 0;
 
 	for (size_t i = 0; i < elf_getNumProgramHeaders(&elfFile); i++)
 	{
@@ -64,8 +86,45 @@ bool reios_loadElf(const std::string& elf) {
 		DEBUG_LOG(REIOS, "Loading section %d to %08lx - %08lx", (int)i, (long)dest, (long)(dest + memsize - 1));
 		memcpy(ptr, src, len);
 		memset(ptr + len, 0, memsize - len);
+		loaded++;
 	}
+
+	// Sections added after linking (objcopy --add-section) have no program
+	// header. Load those the loop above missed, after it so its zero-fill
+	// doesn't clobber them.
+	for (size_t i = 0; i < elf_getNumSections(&elfFile); i++)
+	{
+		if ((elf_getSectionFlags(&elfFile, i) & SHF_ALLOC) == 0
+				|| elf_getSectionType(&elfFile, i) == SHT_NOBITS)
+			continue;
+		uint64_t dest = elf_getSectionAddr(&elfFile, i);
+		size_t len = elf_getSectionSize(&elfFile, i);
+		if (dest == 0 || len == 0 || isLoadedBySegment(&elfFile, dest, len))
+			continue;
+		size_t offset = elf_getSectionOffset(&elfFile, i);
+		if (offset + len > nread) {
+			WARN_LOG(REIOS, "Section %s extends past end of file", elf_getSectionName(&elfFile, i));
+			continue;
+		}
+		u8* ptr = GetMemPtr(dest, len);
+		if (ptr == nullptr)
+		{
+			WARN_LOG(REIOS, "Invalid load address or size for section %s: %08lx size %lx",
+					elf_getSectionName(&elfFile, i), (long)dest, (long)len);
+			continue;
+		}
+		DEBUG_LOG(REIOS, "Loading section %s to %08lx - %08lx",
+				elf_getSectionName(&elfFile, i), (long)dest, (long)(dest + len - 1));
+		memcpy(ptr, (u8 *)(elfFile.elfFile) + offset, len);
+		loaded++;
+	}
+
 	free(elfF);
+
+	if (loaded == 0) {
+		WARN_LOG(REIOS, "Elf file has nothing to load");
+		return false;
+	}
 
 	return true;
 }


### PR DESCRIPTION
So flycast's ELF loading is pretty basic and only read program headers, so sections added after linking which have none were ignored entirely and then zeroed over by the enclosing segment's fill. This loads them too, after the segment pass so nothing clobbers them.

for the vast majority of ELFs flycast elf loader is fine but some homebrew like Bloom injects a section after linking such as the PSX BIOS Bloom embeds which gets ignored causing the elf not to work. 

https://limewire.com/d/IDaPi#4AhngTY1W8

Here is a link to the elf if you want to test.  this ELF does require MMU support so it only works on the dev branch anyway unless the MMU change you did a while back got merged to master.  The elf should work fine if converted to a .cdi this change just makes it also run just fine as a elf. 