### PR TITLE
docs: restore Homebrew installation instructions via the Flycast tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Automated test results are available from the builds page as well.
 
 ### Android ![android](https://flyinghead.github.io/flycast-builds/android.jpg)
 
-Install Flycast from [**Google Play**](https://play.google.com/store/apps/details?id=com.flycast.emulator).
+&emsp;Install Flycast from [**Google Play**](https://play.google.com/store/apps/details?id=com.flycast.emulator).
 
 ### Flatpak (Linux ![ubuntu logo](https://flyinghead.github.io/flycast-builds/ubuntu.png))
 
@@ -36,38 +36,49 @@ Install Flycast from [**Google Play**](https://play.google.com/store/apps/detail
 
 2. Install Flycast from [Flathub](https://flathub.org/apps/details/org.flycast.Flycast):
 
-`flatpak install -y org.flycast.Flycast`
+&emsp;`flatpak install -y org.flycast.Flycast`
 
 3. Run Flycast:
 
-`flatpak run org.flycast.Flycast`
+&emsp;`flatpak run org.flycast.Flycast`
 
-### macOS ![apple logo](https://flyinghead.github.io/flycast-builds/apple.png)
+### Homebrew (macOS ![apple logo](https://flyinghead.github.io/flycast-builds/apple.png))
 
-Homebrew doesn't support Flycast anymore. Download the appplication Zip file from
-the [**builds page**](https://flyinghead.github.io/flycast-builds/) or [**GitHub Releases**](https://github.com/flyinghead/flycast/releases).
+1. [Set up Homebrew](https://brew.sh) or run `brew update` if already installed.
+
+2. Choose one channel:
+
+| Channel              | Install command                                         |
+| -------------------- | ------------------------------------------------------- |
+| Master (recommended) | `brew install --cask flyinghead/flycast/flycast@master` |
+| Stable               | `brew install --cask flyinghead/flycast/flycast`        |
+| Nightly dev          | `brew install --cask flyinghead/flycast/flycast@dev`    |
+
+3. Run Flycast from your Application folder
+
+&emsp;See the <a href="https://github.com/flyinghead/homebrew-flycast#readme">Flycast tap</a> for updating, uninstalling, and switching channels.
 
 ### iOS
 
-Due to persistent harassment from an iOS user, support for this platform has been dropped.
+&emsp;Due to persistent harassment from an iOS user, support for this platform has been dropped.
 
 ### Xbox One/Series ![xbox logo](https://flyinghead.github.io/flycast-builds/xbox.png)
 
-Grab the latest build from [**the builds page**](https://flyinghead.github.io/flycast-builds/), or the [**GitHub Actions**](https://github.com/flyinghead/flycast/actions/workflows/uwp.yml). Then install it using the **Xbox Device Portal**.
+&emsp;Grab the latest build from [**the builds page**](https://flyinghead.github.io/flycast-builds/), or the [**GitHub Actions**](https://github.com/flyinghead/flycast/actions/workflows/uwp.yml). Then install it using the **Xbox Device Portal**.
 
 ## Build from source
 
 ### macOS
 
-Right-click the bootstrap script and choose **Open**:
+&emsp;Right-click the bootstrap script and choose **Open**:
 
-`shell/apple/generate_xcode_project.command`
+&emsp;`shell/apple/generate_xcode_project.command`
 
 ### Windows
 
-Double-click the bootstrap script:
+&emsp;Double-click the bootstrap script:
 
-`shell\windows\generate_vs_project.bat`
+&emsp;`shell\windows\generate_vs_project.bat`
 
 ### Linux
 


### PR DESCRIPTION
Replace the outdated statement that Homebrew no longer supports Flycast with installation instructions using the Flycast tap.

Document the master, stable, and nightly dev channels, recommend master, and link to the tap’s instructions for updating, uninstalling, and switching channels. Also adjust formatting in the installation and build sections.

README-only change.