### PR TITLE
gitlab-ci: build the Switch core's combined archive

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -191,6 +191,20 @@ libretro-build-libnx-aarch64:
   extends:
     - .libretro-libnx-static-cmake-retroarch-master
     - .core-defs-libnx
+  # The template's script, with one word changed. It builds --target
+  # ${CORENAME}_libretro, and on Switch that target is flycast's own objects
+  # and nothing else. `combined` is the target CMakeLists.txt defines for
+  # exactly this case: it folds in xxhash, chdr, zip, elf and the resources,
+  # which is what RetroArch links against afterwards.
+  script:
+    - cmake $CORE_ARGS "$CMAKE_SOURCE_ROOT" -B$BUILD_DIR -DCMAKE_BUILD_TYPE=Release -DLIBRETRO_STATIC=ON -DLIBRETRO_SUFFIX=_libnx -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/Switch.cmake -DNSWITCH=ON -DCFLAGS=-DHAVE_LIBNX=1 -DCXXFLAGS=-DHAVE_LIBNX=1
+    - cmake --build $BUILD_DIR --target combined --config Release -- -j $NUMPROC
+    - mv $BUILD_DIR/$EXTRA_PATH/${CORENAME}_libretro_libnx.a retroarch-precompiled/libretro_libnx.a
+    - cd retroarch-precompiled/
+    - make -f Makefile.libnx -j10
+    - mv retroarch_switch.nro ../${CORENAME}_libretro_libnx.nro
+    - mv retroarch_switch.elf ../${CORENAME}_libretro_libnx.elf
+    - cd ../
 
 # tvOS arm64
 libretro-build-tvos-arm64:


### PR DESCRIPTION
Follow-up to #2465: the Switch job builds, but the archive it hands to RetroArch is incomplete.

The libnx template runs `cmake --build $BUILD_DIR --target ${CORENAME}_libretro`, and on Switch that target is flycast's own objects and nothing else. The dependencies — xxhash, chdr, zip, elf and the resources — are folded in by the `combined` target that `CMakeLists.txt` defines for exactly this case:

```cmake
add_custom_target(combined ALL
    COMMAND ${CMAKE_AR} -x $<TARGET_FILE:xxHash::xxhash>
    ...
    COMMAND ${CMAKE_AR} -rs flycast_libretro_libnx.a *.o
```

`ALL` means a plain `cmake --build` gets it; naming a single target does not. So the job takes the template's script with that one word changed.

Measured on a devkitA64 container, configuring exactly the way the template does:

| target | members | size | `chd.o` / `xxhash.o` / `zip_*.o` |
|---|---|---|---|
| `flycast_libretro` | 251 | 160,395,522 | absent |
| `combined` | 409 | 171,338,952 | present |

[The run](https://github.com/WizzardSK/flycast-libretro/actions/runs/33970375853) builds the first, checks the archive, then builds the second and checks again.

Without this, `make -f Makefile.libnx` in `retroarch-precompiled` links against 158 missing objects.

The alternative would be to move the `combined` commands into a `POST_BUILD` step on the library target, so that building `flycast_libretro` always produces the complete archive and no CI knows about it — happy to do that instead if you prefer it.
