### PR TITLE
ci: build the Switch core here, with CMake

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,11 @@
     IOS_MINVER: 13.0
     MINVER: 13.0
 
+.core-defs-libnx:
+  extends: .core-defs
+  variables:
+    CORE_ARGS: -DLIBRETRO=ON -DUSE_OPENMP=OFF
+
 .core-defs-android:
   extends: .core-defs
   script:
@@ -80,8 +85,8 @@ include:
 
   ################################## CONSOLES ################################  
   # Nintendo Switch
-#  - project: 'libretro-infrastructure/ci-templates'
-#    file: '/libnx-static.yml'
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/libnx-static-cmake.yml'
 
   # tvOS arm64
   - project: 'libretro-infrastructure/ci-templates'
@@ -182,10 +187,10 @@ libretro-build-ios-arm64:
 
 ################################### CONSOLES #################################
 # Nintendo Switch
-#libretro-build-libnx-aarch64:
-#  extends:
-#    - .libretro-libnx-static-retroarch-master
-#    - .core-defs
+libretro-build-libnx-aarch64:
+  extends:
+    - .libretro-libnx-static-cmake-retroarch-master
+    - .core-defs-libnx
 
 # tvOS arm64
 libretro-build-tvos-arm64:


### PR DESCRIPTION
The libretro Switch core on the buildbot still comes from the old `libretro/flycast` tree — that project's `libretro-build-libnx-aarch64` job is green, and it is what publishes `flycast_libretro_libnx.nro` today. Here the job has been commented out since the CI file was written, because it extends `.libretro-libnx-static-retroarch-master`, which runs `make -f Makefile platform=libnx`, and this tree has no Makefile.

There is a CMake version of that template (`libnx-static-cmake.yml`), and the CMakeLists here already knows how to build for Switch: `NINTENDO_SWITCH` plus `LIBRETRO` gives a static library named `flycast_libretro_libnx`, with `shell/switch` on the include path and `HAVE_LIBNX`. The devkitPro `Switch.cmake` toolchain the template passes is what sets `NINTENDO_SWITCH`, so the two line up as they are.

So this just points the job at the CMake template and adds a `.core-defs-libnx` with `-DLIBRETRO=ON -DUSE_OPENMP=OFF` — no libcdio, and no OpenMP, matching what the Android defs do.

**Preflight**: built in the `devkitpro/devkita64` container with exactly the cmake invocation the template uses ([run](https://github.com/WizzardSK/flycast/actions/runs/33788724830)) — 160 MB `build/libnx/flycast_libretro_libnx.a`, which is the file the template hands to the RetroArch static link. That last link step only exists on the buildbot, so it is the one part not covered here.
