### PR TITLE
The Switch archive loses XXH32 to zstd's own copy of xxhash.c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1478,16 +1478,33 @@ endif()
 
 if(NINTENDO_SWITCH)
 	if(LIBRETRO)
+		# ar names a member after the basename of the object, so extracting every
+		# archive into one directory loses whatever two of them happen to share:
+		# zstd carries its own copy of xxhash.c, whose object lands on top of the
+		# real xxHash one and takes XXH32 with it. A directory per archive keeps
+		# them apart.
 		add_custom_target(combined ALL
-			COMMAND ${CMAKE_AR} -x $<TARGET_FILE:xxHash::xxhash>
-			COMMAND ${CMAKE_AR} -x $<TARGET_FILE:chdr-static>
-			COMMAND ${CMAKE_AR} -x $<TARGET_FILE:zip>
-			COMMAND ${CMAKE_AR} -x $<TARGET_FILE:libzstd_static>
-			COMMAND ${CMAKE_AR} -x $<TARGET_FILE:elf>
-			COMMAND ${CMAKE_AR} -x $<TARGET_FILE:tinygettext::tinygettext>
-			COMMAND ${CMAKE_AR} -x $<TARGET_FILE:flycast::res>
-			COMMAND ${CMAKE_AR} -rs flycast_libretro_libnx.a *.o
-			COMMAND rm *.o
+			COMMAND ${CMAKE_COMMAND} -E rm -rf combined-objs
+			COMMAND ${CMAKE_COMMAND} -E make_directory
+				combined-objs/xxhash combined-objs/chdr combined-objs/zip
+				combined-objs/zstd combined-objs/elf combined-objs/tinygettext
+				combined-objs/res
+			COMMAND ${CMAKE_COMMAND} -E chdir combined-objs/xxhash
+				${CMAKE_AR} -x $<TARGET_FILE:xxHash::xxhash>
+			COMMAND ${CMAKE_COMMAND} -E chdir combined-objs/chdr
+				${CMAKE_AR} -x $<TARGET_FILE:chdr-static>
+			COMMAND ${CMAKE_COMMAND} -E chdir combined-objs/zip
+				${CMAKE_AR} -x $<TARGET_FILE:zip>
+			COMMAND ${CMAKE_COMMAND} -E chdir combined-objs/zstd
+				${CMAKE_AR} -x $<TARGET_FILE:libzstd_static>
+			COMMAND ${CMAKE_COMMAND} -E chdir combined-objs/elf
+				${CMAKE_AR} -x $<TARGET_FILE:elf>
+			COMMAND ${CMAKE_COMMAND} -E chdir combined-objs/tinygettext
+				${CMAKE_AR} -x $<TARGET_FILE:tinygettext::tinygettext>
+			COMMAND ${CMAKE_COMMAND} -E chdir combined-objs/res
+				${CMAKE_AR} -x $<TARGET_FILE:flycast::res>
+			COMMAND ${CMAKE_AR} -rs flycast_libretro_libnx.a combined-objs/*/*.o
+			COMMAND ${CMAKE_COMMAND} -E rm -rf combined-objs
 			WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
 			DEPENDS xxHash::xxhash chdr-static zip libzstd_static
 				tinygettext::tinygettext ${PROJECT_NAME})


### PR DESCRIPTION
The libnx job has failed since #2477 went in, at the final link of `retroarch_switch.elf`:

```
libretro_libnx.a(texconv.o): in function `palette_update()':
core/rend/texconv.cpp:151: undefined reference to `XXH32'
core/rend/TexCache.cpp:415: undefined reference to `XXH32_createState'
...
```

`XXH32` went missing from an archive whose first command extracts xxHash.

`ar` names a member after the basename of its object, and zstd builds its own vendored `lib/common/xxhash.c` - namespaced to `ZSTD_`, so it defines `ZSTD_XXH32` and not `XXH32`. Both archives therefore carry a member called `xxhash.c.o`, and `combined` extracts every archive into one directory, so the second one lands on top of the first. Before #2477 zstd was not extracted and the collision did not exist; now it is, and it wins.

Giving each archive a directory of its own keeps every object, whatever it is called.

Checked on a CMake project of the same shape - two static libraries whose members collide, plus a core object - built with the old commands and with these:

```
flat, as now:       core_main, ZSTD_XXH32
a directory each:   core_main, ZSTD_XXH32, XXH32
```

The `-E chdir` calls and the glob in the final `ar -rs` were run through that same test, including the cleanup, so the mechanics work as written. What I could not do is run it on the buildbot: I have no Switch toolchain here, so the proof is the shape of the failure rather than a green pipeline.
