### PR TITLE
The Switch archive is missing zstd and tinygettext

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1482,12 +1482,15 @@ if(NINTENDO_SWITCH)
 			COMMAND ${CMAKE_AR} -x $<TARGET_FILE:xxHash::xxhash>
 			COMMAND ${CMAKE_AR} -x $<TARGET_FILE:chdr-static>
 			COMMAND ${CMAKE_AR} -x $<TARGET_FILE:zip>
+			COMMAND ${CMAKE_AR} -x $<TARGET_FILE:libzstd_static>
 			COMMAND ${CMAKE_AR} -x $<TARGET_FILE:elf>
+			COMMAND ${CMAKE_AR} -x $<TARGET_FILE:tinygettext::tinygettext>
 			COMMAND ${CMAKE_AR} -x $<TARGET_FILE:flycast::res>
 			COMMAND ${CMAKE_AR} -rs flycast_libretro_libnx.a *.o
 			COMMAND rm *.o
 			WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
-			DEPENDS xxHash::xxhash chdr-static zip ${PROJECT_NAME})
+			DEPENDS xxHash::xxhash chdr-static zip libzstd_static
+				tinygettext::tinygettext ${PROJECT_NAME})
 	else()
 		nx_generate_nacp(flycast.nacp NAME "Flycast" AUTHOR "flyinghead, M4xw" VERSION "${GIT_VERSION}")
 		nx_create_nro(flycast NACP flycast.nacp ICON "${CMAKE_SOURCE_DIR}/shell/switch/flycast.jpeg")


### PR DESCRIPTION
With the CMake version sorted out (#2476), the Switch job now compiles the whole tree and gets as far as RetroArch's link, which is where [pipeline 108657](https://git.libretro.com/libretro/flycast-upstream/-/pipelines/108657) stops:

```
ld: core/oslib/i18n.cpp:148: undefined reference to
    `tinygettext::Log::set_log_error_callback(void (*)(std::string const&))'
ld: core/deps/libzip/lib/zip_algorithm_zstd.c:252: undefined reference to `ZSTD_isError'
```

The `combined` target folds xxhash, chdr, zip, elf and the resources into `flycast_libretro_libnx.a`, and those two are not in the list: libzip's zstd backend needs `libzstd_static`, and `core/oslib/i18n.cpp` needs tinygettext. On every other target they come in as ordinary link libraries; on Switch RetroArch links a single archive, so anything not folded in is simply absent. My own omission from #2471 - I built the archive but never got to see the link that consumes it.

Verified on GitHub Actions in `devkitpro/devkita64`: the target builds, and `aarch64-none-elf-nm --defined-only` on the resulting 186 MB archive now shows `T ZSTD_isError` and tinygettext's `set_log_error_callback`, neither of which was there before.