### PR TITLE
ci: verify macOS signatures and upload packaged artifacts

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -22,10 +22,10 @@ jobs:
       matrix:
         config:
           - { name: i686-pc-windows-msvc, os: windows-2022, shell: cmd, arch: x86, cmakeArgs: -G Ninja, buildType: Release }
-          - { name: apple-darwin, os: macos-latest, shell: sh, cmakeArgs: -G Xcode -DUSE_DISCORD=ON -DMOLTENVK_DYLIB=$MOLTENVK_DYLIB, destDir: osx, buildType: RelWithDebInfo }
+          - { name: apple-darwin, os: macos-latest, shell: sh, cmakeArgs: -G Xcode -DUSE_DISCORD=ON -DMOLTENVK_DYLIB=$MOLTENVK_DYLIB, destDir: osx, buildType: RelWithDebInfo, packagePath: artifact/flycast-apple-darwin.zip }
           - { name: x86_64-pc-linux-gnu, os: ubuntu-22.04, shell: sh, cmakeArgs: -G Ninja -DUSE_DISCORD=ON -DUSE_LIBCDIO=ON, destDir: linux, buildType: RelWithDebInfo }
           - { name: x86_64-pc-windows-msvc, os: windows-2022, shell: cmd, arch: x64, cmakeArgs: -G Ninja -DUSE_DISCORD=ON, buildType: Release }
-          - { name: x86_64-w64-mingw32, os: windows-2022, shell: 'msys2 {0}', cmakeArgs: -G Ninja -DUSE_DISCORD=ON -DUSE_LIBCDIO=ON, destDir: win, buildType: RelWithDebInfo }
+          - { name: x86_64-w64-mingw32, os: windows-2022, shell: 'msys2 {0}', cmakeArgs: -G Ninja -DUSE_DISCORD=ON -DUSE_LIBCDIO=ON, destDir: win, buildType: RelWithDebInfo, packagePath: artifact/flycast-x86_64-w64-mingw32.zip }
           - { name: libretro-x86_64-pc-linux-gnu, os: ubuntu-22.04, shell: sh, cmakeArgs: -DLIBRETRO=ON -DUSE_LIBCDIO=ON -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -G Ninja, buildType: Release }
           - { name: libretro-x86_64-w64-mingw32, os: windows-2022, shell: 'msys2 {0}', cmakeArgs: -DLIBRETRO=ON -DUSE_LIBCDIO=ON -G Ninja, buildType: Release }
 
@@ -154,24 +154,28 @@ jobs:
           rm artifact/bin/flycast
         if: matrix.config.name == 'x86_64-pc-linux-gnu'
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: flycast-${{ matrix.config.name }}
-          path: |
-            artifact/bin
-            artifact/lib/libretro
-
       - name: Package app (macos)
         run: |
           cd artifact/bin
+          codesign --verify --deep --strict --all-architectures --verbose=4 Flycast.app
           zip -rm flycast.app.zip Flycast.app
+          cp flycast.app.zip "../../${{ matrix.config.packagePath }}"
         if: matrix.config.name == 'apple-darwin'
 
       - name: Package app (windows)
         run: |
           powershell Compress-Archive artifact/bin/flycast.exe artifact/bin/flycast.zip 
           rm artifact/bin/flycast.exe
+          cp artifact/bin/flycast.zip "${{ matrix.config.packagePath }}"
         if: matrix.config.name == 'x86_64-w64-mingw32'
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: flycast-${{ matrix.config.name }}
+          archive: ${{ !matrix.config.packagePath }}
+          path: |
+            ${{ matrix.config.packagePath || 'artifact/bin' }}
+            ${{ !matrix.config.packagePath && 'artifact/lib/libretro' || '' }}
 
       - name: Setup Rclone
         uses: AnimMouse/setup-rclone@v1


### PR DESCRIPTION
Verify the installed macOS app’s signatures, including nested code and all architectures, before packaging or publishing.

Move macOS (`apple-darwin`) and MinGW Windows (`x86_64-w64-mingw32`) packaging before GitHub artifact upload.
Use `archive: false` so GitHub and S3 receive byte-identical ZIPs without an extra archive wrapper.

Use `packagePath` to create platform-named copies outside `artifact/bin` for GitHub’s artifact naming.
S3 continues uploading only `artifact/bin`, preserving its existing filenames and paths.

Other builds retain their existing upload behavior.

`upload-artifact@v7` also supports uploading Linux’s AppImage directly; let me know if you’d prefer to include that alignment in this PR.