### PR TITLE
OpenGL: fix per-frame VAO leak in the ImGui GL3 backend

### DIFF
--- a/core/deps/imgui/backends/imgui_impl_opengl3.cpp
+++ b/core/deps/imgui/backends/imgui_impl_opengl3.cpp
@@ -278,15 +278,9 @@ static void ImGui_ImplOpenGL3_SetupRenderState(ImDrawData* draw_data, int fb_wid
     if (bd->HasBindSampler && glBindSampler != NULL)
     	glBindSampler(0, 0); // We use combined texture/sampler state. Applications using GL 3.3 may set that otherwise.
 #endif
-    vertex_array_object = 0;
 #ifndef GLES2
     if (GLGraphicsContext::Instance()->getMajorVersion() >= 3)
-    {
-		// Recreate the VAO every time
-		// (This is to easily allow multiple GL contexts. VAO are not shared among GL contexts, and we don't track creation/deletion of windows so we don't have an obvious key to use to cache them.)
-		glGenVertexArrays(1, &vertex_array_object);
 		glBindVertexArray(vertex_array_object);
-    }
 #endif
     glBindBuffer(GL_ARRAY_BUFFER, bd->VboHandle);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, bd->ElementsHandle);
@@ -325,6 +319,10 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data)
     // Recreate the VAO every time (this is to easily allow multiple GL contexts to be rendered to. VAO are not shared among GL contexts)
     // The renderer would actually work without any VAO bound, but then our VertexAttrib calls would overwrite the default one currently bound.
     GLuint vertex_array_object = 0;
+#ifndef GLES2
+    if (GLGraphicsContext::Instance()->getMajorVersion() >= 3)
+        glGenVertexArrays(1, &vertex_array_object);
+#endif
     ImGui_ImplOpenGL3_SetupRenderState(draw_data, fb_width, fb_height, vertex_array_object);
 
     // Will project scissor/clipping rectangles into framebuffer space


### PR DESCRIPTION
# OpenGL: fix per-frame VAO leak in the ImGui GL3 backend

Fixes #2462.

### The bug

`ImGui_ImplOpenGL3_SetupRenderState` generates the VAO into its `vertex_array_object`
parameter, which is passed **by value**:

```c
static void ImGui_ImplOpenGL3_SetupRenderState(..., GLuint vertex_array_object)
{
    ...
    glGenVertexArrays(1, &vertex_array_object);   // writes the local copy only
    glBindVertexArray(vertex_array_object);
}
```

so the name never reaches the caller, `ImGui_ImplOpenGL3_RenderDrawData`, where it is still
`0`:

```c
GLuint vertex_array_object = 0;
ImGui_ImplOpenGL3_SetupRenderState(..., vertex_array_object); // by value
...
if (vertex_array_object != 0)                    // still 0 — never true
    glDeleteVertexArrays(1, &vertex_array_object);
```

The guard is false, `glDeleteVertexArrays` never runs, and **a VAO is leaked every frame**.
The OSD overlay is drawn every frame, so on Mesa/radeonsi host memory grows unbounded until
OOM (~370–535 MiB/h in my testing). The Vulkan renderer's ImGui backend keeps persistent
buffers and is unaffected — which is the tell.

### The fix

Cache the VAO in a single persistent handle (flycast uses one GL context) and drop the dead
delete. The vertex-attrib state is re-established every frame in `SetupRenderState`, so a
single reused VAO is correct.

### Validation

Built and run on Linux / AMD Radeon 780M (radeonsi), OpenGL:

- **Before:** RSS climbs linearly (~370–535 MiB/h), no plateau.
- **After:** RSS plateaus — Sonic Adventure flat at ~200 MiB over 30 min; Crazy Taxi
  byte-identical over 10 min. Vulkan already flat, unchanged.

Rendering and the in-emulator ImGui menus verified visually with the cached VAO.

<sub>Analysis and reproduction assisted by an AI tool; the patch was built and verified on real hardware. (No LLM policy in this repo — remove if unwanted.)</sub>
