### PR TITLE
lua: expose openGdrom and insertGdrom as lua functions

### DIFF
--- a/core/lua/lua.cpp
+++ b/core/lua/lua.cpp
@@ -428,6 +428,26 @@ static void luaRegister(lua_State *L)
 	  		.beginNamespace("emulator")
 				.addFunction("startGame", gui_start_game)	// FIXME threading!
 				.addFunction("stopGame", std::function<void()>([]() { gui_stop_game(""); }))
+				.addFunction("openGdrom", std::function<void()>([]() {
+					bool restart = false;
+					if (gui_state == GuiState::Closed) {
+						gui_open_settings();
+						restart = true;
+					}
+					emu.openGdrom();
+					if (restart)
+						gui_open_settings();
+				}))
+				.addFunction("insertGdrom", std::function<void(const std::string&)>([](const std::string& path) {
+					bool restart = false;
+					if (gui_state == GuiState::Closed) {
+						gui_open_settings();
+						restart = true;
+					}
+					emu.insertGdrom(path);
+					if (restart)
+						gui_open_settings();
+				}))
 				.addFunction("pause", std::function<void()>([]() {
 					if (gui_state == GuiState::Closed)
 						gui_open_settings();


### PR DESCRIPTION
Small change to expose disc swapping as Lua functions for scripting purposes. 

I decided to name the functions as they're reflected in `emu` or `ejectDisc` / `insertDisc` as they're called in the pause menu but I don't have a strong opinion either way. 