### PR TITLE
rend: optimize ARM64 framebuffer paths

### DIFF
--- a/core/hw/pvr/pvr_mem.cpp
+++ b/core/hw/pvr/pvr_mem.cpp
@@ -11,8 +11,6 @@
 #include "hw/holly/holly_intc.h"
 #include "serialize.h"
 
-static u32 pvr_map32(u32 offset32);
-
 RamRegion vram;
 
 // YUV converter code
@@ -286,25 +284,6 @@ void DYNACALL TAWriteSQ(u32 address, const SQBuffer *sqb)
 }
 
 //Misc interface
-
-#define VRAM_BANK_BIT 0x400000
-
-static u32 pvr_map32(u32 offset32)
-{
-	//64b wide bus is achieved by interleaving the banks every 32 bits
-	const u32 static_bits = VRAM_MASK - (VRAM_BANK_BIT * 2 - 1) + 3;
-	const u32 offset_bits = (VRAM_BANK_BIT - 1) & ~3;
-
-	u32 bank = (offset32 & VRAM_BANK_BIT) / VRAM_BANK_BIT;
-
-	u32 rv = offset32 & static_bits;
-
-	rv |= (offset32 & offset_bits) * 2;
-
-	rv |= bank * 4;
-	
-	return rv;
-}
 
 template<typename T, bool upper>
 T DYNACALL pvr_read_area4(u32 addr)

--- a/core/hw/pvr/pvr_mem.h
+++ b/core/hw/pvr/pvr_mem.h
@@ -19,6 +19,20 @@ void YUV_deserialize(Deserializer& deser);
 void YUV_reset();
 
 // 32-bit vram path handlers
+// The 32-bit bus interleaves the two VRAM banks every 32 bits.
+constexpr u32 VRAM_32_BANK_BIT = 0x400000;
+inline u32 pvr_map32(u32 offset32)
+{
+	const u32 static_bits = VRAM_MASK - (VRAM_32_BANK_BIT * 2 - 1) + 3;
+	const u32 offset_bits = (VRAM_32_BANK_BIT - 1) & ~3;
+	const u32 bank = (offset32 & VRAM_32_BANK_BIT) / VRAM_32_BANK_BIT;
+
+	u32 rv = offset32 & static_bits;
+	rv |= (offset32 & offset_bits) * 2;
+	rv |= bank * 4;
+	return rv;
+}
+
 template<typename T> T DYNACALL pvr_read32p(u32 addr);
 template<typename T, bool Internal = false> void DYNACALL pvr_write32p(u32 addr, T data);
 // Area 4 handlers

--- a/core/rend/TexCache.cpp
+++ b/core/rend/TexCache.cpp
@@ -21,7 +21,12 @@
 
 #include <mutex>
 #include <new>
+#include <type_traits>
 #include <xxhash.h>
+
+#if HOST_CPU == CPU_ARM64
+#include <arm_neon.h>
+#endif
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -851,6 +856,142 @@ void BaseTextureCacheData::SetDirectXColorOrder(bool enabled) {
 	pal_needs_update = true;
 }
 
+#if HOST_CPU == CPU_ARM64
+static inline bool pvr32SpanIsContiguous(u32 addr, u32 logicalBytes)
+{
+	const u32 maskedAddr = addr & VRAM_MASK;
+	if ((maskedAddr & 3) != 0
+			|| logicalBytes > VRAM_32_BANK_BIT
+			|| (maskedAddr & (VRAM_32_BANK_BIT - 1)) > VRAM_32_BANK_BIT - logicalBytes
+			|| maskedAddr > VRAM_MASK - (logicalBytes - 1))
+		return false;
+
+	// The 32-bit bus doubles the offset and adds bank * 4. NEON deinterleaving
+	// loads therefore access twice the logical span, including the other bank.
+	return (u64)pvr_map32(maskedAddr) + (u64)logicalBytes * 2 <= (u64)vram.getSize();
+}
+
+template<typename Packer>
+static inline void storeFramebufferRgba(u32 *dst, uint8x16_t red, uint8x16_t green, uint8x16_t blue)
+{
+	uint8x16x4_t rgba;
+	if constexpr (std::is_same_v<Packer, RGBAPacker>)
+	{
+		rgba.val[0] = red;
+		rgba.val[2] = blue;
+	}
+	else
+	{
+		rgba.val[0] = blue;
+		rgba.val[2] = red;
+	}
+	rgba.val[1] = green;
+	rgba.val[3] = vdupq_n_u8(0xff);
+	vst4q_u8((u8 *)dst, rgba);
+}
+
+template<typename Packer, bool RGB565>
+static void readFramebuffer16Line(u32 addr, u32 *dst, int width, u32 fb_concat)
+{
+	int x = 0;
+	for (; x < width && (addr & 3) != 0; x++, addr += 2)
+	{
+		const u16 src = pvr_read32p<u16>(addr);
+		if constexpr (RGB565)
+			dst[x] = Packer::pack((((src >> 11) & 0x1f) << 3) | fb_concat,
+					(((src >> 5) & 0x3f) << 2) | (fb_concat & 3),
+					((src & 0x1f) << 3) | fb_concat, 0xff);
+		else
+			dst[x] = Packer::pack((((src >> 10) & 0x1f) << 3) | fb_concat,
+					(((src >> 5) & 0x1f) << 3) | fb_concat,
+					((src & 0x1f) << 3) | fb_concat, 0xff);
+	}
+
+	for (; x + 16 <= width && pvr32SpanIsContiguous(addr, 32); x += 16, addr += 32)
+	{
+		const u8 *mapped = &vram[pvr_map32(addr)];
+		const uint16x8_t src0 = vreinterpretq_u16_u32(vld2q_u32((const u32 *)mapped).val[0]);
+		const uint16x8_t src1 = vreinterpretq_u16_u32(vld2q_u32((const u32 *)(mapped + 32)).val[0]);
+		const uint16x8_t concat5 = vdupq_n_u16(fb_concat);
+
+		uint16x8_t red0;
+		uint16x8_t red1;
+		uint16x8_t green0;
+		uint16x8_t green1;
+		if constexpr (RGB565)
+		{
+			red0 = vorrq_u16(vshlq_n_u16(vshrq_n_u16(src0, 11), 3), concat5);
+			red1 = vorrq_u16(vshlq_n_u16(vshrq_n_u16(src1, 11), 3), concat5);
+			const uint16x8_t concat6 = vdupq_n_u16(fb_concat & 3);
+			green0 = vorrq_u16(vshlq_n_u16(vandq_u16(vshrq_n_u16(src0, 5), vdupq_n_u16(0x3f)), 2), concat6);
+			green1 = vorrq_u16(vshlq_n_u16(vandq_u16(vshrq_n_u16(src1, 5), vdupq_n_u16(0x3f)), 2), concat6);
+		}
+		else
+		{
+			red0 = vorrq_u16(vshlq_n_u16(vandq_u16(vshrq_n_u16(src0, 10), vdupq_n_u16(0x1f)), 3), concat5);
+			red1 = vorrq_u16(vshlq_n_u16(vandq_u16(vshrq_n_u16(src1, 10), vdupq_n_u16(0x1f)), 3), concat5);
+			green0 = vorrq_u16(vshlq_n_u16(vandq_u16(vshrq_n_u16(src0, 5), vdupq_n_u16(0x1f)), 3), concat5);
+			green1 = vorrq_u16(vshlq_n_u16(vandq_u16(vshrq_n_u16(src1, 5), vdupq_n_u16(0x1f)), 3), concat5);
+		}
+		const uint16x8_t blue0 = vorrq_u16(vshlq_n_u16(vandq_u16(src0, vdupq_n_u16(0x1f)), 3), concat5);
+		const uint16x8_t blue1 = vorrq_u16(vshlq_n_u16(vandq_u16(src1, vdupq_n_u16(0x1f)), 3), concat5);
+		storeFramebufferRgba<Packer>(dst + x,
+				vcombine_u8(vmovn_u16(red0), vmovn_u16(red1)),
+				vcombine_u8(vmovn_u16(green0), vmovn_u16(green1)),
+				vcombine_u8(vmovn_u16(blue0), vmovn_u16(blue1)));
+	}
+
+	for (; x < width; x++, addr += 2)
+	{
+		const u16 src = pvr_read32p<u16>(addr);
+		if constexpr (RGB565)
+			dst[x] = Packer::pack((((src >> 11) & 0x1f) << 3) | fb_concat,
+					(((src >> 5) & 0x3f) << 2) | (fb_concat & 3),
+					((src & 0x1f) << 3) | fb_concat, 0xff);
+		else
+			dst[x] = Packer::pack((((src >> 10) & 0x1f) << 3) | fb_concat,
+					(((src >> 5) & 0x1f) << 3) | fb_concat,
+					((src & 0x1f) << 3) | fb_concat, 0xff);
+	}
+}
+
+template<typename Packer>
+static void readFramebufferC888Line(u32 addr, u32 *dst, int width)
+{
+	int x = 0;
+	for (; x + 8 <= width && pvr32SpanIsContiguous(addr, 32); x += 8, addr += 32)
+	{
+		const u8 *mapped = &vram[pvr_map32(addr)];
+		const uint32x4_t src0 = vld2q_u32((const u32 *)mapped).val[0];
+		const uint32x4_t src1 = vld2q_u32((const u32 *)(mapped + 32)).val[0];
+		const uint8x8_t red = vmovn_u16(vcombine_u16(
+				vmovn_u32(vshrq_n_u32(src0, 16)), vmovn_u32(vshrq_n_u32(src1, 16))));
+		const uint8x8_t green = vmovn_u16(vcombine_u16(
+				vmovn_u32(vshrq_n_u32(src0, 8)), vmovn_u32(vshrq_n_u32(src1, 8))));
+		const uint8x8_t blue = vmovn_u16(vcombine_u16(vmovn_u32(src0), vmovn_u32(src1)));
+		uint8x8x4_t rgba;
+		if constexpr (std::is_same_v<Packer, RGBAPacker>)
+		{
+			rgba.val[0] = red;
+			rgba.val[2] = blue;
+		}
+		else
+		{
+			rgba.val[0] = blue;
+			rgba.val[2] = red;
+		}
+		rgba.val[1] = green;
+		rgba.val[3] = vdup_n_u8(0xff);
+		vst4_u8((u8 *)(dst + x), rgba);
+	}
+	for (; x < width; x++, addr += 4)
+	{
+		const u32 src = pvr_read32p<u32>(addr);
+		dst[x] = Packer::pack(src >> 16, src >> 8, src, 0xff);
+	}
+}
+#endif
+
 template<typename Packer>
 void ReadFramebuffer(const FramebufferInfo& info, PixelBuffer<u32>& pb, int& width, int& height)
 {
@@ -909,6 +1050,11 @@ void ReadFramebuffer(const FramebufferInfo& info, PixelBuffer<u32>& pb, int& wid
 		case fbde_0555:    // 555 RGB
 			for (int y = 0; y < height; y++)
 			{
+#if HOST_CPU == CPU_ARM64
+				readFramebuffer16Line<Packer, false>(addr, dst, width, fb_concat);
+				dst += width;
+				addr += (width + modulus) * bpp;
+#else
 				for (int i = 0; i < width; i++)
 				{
 					u16 src = pvr_read32p<u16>(addr);
@@ -920,12 +1066,18 @@ void ReadFramebuffer(const FramebufferInfo& info, PixelBuffer<u32>& pb, int& wid
 					addr += bpp;
 				}
 				addr += modulus * bpp;
+#endif
 			}
 			break;
 
 		case fbde_565:    // 565 RGB
 			for (int y = 0; y < height; y++)
 			{
+#if HOST_CPU == CPU_ARM64
+				readFramebuffer16Line<Packer, true>(addr, dst, width, fb_concat);
+				dst += width;
+				addr += (width + modulus) * bpp;
+#else
 				for (int i = 0; i < width; i++)
 				{
 					u16 src = pvr_read32p<u16>(addr);
@@ -937,6 +1089,7 @@ void ReadFramebuffer(const FramebufferInfo& info, PixelBuffer<u32>& pb, int& wid
 					addr += bpp;
 				}
 				addr += modulus * bpp;
+#endif
 			}
 			break;
 		case fbde_888:		// 888 RGB
@@ -967,6 +1120,11 @@ void ReadFramebuffer(const FramebufferInfo& info, PixelBuffer<u32>& pb, int& wid
 		case fbde_C888:     // 0888 RGB
 			for (int y = 0; y < height; y++)
 			{
+#if HOST_CPU == CPU_ARM64
+				readFramebufferC888Line<Packer>(addr, dst, width);
+				dst += width;
+				addr += (width + modulus) * bpp;
+#else
 				for (int i = 0; i < width; i++)
 				{
 					u32 src = pvr_read32p<u32>(addr);
@@ -974,6 +1132,7 @@ void ReadFramebuffer(const FramebufferInfo& info, PixelBuffer<u32>& pb, int& wid
 					addr += bpp;
 				}
 				addr += modulus * bpp;
+#endif
 			}
 			break;
 	}
@@ -1353,22 +1512,154 @@ static void writeFramebufferLW(u32 width, u32 height, const u8 *data, u32 dstAdd
 	}
 }
 
+#if HOST_CPU == CPU_ARM64
+template<int PackMode, int Red, int Green, int Blue, int Alpha>
+static inline u16 packFramebuffer16Pixel(const u8 *pixel, FB_W_CTRL_type fb_w_ctrl)
+{
+	const u16 red = pixel[Red];
+	const u16 green = pixel[Green];
+	const u16 blue = pixel[Blue];
+	if constexpr (PackMode == 0)
+		return ((red >> 3) << 10) | ((green >> 3) << 5) | (blue >> 3)
+				| ((fb_w_ctrl.fb_kval & 0x80) << 8);
+	else if constexpr (PackMode == 1)
+		return ((red >> 3) << 11) | ((green >> 2) << 5) | (blue >> 3);
+	else if constexpr (PackMode == 2)
+		return ((pixel[Alpha] >> 4) << 12) | ((red >> 4) << 8)
+				| ((green >> 4) << 4) | (blue >> 4);
+	else
+		return (pixel[Alpha] >= fb_w_ctrl.fb_alpha_threshold ? 0x8000 : 0)
+				| ((red >> 3) << 10) | ((green >> 3) << 5) | (blue >> 3);
+}
+
+template<int PackMode>
+static inline uint16x8_t packFramebuffer16Pixels(uint8x8_t red, uint8x8_t green,
+		uint8x8_t blue, uint8x8_t alpha, FB_W_CTRL_type fb_w_ctrl)
+{
+	const uint16x8_t red16 = vmovl_u8(red);
+	const uint16x8_t green16 = vmovl_u8(green);
+	const uint16x8_t blue16 = vmovl_u8(blue);
+	if constexpr (PackMode == 0)
+	{
+		uint16x8_t packed = vshlq_n_u16(vshrq_n_u16(red16, 3), 10);
+		packed = vorrq_u16(packed, vshlq_n_u16(vshrq_n_u16(green16, 3), 5));
+		packed = vorrq_u16(packed, vshrq_n_u16(blue16, 3));
+		return vorrq_u16(packed, vdupq_n_u16((fb_w_ctrl.fb_kval & 0x80) << 8));
+	}
+	else if constexpr (PackMode == 1)
+	{
+		uint16x8_t packed = vshlq_n_u16(vshrq_n_u16(red16, 3), 11);
+		packed = vorrq_u16(packed, vshlq_n_u16(vshrq_n_u16(green16, 2), 5));
+		return vorrq_u16(packed, vshrq_n_u16(blue16, 3));
+	}
+	else if constexpr (PackMode == 2)
+	{
+		uint16x8_t packed = vshlq_n_u16(vshrq_n_u16(vmovl_u8(alpha), 4), 12);
+		packed = vorrq_u16(packed, vshlq_n_u16(vshrq_n_u16(red16, 4), 8));
+		packed = vorrq_u16(packed, vshlq_n_u16(vshrq_n_u16(green16, 4), 4));
+		return vorrq_u16(packed, vshrq_n_u16(blue16, 4));
+	}
+	else
+	{
+		uint16x8_t packed = vshlq_n_u16(vshrq_n_u16(red16, 3), 10);
+		packed = vorrq_u16(packed, vshlq_n_u16(vshrq_n_u16(green16, 3), 5));
+		packed = vorrq_u16(packed, vshrq_n_u16(blue16, 3));
+		const uint16x8_t alphaBit = vandq_u16(
+				vshlq_n_u16(vmovl_u8(vcge_u8(alpha, vdup_n_u8(fb_w_ctrl.fb_alpha_threshold))), 8),
+				vdupq_n_u16(0x8000));
+		return vorrq_u16(packed, alphaBit);
+	}
+}
+
+static inline void storeFramebuffer16Pixels(u8 *mapped, uint16x8_t pixels0, uint16x8_t pixels1)
+{
+	const uint32x4_t pairs0 = vreinterpretq_u32_u16(pixels0);
+	const uint32x4_t pairs1 = vreinterpretq_u32_u16(pixels1);
+	vst1q_lane_u32((u32 *)(mapped + 0), pairs0, 0);
+	vst1q_lane_u32((u32 *)(mapped + 8), pairs0, 1);
+	vst1q_lane_u32((u32 *)(mapped + 16), pairs0, 2);
+	vst1q_lane_u32((u32 *)(mapped + 24), pairs0, 3);
+	vst1q_lane_u32((u32 *)(mapped + 32), pairs1, 0);
+	vst1q_lane_u32((u32 *)(mapped + 40), pairs1, 1);
+	vst1q_lane_u32((u32 *)(mapped + 48), pairs1, 2);
+	vst1q_lane_u32((u32 *)(mapped + 56), pairs1, 3);
+}
+
+template<int PackMode, int Red, int Green, int Blue, int Alpha>
+static void writeFramebuffer16Neon(u32 width, u32 height, const u8 *data, u32 dstAddr,
+		FB_W_CTRL_type fb_w_ctrl, u32 linestride, const Rect& clip)
+{
+	u32 padding = linestride;
+	if (padding > width * 2)
+		padding -= width * 2;
+	else
+		padding = 0;
+
+	const int clipWidth = std::min<int>(width, clip.origin.x + clip.size.x);
+	height = std::min<u32>(height, clip.origin.y + clip.size.y);
+	if (clip.origin.x >= clipWidth || clip.origin.y >= (int)height)
+		return;
+
+	const u32 lineStride = width * 2 + padding;
+	const int count = clipWidth - clip.origin.x;
+	for (u32 y = clip.origin.y; y < height; y++)
+	{
+		const u8 *pixel = data + ((size_t)y * width + clip.origin.x) * 4;
+		u32 addr = dstAddr + y * lineStride + clip.origin.x * 2;
+		int x = 0;
+		for (; x < count && (addr & 3) != 0; x++, addr += 2, pixel += 4)
+			pvr_write32p<u16, true>(addr, packFramebuffer16Pixel<PackMode, Red, Green, Blue, Alpha>(pixel, fb_w_ctrl));
+
+		for (; x + 16 <= count && pvr32SpanIsContiguous(addr, 32); x += 16, addr += 32, pixel += 64)
+		{
+			const uint8x16x4_t rgba = vld4q_u8(pixel);
+			const uint16x8_t packed0 = packFramebuffer16Pixels<PackMode>(
+					vget_low_u8(rgba.val[Red]), vget_low_u8(rgba.val[Green]),
+					vget_low_u8(rgba.val[Blue]), vget_low_u8(rgba.val[Alpha]), fb_w_ctrl);
+			const uint16x8_t packed1 = packFramebuffer16Pixels<PackMode>(
+					vget_high_u8(rgba.val[Red]), vget_high_u8(rgba.val[Green]),
+					vget_high_u8(rgba.val[Blue]), vget_high_u8(rgba.val[Alpha]), fb_w_ctrl);
+			storeFramebuffer16Pixels(&vram[pvr_map32(addr)], packed0, packed1);
+		}
+
+		for (; x < count; x++, addr += 2, pixel += 4)
+			pvr_write32p<u16, true>(addr, packFramebuffer16Pixel<PackMode, Red, Green, Blue, Alpha>(pixel, fb_w_ctrl));
+	}
+}
+#endif
+
 template<int Red, int Green, int Blue, int Alpha>
 void WriteFramebuffer(u32 width, u32 height, const u8 *data, u32 dstAddr, FB_W_CTRL_type fb_w_ctrl, u32 linestride, const Rect& clip)
 {
 	switch (fb_w_ctrl.fb_packmode)
 	{
 	case 0: // 0555 KRGB 16 bit
+#if HOST_CPU == CPU_ARM64
+		writeFramebuffer16Neon<0, Red, Green, Blue, Alpha>(width, height, data, dstAddr, fb_w_ctrl, linestride, clip);
+#else
 		writeFramebufferLW<FBLineWriter0555<Red, Green, Blue, Alpha, FBPixelWriter>>(width, height, data, dstAddr, fb_w_ctrl, linestride, clip);
+#endif
 		break;
 	case 1: // 565 RGB 16 bit
+#if HOST_CPU == CPU_ARM64
+		writeFramebuffer16Neon<1, Red, Green, Blue, Alpha>(width, height, data, dstAddr, fb_w_ctrl, linestride, clip);
+#else
 		writeFramebufferLW<FBLineWriter565<Red, Green, Blue, Alpha, FBPixelWriter>>(width, height, data, dstAddr, fb_w_ctrl, linestride, clip);
+#endif
 		break;
 	case 2: // 4444 ARGB 16 bit
+#if HOST_CPU == CPU_ARM64
+		writeFramebuffer16Neon<2, Red, Green, Blue, Alpha>(width, height, data, dstAddr, fb_w_ctrl, linestride, clip);
+#else
 		writeFramebufferLW<FBLineWriter4444<Red, Green, Blue, Alpha, FBPixelWriter>>(width, height, data, dstAddr, fb_w_ctrl, linestride, clip);
+#endif
 		break;
 	case 3: // 1555 ARGB 16 bit
+#if HOST_CPU == CPU_ARM64
+		writeFramebuffer16Neon<3, Red, Green, Blue, Alpha>(width, height, data, dstAddr, fb_w_ctrl, linestride, clip);
+#else
 		writeFramebufferLW<FBLineWriter1555<Red, Green, Blue, Alpha, FBPixelWriter>>(width, height, data, dstAddr, fb_w_ctrl, linestride, clip);
+#endif
 		break;
 	case 4: // 888 RGB 24 bit packed
 		writeFramebufferLW<FBLineWriter888<Red, Green, Blue, Alpha, FBPixelWriter>>(width, height, data, dstAddr, fb_w_ctrl, linestride, clip);

--- a/core/stdclass.h
+++ b/core/stdclass.h
@@ -103,6 +103,9 @@ public:
 	void zero() {
 		std::memset(data, 0, size);
 	}
+	size_t getSize() const {
+		return size;
+	}
 
 	u8& operator [](size_t i) {
 		return data[i];


### PR DESCRIPTION
## Summary

- Add ARM64 NEON paths for framebuffer conversion and VRAM writes.
- Preserve scalar fallbacks for unsupported or unaligned regions.
- Validate the physical VRAM allocation before vector reads, preventing out-of-bounds access with both 8 MB and 16 MB VRAM configurations.