### PR TITLE
gitlab-ci: the Switch job's image has a CMake older than this tree needs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -191,6 +191,15 @@ libretro-build-libnx-aarch64:
   extends:
     - .libretro-libnx-static-cmake-retroarch-master
     - .core-defs-libnx
+  # The libnx image ships CMake 3.18.4 and this tree asks for 3.22.1, so the
+  # job stops at configure. Put a newer one in front of it - in /tmp, since
+  # the job does not run as a user who can write /opt.
+  before_script:
+    - !reference [.libretro-libnx-static-cmake, before_script]
+    - |
+      CMAKE_VER=3.31.6
+      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /tmp
+      export PATH="/tmp/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
   # The template's script, with one word changed. It builds --target
   # ${CORENAME}_libretro, and on Switch that target is flycast's own objects
   # and nothing else. `combined` is the target CMakeLists.txt defines for


### PR DESCRIPTION
The Switch job builds now, but the buildbot's image cannot configure it ([pipeline 108461](https://git.libretro.com/libretro/flycast-upstream/-/pipelines/108461)):

```
CMake Error at CMakeLists.txt:6 (cmake_minimum_required):
  CMake 3.22.1 or higher is required.  You are running version 3.18.4
```

`libretro-build-libnx-devkitpro:v4-10-0` ships CMake 3.18.4, and `CMakeLists.txt` asks for 3.22.1. Nothing else in the job is wrong - it stops before it compiles a line. This puts a current CMake on the path first, the same way the windows and 3DS jobs of other cores do. It goes to `/tmp` rather than `/opt` because that job does not run as root.

Verified on GitHub Actions:

- with CMake 3.31.6 on the path, `devkitpro/devkita64` configures this tree with the job's exact arguments and builds the `combined` target: `flycast_libretro_libnx.a`, 171 MB, in about four minutes.
- the fetch itself works as a user who cannot write `/opt` - `mkdir /opt/...` gives `Permission denied`, the tarball unpacks into `/tmp`, and `command -v cmake` then resolves to `/tmp/cmake-3.31.6-linux-x86_64/bin/cmake`.

I could not run it in the buildbot's own image: that registry is not anonymously pullable, so the 3.18.4 figure above is from the job log rather than from a run of mine.