### PR TITLE
ui: display FPS with two decimal places

### DIFF
--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1430,7 +1430,7 @@ static std::string getFPSNotification()
 		}
 		if (fps >= 0.f && fps < 9999.f) {
 			char text[32];
-			snprintf(text, sizeof(text), "F:%4.1f%s", fps, settings.input.fastForwardMode ? " >>" : "");
+			snprintf(text, sizeof(text), "F:%5.2f%s", fps, settings.input.fastForwardMode ? " >>" : "");
 
 			return std::string(text);
 		}


### PR DESCRIPTION
Display the FPS counter with two decimal places instead of one.

This makes fractional refresh rates such as 59.94 Hz easier to distinguish, which is useful when checking the actual video refresh rate.

This only changes the FPS display formatting and does not affect timing or emulation behavior.