### PR TITLE
Get Bleemcast beta titles running on flycast.

### DIFF
--- a/core/hw/sh4/modules/ccn.cpp
+++ b/core/hw/sh4/modules/ccn.cpp
@@ -58,9 +58,15 @@ static void CCN_MMUCR_write(u32 addr, u32 value)
 
 	if (mmu_changed_state)
 	{
-		//printf("<*******>MMU Enabled , ONLY SQ remaps work<*******>\n");
-		mmu_set_state();
-		emu.getSh4Executor()->ResetCache();
+		// only non-strict guests need this: strict ones keep their code and
+		// handlers across AT-off windows, where translation goes identity
+#ifdef FAST_MMU
+		if (!mmuStrict || !mmu_enabled())
+#endif
+		{
+			mmu_set_state();
+			emu.getSh4Executor()->ResetCache();
+		}
 	}
 }
 

--- a/core/hw/sh4/modules/ccn.cpp
+++ b/core/hw/sh4/modules/ccn.cpp
@@ -28,7 +28,8 @@ static void CCN_PTEH_write(u32 addr, u32 value)
 	CCN_PTEH_type temp;
 	temp.reg_data = value & 0xfffffcff;
 #ifdef FAST_MMU
-	if (temp.ASID != CCN_PTEH.ASID)
+	// strict mode never populates the LUT
+	if (temp.ASID != CCN_PTEH.ASID && !mmuStrict)
 		mmuAddressLUTFlush(false);
 #endif
 
@@ -50,6 +51,10 @@ static void CCN_MMUCR_write(u32 addr, u32 value)
 		temp.TI = 0;
 	}
 	CCN_MMUCR = temp;
+#ifdef FAST_MMU
+	// SV affects UTLB matching
+	mmuStrictCacheFlush();
+#endif
 
 	if (mmu_changed_state)
 	{

--- a/core/hw/sh4/modules/fastmmu.cpp
+++ b/core/hw/sh4/modules/fastmmu.cpp
@@ -386,6 +386,14 @@ MmuError mmu_data_translation(u32 va, u32& rv)
 		return MmuError::NONE;
 	}
 
+	if (CCN_MMUCR.AT == 0)
+	{
+		// handlers stay installed across strict guests' AT-off windows
+		rv = va;
+		mmuLastPageMask = 0xFFFFF000;
+		return MmuError::NONE;
+	}
+
 	const TLB_Entry *entry = nullptr;
 	MmuError lookup = mmu_full_lookup(va, &entry, rv);
 	if (lookup == MmuError::NONE)

--- a/core/hw/sh4/modules/fastmmu.cpp
+++ b/core/hw/sh4/modules/fastmmu.cpp
@@ -38,6 +38,10 @@ static TLB_Entry const *lru_entry;
 static u32 lru_mask;
 static u32 lru_address;
 
+// Page mask of the last successful data translation, to keep sub-4K pages
+// out of the 4K-granular mmuAddressLUT.
+u32 mmuLastPageMask = 0xFFFFF000;
+
 struct TLB_LinkedEntry {
 	TLB_Entry entry;
 	TLB_LinkedEntry *next_entry;
@@ -54,8 +58,6 @@ static u16 bucket_index(u32 address, int size, u32 asid)
 
 static void cache_entry(const TLB_Entry &entry)
 {
-	if (entry.Data.SZ0 == 0 && entry.Data.SZ1 == 0)
-		return;
 	if (full_table_size >= std::size(full_table))
 		return;
 
@@ -108,6 +110,9 @@ static bool find_entry(u32 address, const TLB_Entry **ret_entry)
 		return true;
 	// 1m
 	if (find_entry_by_page_size<3>(address, ret_entry))
+		return true;
+	// 1k last, so guests that don't use them don't pay for the probe
+	if (find_entry_by_page_size<0>(address, ret_entry))
 		return true;
 	return false;
 }
@@ -298,6 +303,7 @@ MmuError mmu_data_translation(u32 va, u32& rv)
 	if (fast_reg_lut[va >> 29] != 0)
 	{
 		rv = va;
+		mmuLastPageMask = 0xFFFFF000;
 		return MmuError::NONE;
 	}
 
@@ -305,10 +311,13 @@ MmuError mmu_data_translation(u32 va, u32& rv)
 	{
 		// On-chip RAM area isn't translated
 		rv = va;
+		mmuLastPageMask = 0xFFFFF000;
 		return MmuError::NONE;
 	}
 
 	MmuError lookup = mmu_full_lookup(va, nullptr, rv);
+	if (lookup == MmuError::NONE)
+		mmuLastPageMask = lru_mask;
 	if (lookup == MmuError::NONE && (rv & 0x1C000000) == 0x1C000000)
 		// map 1C000000-1FFFFFFF to P4 memory-mapped registers
 		rv |= 0xF0000000;

--- a/core/hw/sh4/modules/fastmmu.cpp
+++ b/core/hw/sh4/modules/fastmmu.cpp
@@ -42,6 +42,10 @@ static u32 lru_address;
 // out of the 4K-granular mmuAddressLUT.
 u32 mmuLastPageMask = 0xFFFFF000;
 
+// true for guests the cached path can't serve (sub-4K pages, ASID used as
+// dispatch, emulation driven by protection faults)
+bool mmuStrict = false;
+
 struct TLB_LinkedEntry {
 	TLB_Entry entry;
 	TLB_LinkedEntry *next_entry;
@@ -222,6 +226,29 @@ void ITLB_Sync(u32 entry)
 //Do a full lookup on the UTLB entry's
 MmuError mmu_full_lookup(u32 va, const TLB_Entry** tlb_entry_ret, u32& rv)
 {
+	if (mmuStrict)
+	{
+		// No LRU, no hash cache, no synthesized entries
+		const TLB_Entry *match = nullptr;
+		for (const TLB_Entry& tlb_entry : UTLB)
+		{
+			if (!mmu_match(va, tlb_entry.Address, tlb_entry.Data))
+				continue;
+			if (match != nullptr)
+				return MmuError::TLB_MHIT;
+			match = &tlb_entry;
+			u32 sz = tlb_entry.Data.SZ1 * 2 + tlb_entry.Data.SZ0;
+			u32 mask = mmu_mask[sz];
+			rv = ((tlb_entry.Data.PPN << 10) & mask) | (va & ~mask);
+			lru_mask = mask;
+		}
+		if (match == nullptr)
+			return MmuError::TLB_MISS;
+		if (tlb_entry_ret != nullptr)
+			*tlb_entry_ret = match;
+		return MmuError::NONE;
+	}
+
 	if (lru_entry != NULL)
 	{
 		if (/*lru_entry->Data.V == 1 && */
@@ -315,9 +342,24 @@ MmuError mmu_data_translation(u32 va, u32& rv)
 		return MmuError::NONE;
 	}
 
-	MmuError lookup = mmu_full_lookup(va, nullptr, rv);
+	const TLB_Entry *entry = nullptr;
+	MmuError lookup = mmu_full_lookup(va, &entry, rv);
 	if (lookup == MmuError::NONE)
+	{
 		mmuLastPageMask = lru_mask;
+		if (mmuStrict)
+		{
+			if ((entry->Data.PR >> 1) == 0 && Sh4cntx.sr.MD == 0)
+				return MmuError::PROTECTED;
+			if (translation_type == MMU_TT_DWRITE)
+			{
+				if ((entry->Data.PR & 1) == 0)
+					return MmuError::PROTECTED;
+				else if (entry->Data.D == 0)
+					return MmuError::FIRSTWRITE;
+			}
+		}
+	}
 	if (lookup == MmuError::NONE && (rv & 0x1C000000) == 0x1C000000)
 		// map 1C000000-1FFFFFFF to P4 memory-mapped registers
 		rv |= 0xF0000000;
@@ -339,6 +381,13 @@ template MmuError mmu_data_translation<MMU_TT_DWRITE>(u32 va, u32& rv);
 
 void mmu_flush_table()
 {
+	// TI means the guest is invalidating its own TLB, so the entries have to
+	// go and not just our caches: strict mode matches on the UTLB directly
+	for (TLB_Entry& entry : ITLB)
+		entry.Data.V = 0;
+	for (TLB_Entry& entry : UTLB)
+		entry.Data.V = 0;
+
 	lru_entry = nullptr;
 	flush_cache();
 	mmuAddressLUTFlush(true);

--- a/core/hw/sh4/modules/fastmmu.cpp
+++ b/core/hw/sh4/modules/fastmmu.cpp
@@ -46,6 +46,28 @@ u32 mmuLastPageMask = 0xFFFFF000;
 // dispatch, emulation driven by protection faults)
 bool mmuStrict = false;
 
+// Caches what the strict scan found. That scan has to look at all 64 entries,
+// so it dominates runtime. Dropped wherever the match set can change; the ASID
+// is in the tag, so switching it costs nothing.
+struct StrictCacheEntry
+{
+	u32 tag;		// bit 31 = valid | ASID << 22 | va >> 10; zero-init is empty
+	u32 mask;
+	u32 ppnBase;
+	u32 entryIdx;	// into UTLB, or StrictMissIdx for a cached miss
+};
+constexpr u32 StrictMissIdx = ~0u;
+constexpr u32 StrictCacheSize = 4096;
+static StrictCacheEntry strictCache[StrictCacheSize];
+
+void mmuStrictCacheFlush()
+{
+	// the flush sites (LDTLB above all) are hot for guests that never fill it
+	if (!mmuStrict)
+		return;
+	memset(strictCache, 0, sizeof(strictCache));
+}
+
 struct TLB_LinkedEntry {
 	TLB_Entry entry;
 	TLB_LinkedEntry *next_entry;
@@ -187,6 +209,7 @@ int main(int argc, char *argv[])
 
 bool UTLB_Sync(u32 entry)
 {
+	mmuStrictCacheFlush();
 	TLB_Entry& tlb_entry = UTLB[entry];
 	u32 sz = tlb_entry.Data.SZ1 * 2 + tlb_entry.Data.SZ0;
 
@@ -228,7 +251,20 @@ MmuError mmu_full_lookup(u32 va, const TLB_Entry** tlb_entry_ret, u32& rv)
 {
 	if (mmuStrict)
 	{
-		// No LRU, no hash cache, no synthesized entries
+		const u32 asid = CCN_PTEH.ASID;
+		const u32 tag = 0x80000000u | (asid << 22) | (va >> 10);
+		StrictCacheEntry& cached = strictCache[((va >> 10) ^ (asid << 5)) & (StrictCacheSize - 1)];
+		if (cached.tag == tag)
+		{
+			if (cached.entryIdx == StrictMissIdx)
+				return MmuError::TLB_MISS;
+			rv = cached.ppnBase | (va & ~cached.mask);
+			lru_mask = cached.mask;
+			if (tlb_entry_ret != nullptr)
+				*tlb_entry_ret = &UTLB[cached.entryIdx];
+			return MmuError::NONE;
+		}
+
 		const TLB_Entry *match = nullptr;
 		for (const TLB_Entry& tlb_entry : UTLB)
 		{
@@ -242,8 +278,16 @@ MmuError mmu_full_lookup(u32 va, const TLB_Entry** tlb_entry_ret, u32& rv)
 			rv = ((tlb_entry.Data.PPN << 10) & mask) | (va & ~mask);
 			lru_mask = mask;
 		}
+		// with SV == 1 matching depends on sr.MD, which flips on every
+		// exception, so only cache the MD-independent case
 		if (match == nullptr)
+		{
+			if (CCN_MMUCR.SV == 0)
+				cached = { tag, 0, 0, StrictMissIdx };
 			return MmuError::TLB_MISS;
+		}
+		if (CCN_MMUCR.SV == 0)
+			cached = { tag, lru_mask, rv & lru_mask, (u32)(match - &UTLB[0]) };
 		if (tlb_entry_ret != nullptr)
 			*tlb_entry_ret = match;
 		return MmuError::NONE;
@@ -391,5 +435,6 @@ void mmu_flush_table()
 	lru_entry = nullptr;
 	flush_cache();
 	mmuAddressLUTFlush(true);
+	mmuStrictCacheFlush();
 }
 #endif 	// FAST_MMU

--- a/core/hw/sh4/modules/mmu.cpp
+++ b/core/hw/sh4/modules/mmu.cpp
@@ -474,6 +474,9 @@ void mmu_set_state()
 			mmuOn = true;
 #ifdef FAST_MMU
 			mmuStrict = true;
+			// ASID changes no longer flush these in strict mode, so start clean
+			mmuAddressLUTFlush(true);
+			mmuStrictCacheFlush();
 #endif
 			static bool logged;
 			if (!logged)
@@ -631,4 +634,7 @@ void mmu_deserialize(Deserializer& deser)
 
 	deser >> sq_remap;
 	deser.skip(64 * 4, Deserializer::V23); // ITLB_LRU_USE
+#ifdef FAST_MMU
+	mmuStrictCacheFlush();
+#endif
 }

--- a/core/hw/sh4/modules/mmu.cpp
+++ b/core/hw/sh4/modules/mmu.cpp
@@ -437,6 +437,23 @@ retry_ITLB_Match:
 	return MmuError::NONE;
 }
 
+// Some titles load the UTLB with AT still 0 and enable translation last, so
+// UTLB_Sync's on-demand check never fires for them.
+static bool utlbHasRealMapping()
+{
+	for (const TLB_Entry& e : UTLB)
+	{
+		if (e.Data.V == 0)
+			continue;
+		if ((e.Address.VPN & (0xFC000000 >> 10)) == (0xE0000000 >> 10))
+			continue;	// store queue remap
+		if (e.Address.VPN == 0x30040 || e.Address.VPN == 0x30000)
+			continue;	// bogus mappings used by some arcade/VC games, as in UTLB_Sync
+		return true;
+	}
+	return false;
+}
+
 void mmu_set_state()
 {
 	if (CCN_MMUCR.AT == 1)
@@ -449,10 +466,31 @@ void mmu_set_state()
 			mmuOn = true;
 			NOTICE_LOG(SH4, "Enabling Full MMU support");
 		}
+		// WinCE gets here with a loaded UTLB too, after an AT toggle or a
+		// savestate load. Strict mode would only make it slow and raise
+		// faults it never sees, so it has to be ruled out first
+		else if (!mmuOn && utlbHasRealMapping())
+		{
+			mmuOn = true;
+#ifdef FAST_MMU
+			mmuStrict = true;
+#endif
+			static bool logged;
+			if (!logged)
+			{
+				logged = true;
+				NOTICE_LOG(SH4, "Enabling Full MMU support (UTLB loaded before AT, strict TLB)");
+			}
+		}
 	}
 	else
 	{
 		mmuOn = false;
+#ifdef FAST_MMU
+		// strict guests skip this on AT toggles, so we're resetting: don't
+		// let strict mode leak into the next guest
+		mmuStrict = false;
+#endif
 	}
 
 	SetMemoryHandlers();

--- a/core/hw/sh4/modules/mmu.h
+++ b/core/hw/sh4/modules/mmu.h
@@ -120,6 +120,7 @@ void mmu_TranslateSQW(u32 adr, u32* out);
 // maps 4K virtual page number to physical address
 extern u32 mmuAddressLUT[0x100000];
 extern u32 mmuLastPageMask;
+extern bool mmuStrict;
 
 static inline void mmuAddressLUTFlush(bool full)
 {
@@ -154,9 +155,8 @@ static inline u32 DYNACALL mmuDynarecLookup(u32 vaddr, u32 write, u32 pc)
 		return 0;
 	}
 #ifdef FAST_MMU
-	// The LUT is 4K-granular, so a smaller page must not enter it: the inline
-	// lookup then misses and calls through here.
-	if (vaddr >> 31 == 0 && (mmuLastPageMask & 0xFFF) == 0)
+	// the LUT is 4K-granular, and strict guests must miss it entirely
+	if (!mmuStrict && vaddr >> 31 == 0 && (mmuLastPageMask & 0xFFF) == 0)
 		mmuAddressLUT[vaddr >> 12] = paddr & ~0xfff;
 #endif
 

--- a/core/hw/sh4/modules/mmu.h
+++ b/core/hw/sh4/modules/mmu.h
@@ -119,6 +119,7 @@ void mmu_TranslateSQW(u32 adr, u32* out);
 #ifdef FAST_MMU
 // maps 4K virtual page number to physical address
 extern u32 mmuAddressLUT[0x100000];
+extern u32 mmuLastPageMask;
 
 static inline void mmuAddressLUTFlush(bool full)
 {
@@ -153,7 +154,9 @@ static inline u32 DYNACALL mmuDynarecLookup(u32 vaddr, u32 write, u32 pc)
 		return 0;
 	}
 #ifdef FAST_MMU
-	if (vaddr >> 31 == 0)
+	// The LUT is 4K-granular, so a smaller page must not enter it: the inline
+	// lookup then misses and calls through here.
+	if (vaddr >> 31 == 0 && (mmuLastPageMask & 0xFFF) == 0)
 		mmuAddressLUT[vaddr >> 12] = paddr & ~0xfff;
 #endif
 

--- a/core/hw/sh4/modules/mmu.h
+++ b/core/hw/sh4/modules/mmu.h
@@ -122,6 +122,9 @@ extern u32 mmuAddressLUT[0x100000];
 extern u32 mmuLastPageMask;
 extern bool mmuStrict;
 
+// call wherever the set of matching UTLB entries can change
+void mmuStrictCacheFlush();
+
 static inline void mmuAddressLUTFlush(bool full)
 {
 	if (full)

--- a/core/hw/sh4/modules/mmu.h
+++ b/core/hw/sh4/modules/mmu.h
@@ -76,7 +76,8 @@ MmuError mmu_full_SQ(u32 va, u32& rv);
 #ifdef FAST_MMU
 static inline MmuError mmu_instruction_translation(u32 va, u32& rv)
 {
-	if (fast_reg_lut[va >> 29] != 0)
+	// handlers stay installed while a strict guest has AT off, so check it here
+	if (fast_reg_lut[va >> 29] != 0 || CCN_MMUCR.AT == 0)
 	{
 		rv = va;
 		return MmuError::NONE;

--- a/core/imgread/common.cpp
+++ b/core/imgread/common.cpp
@@ -29,6 +29,11 @@ constexpr Disc* (*drivers[])(const char* path, std::vector<u8> *digest)
 
 static u8 q_subchannel[96];
 
+static u8 bin2bcd(u32 v)
+{
+	return (u8)((v % 10) | ((v / 10) << 4));
+}
+
 static bool convertSector(u8* in_buff , u8* out_buff , int from , int to,int sector)
 {
 	//get subchannel data, if any
@@ -49,8 +54,18 @@ static bool convertSector(u8* in_buff , u8* out_buff , int from , int to,int sec
 	switch (to)
 	{
 	case 2340:
-		verify(from == 2352);
-		memcpy(out_buff, &in_buff[12], 2340);
+		verify(from == 2352 || from == 2336);
+		if (from == 2336)
+		{
+			// 2336 formats have no header, synthesize one from the FAD
+			out_buff[0] = bin2bcd(sector / 75 / 60);
+			out_buff[1] = bin2bcd((sector / 75) % 60);
+			out_buff[2] = bin2bcd(sector % 75);
+			out_buff[3] = 2;
+			memcpy(&out_buff[4], in_buff, 2336);
+		}
+		else
+			memcpy(out_buff, &in_buff[12], 2340);
 		break;
 	case 2328:
 		verify(from == 2352);
@@ -313,6 +328,9 @@ u32 Disc::ReadSectors(u32 FAD, u32 count, u8* dst, u32 fmt, bool stopOnMiss, Loa
 		}
 		else if (fmt == 2048 && secfmt == SECFMT_2336_MODE2) {
 			memcpy(dst, temp + 8, 2048);
+		}
+		else if (fmt == 2340 && secfmt == SECFMT_2336_MODE2) {
+			convertSector(temp, dst, 2336, fmt, FAD);
 		}
 		else if (fmt == 2048 && (secfmt == SECFMT_2048_MODE1 || secfmt == SECFMT_2048_MODE2_FORM1)) {
 			memcpy(dst, temp, 2048);


### PR DESCRIPTION
So, this should allow the vast majority of Bleem'd games that people have been playing on real hw for years to run on flycast. I tested about 6 games from the BleemcastShindouGo archive on the dreamcasttalk.com forum. 

- Hercules 
- Army Men - Sarge's Heroes
- Medievil 2  
- Rayman 2
- Megaman Legends
- 007 Racing.

All that I tested seem to work. I couldnt test them all due to there being hundreds. 
One issue I got is many of these titles have actual renderering issues on real hardware so it is difficult to say what is 'incorrect emulation' on flycasts end or just a bleem title being broken normally.
The offical bleem titles also do not work due to how copyprotection stuff I have still yet to figure out.

I'm not confident about this PR but I thought I'd just submit it instead of just abandoning it as if someone else decides to add bleem support later they got something to go off.  I decided it be better if these changes dont impact other games as speeding up bleem titles would of involved changes that could impact multiple platforms that I cant test for. like bumping CODE_SIZE to reduce the amount of flushes. For the games I did test they seemed to run ok  albeit with some occasional stuttering.  As it stands I think the only risk this PR is to a non bleem game is if a non-WinCE title that loads real UTLB entries before enabling AT which could cause it to crash or run slower for all I know.

I guess another issue is this does add a second path through the MMU code that someone has to maintain but should make flycast slightly more accurate so kinda a trade off that's not my place to decide.

Also mmu_flush_table now clears the UTLB and ITLB valid bits, like the non-FAST_MMU version already does. After a TI the fast path kept V=1 on entries the guest had invalidated, which was harmless while nothing read those bits. The strict scan reads them now so I had to sort that out.

One thing  I didnt tackle is Flycast doesn't save which MMU mode a game is in, so it re-guesses when you load a savestate. On dev/master that guess might come back wrong already I think but i tried Mario64 and seems to be fine, but this PR adds strict mode as another thing it can wrongly guess, which would leave a non-bleem title running slower and taking faults it shouldn't. Saving mmuOn/mmuStrict in the savestate would fix it most likely, but I didnt want to touch the save format.